### PR TITLE
feat: add finality health monitor

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from 'react'
 import { InspectionForm } from '@/src/components/inspections/InspectionForm'
 import { SyncStatusBar } from '@/src/components/SyncStatusBar'
+import { FinalityHealthGauge } from '@/src/components/validators/FinalityHealthGauge'
+import { useFinalityCheckpoints } from '@/src/hooks/useFinalityCheckpoints'
 import { syncManager } from '@/src/services/syncManager'
 import { initializeEncryption, hasEncryptionKey } from '@/src/services/crypto'
 
@@ -16,6 +18,8 @@ const inspectionFields = [
 ]
 
 export default function Home() {
+  const finalityHealth = useFinalityCheckpoints()
+
   useEffect(() => {
     if (!hasEncryptionKey()) {
       initializeEncryption('default-pin-0000').catch(console.error)
@@ -33,6 +37,10 @@ export default function Home() {
         <p className="mb-8 text-sm text-zinc-500 dark:text-zinc-400">
           Physical node inspection — data is cached locally and synced when online.
         </p>
+
+        <div className="mb-6">
+          <FinalityHealthGauge snapshot={finalityHealth} />
+        </div>
 
         <div className="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
           <InspectionForm fields={inspectionFields} />

--- a/src/components/validators/FinalityHealthGauge.tsx
+++ b/src/components/validators/FinalityHealthGauge.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import type { FinalityHealthSnapshot } from '@/src/utils/compositeScore'
+
+const COLORS: Record<FinalityHealthSnapshot['color'], string> = {
+  green: '#22c55e',
+  yellow: '#f59e0b',
+  red: '#ef4444',
+}
+
+export function FinalityHealthGauge({ snapshot }: { snapshot: FinalityHealthSnapshot | null }) {
+  const score = snapshot?.score ?? 0
+  const circumference = 2 * Math.PI * 46
+  const offset = circumference - (score / 100) * circumference
+  const color = snapshot ? COLORS[snapshot.color] : '#64748b'
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/80 p-6 text-white">
+      <div className="mb-5 flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Network Health</h2>
+          <p className="text-sm text-slate-400">Beacon finality checkpoint health</p>
+        </div>
+        <span className="rounded-full px-3 py-1 text-xs font-semibold" style={{ backgroundColor: `${color}22`, color }}>
+          {snapshot?.color.toUpperCase() ?? 'LOADING'}
+        </span>
+      </div>
+      <div className="flex flex-col items-center gap-5 sm:flex-row">
+        <svg viewBox="0 0 120 120" className="h-36 w-36 -rotate-90">
+          <circle cx="60" cy="60" r="46" fill="none" stroke="#1e293b" strokeWidth="12" />
+          <circle cx="60" cy="60" r="46" fill="none" stroke={color} strokeWidth="12" strokeLinecap="round" strokeDasharray={circumference} strokeDashoffset={offset} />
+        </svg>
+        <div className="w-full space-y-3">
+          <div>
+            <p className="text-5xl font-bold">{score}</p>
+            <p className="text-sm text-slate-400">Composite score / 100</p>
+          </div>
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <Metric label="Finalized epoch" value={snapshot?.finalizedEpoch ?? '—'} />
+            <Metric label="Justified epoch" value={snapshot?.justifiedEpoch ?? '—'} />
+            <Metric label="Participation" value={snapshot ? `${snapshot.participationRate.toFixed(1)}%` : '—'} />
+            <Metric label="Stalled slots" value={snapshot?.stalledSlots ?? '—'} />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
+      <p className="text-xs uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="mt-1 font-semibold text-slate-100">{value}</p>
+    </div>
+  )
+}

--- a/src/hooks/useFinalityCheckpoints.ts
+++ b/src/hooks/useFinalityCheckpoints.ts
@@ -1,0 +1,68 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { calculateFinalityHealthScore, type FinalityCheckpointInput, type FinalityHealthSnapshot, type FinalityScoreState } from '@/src/utils/compositeScore'
+import { createBeaconChainService, createDemoBeaconChainService } from '@/src/services/beaconChainService'
+import { useHealthStore } from '@/src/store/healthSlice'
+import { createFinalityHealthChannel } from '@/src/utils/crossTabSync'
+import { pruneFinalityHealthHistory, saveFinalityHealthSnapshot } from '@/src/services/healthHistoryStore'
+
+const SLOT_INTERVAL_MS = 12_000
+const GC_INTERVAL_MS = 60 * 60 * 1000
+
+export function useFinalityCheckpoints(beaconNodeUrl?: string) {
+  const [snapshot, setSnapshot] = useState<FinalityHealthSnapshot | null>(null)
+  const setFinalityHealth = useHealthStore((state) => state.setFinalityHealth)
+  const scoreState = useRef<FinalityScoreState>({ lastFinalizedEpoch: null, stalledSlots: 0 })
+  const frameRef = useRef<number | null>(null)
+  const pendingRef = useRef<FinalityHealthSnapshot | null>(null)
+
+  useEffect(() => {
+    const channel = createFinalityHealthChannel((incoming) => {
+      pendingRef.current = incoming
+      if (frameRef.current === null) {
+        frameRef.current = requestAnimationFrame(() => {
+          frameRef.current = null
+          if (pendingRef.current) setSnapshot(pendingRef.current)
+        })
+      }
+    })
+
+    function publishCheckpoint(input: FinalityCheckpointInput) {
+      const result = calculateFinalityHealthScore(input, scoreState.current)
+      scoreState.current = result.state
+      pendingRef.current = result.snapshot
+      channel.publish(result.snapshot)
+      setFinalityHealth(result.snapshot)
+      saveFinalityHealthSnapshot(result.snapshot).catch(console.error)
+
+      if (frameRef.current === null) {
+        frameRef.current = requestAnimationFrame(() => {
+          frameRef.current = null
+          if (pendingRef.current) setSnapshot(pendingRef.current)
+        })
+      }
+    }
+
+    const provider = beaconNodeUrl ? createBeaconChainService(beaconNodeUrl) : createDemoBeaconChainService()
+    let slot = Math.floor(Date.now() / SLOT_INTERVAL_MS)
+    provider.fetchCheckpoint(slot).then(publishCheckpoint).catch(console.error)
+    const interval = window.setInterval(() => {
+      provider.fetchCheckpoint(++slot).then(publishCheckpoint).catch(console.error)
+    }, SLOT_INTERVAL_MS)
+    const gcInterval = window.setInterval(() => pruneFinalityHealthHistory().catch(console.error), GC_INTERVAL_MS)
+    pruneFinalityHealthHistory().catch(console.error)
+
+    const unsubscribeHead = beaconNodeUrl ? provider.subscribeToHead(publishCheckpoint) : () => undefined
+
+    return () => {
+      window.clearInterval(interval)
+      window.clearInterval(gcInterval)
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current)
+      unsubscribeHead()
+      channel.close()
+    }
+  }, [beaconNodeUrl, setFinalityHealth])
+
+  return snapshot
+}

--- a/src/services/beaconChainService.ts
+++ b/src/services/beaconChainService.ts
@@ -1,0 +1,66 @@
+import type { FinalityCheckpointInput } from '@/src/utils/compositeScore'
+
+export type BeaconFinalityProvider = {
+  fetchCheckpoint(slot: number): Promise<FinalityCheckpointInput>
+  subscribeToHead(onCheckpoint: (checkpoint: FinalityCheckpointInput) => void): () => void
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export function createDemoBeaconChainService(): BeaconFinalityProvider {
+  return {
+    async fetchCheckpoint(slot) {
+      const finalizedEpoch = Math.max(1, Math.floor(slot / 32) - 1)
+      return {
+        slot,
+        finalizedEpoch,
+        justifiedEpoch: finalizedEpoch + 1,
+        participationRate: 96 + Math.sin(slot / 8) * 2,
+      }
+    },
+    subscribeToHead() {
+      return () => undefined
+    },
+  }
+}
+
+export function createBeaconChainService(baseUrl: string): BeaconFinalityProvider {
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, '')
+
+  return {
+    async fetchCheckpoint(slot) {
+      const [finalityResponse, participationResponse] = await Promise.all([
+        fetch(`${normalizedBaseUrl}/eth/v1/beacon/states/head/finality_checkpoints`),
+        fetch(`${normalizedBaseUrl}/eth/v1/beacon/states/head/validator_participation`),
+      ])
+      if (!finalityResponse.ok) throw new Error('Unable to fetch beacon finality checkpoints')
+      const finality = await finalityResponse.json() as {
+        data?: { finalized?: { epoch?: string | number }; current_justified?: { epoch?: string | number } }
+      }
+      const participation = participationResponse.ok
+        ? await participationResponse.json() as { data?: { current_epoch_active_gwei?: string | number; current_epoch_target_attesting_gwei?: string | number } }
+        : null
+      const active = toNumber(participation?.data?.current_epoch_active_gwei)
+      const attesting = toNumber(participation?.data?.current_epoch_target_attesting_gwei)
+
+      return {
+        slot,
+        finalizedEpoch: toNumber(finality.data?.finalized?.epoch),
+        justifiedEpoch: toNumber(finality.data?.current_justified?.epoch),
+        participationRate: active > 0 ? (attesting / active) * 100 : 0,
+      }
+    },
+    subscribeToHead(onCheckpoint) {
+      const socket = new WebSocket(`${normalizedBaseUrl.replace(/^http/, 'ws')}/eth/v1/events?topics=head`)
+      socket.onmessage = (event) => {
+        const payload = JSON.parse(event.data) as { data?: { slot?: string | number } }
+        const slot = toNumber(payload.data?.slot)
+        if (slot > 0) this.fetchCheckpoint(slot).then(onCheckpoint).catch(console.error)
+      }
+      return () => socket.close()
+    },
+  }
+}

--- a/src/services/healthHistoryStore.ts
+++ b/src/services/healthHistoryStore.ts
@@ -1,0 +1,53 @@
+import type { FinalityHealthSnapshot } from '@/src/utils/compositeScore'
+
+const DB_NAME = 'verinode-health-history'
+const STORE_NAME = 'finality-scores'
+const VERSION = 1
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1000
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, VERSION)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'timestamp' })
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+}
+
+export async function saveFinalityHealthSnapshot(snapshot: FinalityHealthSnapshot): Promise<void> {
+  if (typeof indexedDB === 'undefined') return
+  const db = await openDb()
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    tx.objectStore(STORE_NAME).put(snapshot)
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+  })
+  db.close()
+}
+
+export async function pruneFinalityHealthHistory(now = Date.now()): Promise<void> {
+  if (typeof indexedDB === 'undefined') return
+  const db = await openDb()
+  const cutoff = now - RETENTION_MS
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    const request = store.openCursor()
+    request.onsuccess = () => {
+      const cursor = request.result
+      if (cursor) {
+        if ((cursor.value as FinalityHealthSnapshot).timestamp < cutoff) cursor.delete()
+        cursor.continue()
+      }
+    }
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+  })
+  db.close()
+}

--- a/src/store/healthSlice.ts
+++ b/src/store/healthSlice.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand'
+import type { FinalityHealthSnapshot } from '@/src/utils/compositeScore'
+
+type HealthState = {
+  finalityHealth: FinalityHealthSnapshot | null
+  setFinalityHealth: (snapshot: FinalityHealthSnapshot) => void
+}
+
+export const useHealthStore = create<HealthState>((set) => ({
+  finalityHealth: null,
+  setFinalityHealth: (snapshot) => set({ finalityHealth: snapshot }),
+}))

--- a/src/utils/compositeScore.ts
+++ b/src/utils/compositeScore.ts
@@ -1,0 +1,60 @@
+export type FinalityCheckpointInput = {
+  slot: number
+  finalizedEpoch: number
+  justifiedEpoch: number
+  participationRate: number
+}
+
+export type FinalityHealthSnapshot = FinalityCheckpointInput & {
+  score: number
+  color: 'green' | 'yellow' | 'red'
+  stalledSlots: number
+  timestamp: number
+}
+
+export type FinalityScoreState = {
+  lastFinalizedEpoch: number | null
+  stalledSlots: number
+}
+
+const FINALIZED_WEIGHT = 0.4
+const JUSTIFIED_WEIGHT = 0.35
+const PARTICIPATION_WEIGHT = 0.25
+const STALL_THRESHOLD_SLOTS = 4
+const STALL_DECAY_SLOTS = 32
+
+function clamp(value: number, min = 0, max = 100): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+export function getFinalityHealthColor(score: number): FinalityHealthSnapshot['color'] {
+  if (score >= 80) return 'green'
+  if (score >= 50) return 'yellow'
+  return 'red'
+}
+
+export function calculateFinalityHealthScore(
+  input: FinalityCheckpointInput,
+  previous: FinalityScoreState = { lastFinalizedEpoch: null, stalledSlots: 0 },
+): { snapshot: FinalityHealthSnapshot; state: FinalityScoreState } {
+  const advanced = previous.lastFinalizedEpoch === null || input.finalizedEpoch > previous.lastFinalizedEpoch
+  const stalledSlots = advanced ? 0 : previous.stalledSlots + 1
+  const finalizedProgress = advanced ? 100 : stalledSlots < STALL_THRESHOLD_SLOTS ? 100 : clamp(100 - ((stalledSlots - STALL_THRESHOLD_SLOTS + 1) / STALL_DECAY_SLOTS) * 100)
+  const justifiedRatio = input.finalizedEpoch <= 0 ? 100 : clamp((input.justifiedEpoch / input.finalizedEpoch) * 100)
+  const participation = clamp(input.participationRate <= 1 ? input.participationRate * 100 : input.participationRate)
+  const score = clamp((FINALIZED_WEIGHT * finalizedProgress) + (JUSTIFIED_WEIGHT * justifiedRatio) + (PARTICIPATION_WEIGHT * participation))
+
+  const snapshot: FinalityHealthSnapshot = {
+    ...input,
+    participationRate: participation,
+    score: Math.round(score),
+    color: getFinalityHealthColor(score),
+    stalledSlots,
+    timestamp: Date.now(),
+  }
+
+  return {
+    snapshot,
+    state: { lastFinalizedEpoch: input.finalizedEpoch, stalledSlots },
+  }
+}

--- a/src/utils/crossTabSync.ts
+++ b/src/utils/crossTabSync.ts
@@ -1,0 +1,13 @@
+import type { FinalityHealthSnapshot } from '@/src/utils/compositeScore'
+
+const CHANNEL_NAME = 'verinode-finality-health'
+
+export function createFinalityHealthChannel(onSnapshot: (snapshot: FinalityHealthSnapshot) => void) {
+  if (typeof BroadcastChannel === 'undefined') return { publish: () => undefined, close: () => undefined }
+  const channel = new BroadcastChannel(CHANNEL_NAME)
+  channel.onmessage = (event: MessageEvent<FinalityHealthSnapshot>) => onSnapshot(event.data)
+  return {
+    publish: (snapshot: FinalityHealthSnapshot) => channel.postMessage(snapshot),
+    close: () => channel.close(),
+  }
+}


### PR DESCRIPTION
Closes #44 
## Summary
- Add beacon finality checkpoint scoring with weighted finalized progress, justified/finalized ratio, participation rate, and linear stall decay.
- Add a client hook that recalculates on slot cadence, coalesces UI updates with requestAnimationFrame, persists snapshots to IndexedDB, prunes data after 7 days, and synchronizes state across tabs with BroadcastChannel.
- Add a Network Health radial gauge to the dashboard with green/yellow/red score thresholds.

## Testing
- npm run lint (passes with existing warnings)
- npx tsc --noEmit