### PR TITLE
feat: validator balance delta stream compressor

### DIFF
--- a/src/components/validators/BalanceHistoryChart.tsx
+++ b/src/components/validators/BalanceHistoryChart.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import type { BalanceSnapshot, DeltaSummary } from '@/src/types/balance';
+import { useHistoricalBalances } from '@/src/hooks/useHistoricalBalances';
+
+const GWEI_PER_ETH = 1_000_000_000;
+
+/** Format a gwei balance as an ETH string with 4 decimals (sign-aware). */
+function formatEth(gwei: bigint): string {
+  const negative = gwei < BigInt(0);
+  const abs = negative ? -gwei : gwei;
+  const whole = abs / BigInt(GWEI_PER_ETH);
+  const frac = abs % BigInt(GWEI_PER_ETH);
+  const fracStr = frac.toString().padStart(9, '0').slice(0, 4);
+  return `${negative ? '-' : ''}${whole.toString()}.${fracStr}`;
+}
+
+interface ChartGeometry {
+  points: string;
+  minEth: number;
+  maxEth: number;
+}
+
+const VIEW_W = 600;
+const VIEW_H = 180;
+
+function buildGeometry(series: BalanceSnapshot[]): ChartGeometry | null {
+  if (series.length < 2) return null;
+
+  const values = series.map((s) => Number(s.balanceGwei) / GWEI_PER_ETH);
+  const minEth = Math.min(...values);
+  const maxEth = Math.max(...values);
+  const span = maxEth - minEth || 1;
+  const epochs = series.map((s) => s.epoch);
+  const minEpoch = epochs[0];
+  const epochSpan = epochs[epochs.length - 1] - minEpoch || 1;
+
+  const points = series
+    .map((s, i) => {
+      const x = ((s.epoch - minEpoch) / epochSpan) * VIEW_W;
+      const y = VIEW_H - ((values[i] - minEth) / span) * VIEW_H;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(' ');
+
+  return { points, minEth, maxEth };
+}
+
+export function BalanceHistoryChart({ validatorIndex }: { validatorIndex: number }) {
+  const { series, summary } = useHistoricalBalances();
+  const [data, setData] = useState<BalanceSnapshot[]>([]);
+  const [delta, setDelta] = useState<DeltaSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const reconstructed = await series(validatorIndex);
+        if (cancelled) return;
+        setData(reconstructed);
+
+        if (reconstructed.length > 0) {
+          const fromEpoch = reconstructed[0].epoch;
+          const toEpoch = reconstructed[reconstructed.length - 1].epoch;
+          const summed = await summary(validatorIndex, fromEpoch, toEpoch);
+          if (!cancelled) setDelta(summed);
+        } else {
+          setDelta(null);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load balances');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [validatorIndex, series, summary]);
+
+  const geometry = useMemo(() => buildGeometry(data), [data]);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/80 p-6 text-white">
+      <div className="mb-5 flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Balance History</h2>
+          <p className="text-sm text-slate-400">Validator #{validatorIndex} · per-epoch effective balance</p>
+        </div>
+        <span className="rounded-full bg-sky-500/10 px-3 py-1 text-xs font-semibold text-sky-300">
+          {data.length} epochs
+        </span>
+      </div>
+
+      {loading ? (
+        <p className="py-10 text-center text-sm text-slate-400">Decompressing history…</p>
+      ) : error ? (
+        <p className="py-10 text-center text-sm text-red-400">{error}</p>
+      ) : !geometry ? (
+        <p className="py-10 text-center text-sm text-slate-400">No balance history recorded yet.</p>
+      ) : (
+        <>
+          <svg
+            viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+            preserveAspectRatio="none"
+            className="h-44 w-full rounded-xl bg-slate-950/60"
+          >
+            <polyline
+              points={geometry.points}
+              fill="none"
+              stroke="#38bdf8"
+              strokeWidth="2"
+              strokeLinejoin="round"
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+            />
+          </svg>
+          <div className="mt-2 flex justify-between text-xs text-slate-500">
+            <span>{geometry.minEth.toFixed(4)} ETH</span>
+            <span>{geometry.maxEth.toFixed(4)} ETH</span>
+          </div>
+        </>
+      )}
+
+      <div className="mt-5 grid grid-cols-3 gap-3 text-sm">
+        <Metric label="Rewards" value={delta ? `+${formatEth(delta.rewards)}` : '—'} tone="text-emerald-400" />
+        <Metric label="Penalties" value={delta ? `-${formatEth(delta.penalties)}` : '—'} tone="text-red-400" />
+        <Metric
+          label="Net change"
+          value={delta ? `${delta.netChange < BigInt(0) ? '' : '+'}${formatEth(delta.netChange)}` : '—'}
+          tone={delta && delta.netChange < BigInt(0) ? 'text-red-400' : 'text-emerald-400'}
+        />
+      </div>
+    </section>
+  );
+}
+
+function Metric({ label, value, tone }: { label: string; value: string; tone: string }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
+      <p className="text-xs uppercase tracking-wide text-slate-500">{label}</p>
+      <p className={`mt-1 font-semibold ${tone}`}>{value} <span className="text-xs text-slate-500">ETH</span></p>
+    </div>
+  );
+}

--- a/src/hooks/useHistoricalBalances.ts
+++ b/src/hooks/useHistoricalBalances.ts
@@ -1,0 +1,210 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import type {
+  BalanceQueryRequest,
+  BalanceQueryResponse,
+  BalanceSnapshot,
+  DeltaSummary,
+} from '@/src/types/balance';
+import {
+  getMergedBalance,
+  putCompressedBalance,
+} from '@/src/services/balanceIndexedDB';
+import {
+  balanceAt,
+  compress,
+  deltaSummary as deltaSummaryUtil,
+  firstBalanceInRange,
+  fullDecompress,
+  prepare,
+} from '@/src/utils/deltaCompressor';
+
+const LRU_LIMIT = 50;
+
+interface FirstInRange {
+  epoch: number;
+  balance: bigint;
+}
+
+type Pending = (response: BalanceQueryResponse) => void;
+
+function createWorker(): Worker | null {
+  try {
+    return new Worker(new URL('../workers/balanceQueryWorker.ts', import.meta.url));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Query validator balance history through the decompression worker, with a
+ * main-thread fallback and an in-memory LRU cache of recently reconstructed
+ * series (most-recent 50 validators).
+ */
+export function useHistoricalBalances() {
+  const workerRef = useRef<Worker | null>(null);
+  const requestIdRef = useRef(0);
+  const pendingRef = useRef<Map<string, Pending>>(new Map());
+  const seriesCacheRef = useRef<Map<number, BalanceSnapshot[]>>(new Map());
+
+  useEffect(() => {
+    const worker = createWorker();
+    workerRef.current = worker;
+    const pending = pendingRef.current;
+
+    const handler = (e: MessageEvent<BalanceQueryResponse>) => {
+      const { requestId } = e.data.payload;
+      const resolve = pending.get(requestId);
+      if (resolve) {
+        pending.delete(requestId);
+        resolve(e.data);
+      }
+    };
+
+    worker?.addEventListener('message', handler);
+    return () => {
+      worker?.removeEventListener('message', handler);
+      worker?.terminate();
+      pending.clear();
+    };
+  }, []);
+
+  const request = useCallback((build: (requestId: string) => BalanceQueryRequest) => {
+    const worker = workerRef.current;
+    if (!worker) return null;
+    const requestId = `bq-${++requestIdRef.current}`;
+    const message = build(requestId);
+    return new Promise<BalanceQueryResponse>((resolve, reject) => {
+      pendingRef.current.set(requestId, resolve);
+      try {
+        worker.postMessage(message);
+      } catch (err) {
+        pendingRef.current.delete(requestId);
+        reject(err);
+      }
+    });
+  }, []);
+
+  const touchCache = useCallback((validatorIndex: number, series: BalanceSnapshot[]) => {
+    const cache = seriesCacheRef.current;
+    cache.delete(validatorIndex);
+    cache.set(validatorIndex, series);
+    if (cache.size > LRU_LIMIT) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) cache.delete(oldest);
+    }
+  }, []);
+
+  /** Compress and persist a batch of raw snapshots for a validator. */
+  const ingest = useCallback(
+    async (validatorIndex: number, snapshots: BalanceSnapshot[]) => {
+      await putCompressedBalance(validatorIndex, compress(snapshots));
+      seriesCacheRef.current.delete(validatorIndex);
+    },
+    [],
+  );
+
+  /** Balance at a single epoch (carried forward beyond coverage; null before). */
+  const balanceAtEpoch = useCallback(
+    async (validatorIndex: number, epoch: number): Promise<bigint | null> => {
+      const res = await request((requestId) => ({
+        type: 'BALANCE_AT',
+        payload: { requestId, validatorIndex, epoch },
+      }));
+      if (res) {
+        if (res.type === 'ERROR') throw new Error(res.payload.message);
+        if (res.type === 'BALANCE_AT') {
+          return res.payload.balance === null ? null : BigInt(res.payload.balance);
+        }
+      }
+      // Fallback: main thread.
+      return balanceAt(prepare(await getMergedBalance(validatorIndex)), epoch);
+    },
+    [request],
+  );
+
+  /** First recorded balance within [fromEpoch, toEpoch]. */
+  const firstInRange = useCallback(
+    async (
+      validatorIndex: number,
+      fromEpoch: number,
+      toEpoch: number,
+    ): Promise<FirstInRange | null> => {
+      const res = await request((requestId) => ({
+        type: 'FIRST_IN_RANGE',
+        payload: { requestId, validatorIndex, fromEpoch, toEpoch },
+      }));
+      if (res) {
+        if (res.type === 'ERROR') throw new Error(res.payload.message);
+        if (res.type === 'FIRST_IN_RANGE') {
+          return res.payload.epoch === null
+            ? null
+            : { epoch: res.payload.epoch, balance: BigInt(res.payload.balance) };
+        }
+      }
+      return firstBalanceInRange(await getMergedBalance(validatorIndex), fromEpoch, toEpoch);
+    },
+    [request],
+  );
+
+  /** Rewards / penalties / net change across an epoch range. */
+  const summary = useCallback(
+    async (
+      validatorIndex: number,
+      fromEpoch: number,
+      toEpoch: number,
+    ): Promise<DeltaSummary> => {
+      const res = await request((requestId) => ({
+        type: 'DELTA_SUMMARY',
+        payload: { requestId, validatorIndex, fromEpoch, toEpoch },
+      }));
+      if (res) {
+        if (res.type === 'ERROR') throw new Error(res.payload.message);
+        if (res.type === 'DELTA_SUMMARY') {
+          return {
+            rewards: BigInt(res.payload.rewards),
+            penalties: BigInt(res.payload.penalties),
+            netChange: BigInt(res.payload.netChange),
+          };
+        }
+      }
+      return deltaSummaryUtil(await getMergedBalance(validatorIndex), fromEpoch, toEpoch);
+    },
+    [request],
+  );
+
+  /** Full reconstructed series for charting, served from the LRU when warm. */
+  const series = useCallback(
+    async (validatorIndex: number): Promise<BalanceSnapshot[]> => {
+      const cached = seriesCacheRef.current.get(validatorIndex);
+      if (cached) {
+        touchCache(validatorIndex, cached);
+        return cached;
+      }
+
+      const res = await request((requestId) => ({
+        type: 'FULL_DECOMPRESS',
+        payload: { requestId, validatorIndex },
+      }));
+
+      let reconstructed: BalanceSnapshot[];
+      if (res && res.type === 'FULL_DECOMPRESS') {
+        reconstructed = res.payload.series.map((s) => ({
+          epoch: s.epoch,
+          balanceGwei: BigInt(s.balanceGwei),
+        }));
+      } else if (res && res.type === 'ERROR') {
+        throw new Error(res.payload.message);
+      } else {
+        reconstructed = fullDecompress(await getMergedBalance(validatorIndex));
+      }
+
+      touchCache(validatorIndex, reconstructed);
+      return reconstructed;
+    },
+    [request, touchCache],
+  );
+
+  return { ingest, balanceAtEpoch, firstInRange, summary, series };
+}

--- a/src/services/balanceIndexedDB.ts
+++ b/src/services/balanceIndexedDB.ts
@@ -1,0 +1,208 @@
+// IndexedDB persistence for compressed validator balance histories.
+//
+// One object store holds compressed blocks keyed by `${validatorIndex}:${baseEpoch}`.
+// A validator may accumulate several non-overlapping blocks over time (each
+// upsert writes/replaces one block); reads merge them into a single
+// CompressedBalance for querying. Retention GC drops blocks older than a
+// configured age.
+
+import type { CompressedBalance, StoredBalanceBlock } from '@/src/types/balance';
+import { balanceAt, emptyBlock, prepare } from '@/src/utils/deltaCompressor';
+
+const DB_NAME = 'verinode-balance-history';
+const STORE_NAME = 'compressed-balances';
+const VERSION = 1;
+const INDEX_VALIDATOR = 'validatorIndex';
+const INDEX_UPDATED = 'updatedAt';
+
+/** Default retention: 90 days of epochs. */
+export const DEFAULT_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+
+function blockKey(validatorIndex: number, baseEpoch: number): string {
+  return `${validatorIndex}:${baseEpoch}`;
+}
+
+export function openBalanceDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'key' });
+        store.createIndex(INDEX_VALIDATOR, 'validatorIndex', { unique: false });
+        store.createIndex(INDEX_UPDATED, 'updatedAt', { unique: false });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+// ---- (de)serialization: bigint <-> decimal string -----------------------
+
+export function serializeBlock(
+  validatorIndex: number,
+  compressed: CompressedBalance,
+  now: number,
+): StoredBalanceBlock {
+  return {
+    key: blockKey(validatorIndex, compressed.baseEpoch),
+    validatorIndex,
+    baseEpoch: compressed.baseEpoch,
+    lastEpoch: compressed.lastEpoch,
+    baseBalance: compressed.baseBalance.toString(),
+    deltas: compressed.deltas.map((d) => ({ epoch: d.epoch, delta: d.delta.toString() })),
+    zeroRuns: compressed.zeroRuns,
+    updatedAt: now,
+  };
+}
+
+export function deserializeBlock(stored: StoredBalanceBlock): CompressedBalance {
+  return {
+    baseBalance: BigInt(stored.baseBalance),
+    baseEpoch: stored.baseEpoch,
+    lastEpoch: stored.lastEpoch,
+    deltas: stored.deltas.map((d) => ({ epoch: d.epoch, delta: BigInt(d.delta) })),
+    zeroRuns: stored.zeroRuns,
+  };
+}
+
+/**
+ * Merge non-overlapping blocks (ascending by baseEpoch) into one
+ * CompressedBalance. The balance carried at the end of one block bridges to
+ * the next block's base via a synthetic delta, preserving continuity.
+ */
+export function mergeBlocks(blocks: CompressedBalance[]): CompressedBalance {
+  const ordered = blocks
+    .filter((b) => b.lastEpoch >= b.baseEpoch)
+    .sort((a, b) => a.baseEpoch - b.baseEpoch);
+  if (ordered.length === 0) return emptyBlock();
+
+  const first = ordered[0];
+  const merged: CompressedBalance = {
+    baseBalance: first.baseBalance,
+    baseEpoch: first.baseEpoch,
+    lastEpoch: first.lastEpoch,
+    deltas: [...first.deltas],
+    zeroRuns: [...first.zeroRuns],
+  };
+  let runningBalance = balanceAt(prepare(first), first.lastEpoch) ?? first.baseBalance;
+
+  for (let i = 1; i < ordered.length; i++) {
+    const block = ordered[i];
+    const bridge = block.baseBalance - runningBalance;
+    if (bridge !== BigInt(0)) {
+      merged.deltas.push({ epoch: block.baseEpoch, delta: bridge });
+    } else {
+      merged.zeroRuns.push({ startEpoch: block.baseEpoch, zeroLength: 1 });
+    }
+    merged.deltas.push(...block.deltas);
+    merged.zeroRuns.push(...block.zeroRuns);
+    merged.lastEpoch = block.lastEpoch;
+    runningBalance = balanceAt(prepare(block), block.lastEpoch) ?? block.baseBalance;
+  }
+
+  merged.deltas.sort((a, b) => a.epoch - b.epoch);
+  merged.zeroRuns.sort((a, b) => a.startEpoch - b.startEpoch);
+  return merged;
+}
+
+// ---- public API ----------------------------------------------------------
+
+/** Upsert one compressed block for a validator. */
+export async function putCompressedBalance(
+  validatorIndex: number,
+  compressed: CompressedBalance,
+  now = Date.now(),
+): Promise<void> {
+  if (typeof indexedDB === 'undefined') return;
+  const db = await openBalanceDb();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).put(serializeBlock(validatorIndex, compressed, now));
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/** Load every stored block for a validator (ascending by baseEpoch). */
+export async function getBlocks(validatorIndex: number): Promise<CompressedBalance[]> {
+  if (typeof indexedDB === 'undefined') return [];
+  const db = await openBalanceDb();
+  try {
+    const stored = await new Promise<StoredBalanceBlock[]>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const index = tx.objectStore(STORE_NAME).index(INDEX_VALIDATOR);
+      const request = index.getAll(IDBKeyRange.only(validatorIndex));
+      request.onsuccess = () => resolve((request.result as StoredBalanceBlock[]) ?? []);
+      request.onerror = () => reject(request.error);
+    });
+    return stored.map(deserializeBlock).sort((a, b) => a.baseEpoch - b.baseEpoch);
+  } finally {
+    db.close();
+  }
+}
+
+/** Load and merge all of a validator's blocks into a single queryable block. */
+export async function getMergedBalance(validatorIndex: number): Promise<CompressedBalance> {
+  return mergeBlocks(await getBlocks(validatorIndex));
+}
+
+/** Remove every block for a validator. */
+export async function clearValidator(validatorIndex: number): Promise<void> {
+  if (typeof indexedDB === 'undefined') return;
+  const db = await openBalanceDb();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const index = tx.objectStore(STORE_NAME).index(INDEX_VALIDATOR);
+      const request = index.openKeyCursor(IDBKeyRange.only(validatorIndex));
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (cursor) {
+          tx.objectStore(STORE_NAME).delete(cursor.primaryKey);
+          cursor.continue();
+        }
+      };
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/** Garbage-collect blocks not updated within the retention window. */
+export async function pruneOldBalances(
+  now = Date.now(),
+  retentionMs = DEFAULT_RETENTION_MS,
+): Promise<number> {
+  if (typeof indexedDB === 'undefined') return 0;
+  const db = await openBalanceDb();
+  const cutoff = now - retentionMs;
+  let removed = 0;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const index = tx.objectStore(STORE_NAME).index(INDEX_UPDATED);
+      const request = index.openCursor(IDBKeyRange.upperBound(cutoff, true));
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (cursor) {
+          cursor.delete();
+          removed++;
+          cursor.continue();
+        }
+      };
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } finally {
+    db.close();
+  }
+  return removed;
+}

--- a/src/types/balance.ts
+++ b/src/types/balance.ts
@@ -1,0 +1,92 @@
+// Validator balance history types.
+//
+// Each epoch (~6.4 min) produces a balance snapshot per validator. Storing
+// every snapshot is wasteful: balances change rarely and by small amounts.
+// We instead store a base balance plus a chain of per-epoch deltas, and
+// run-length-encode the long stretches where the balance does not change.
+
+/** A raw balance observation for a single validator at a single epoch. */
+export interface BalanceSnapshot {
+  epoch: number;
+  /** Effective/actual balance in gwei. */
+  balanceGwei: bigint;
+}
+
+/** A non-zero balance change at a given epoch (balance_n - balance_n-1). */
+export interface DeltaEntry {
+  epoch: number;
+  delta: bigint;
+}
+
+/**
+ * A run of consecutive epochs over which the balance did not change.
+ * `startEpoch` is the first unchanged epoch; `zeroLength` counts how many
+ * consecutive epochs (including the start) carried a zero delta.
+ */
+export interface RunLengthEntry {
+  startEpoch: number;
+  zeroLength: number;
+}
+
+/**
+ * Compressed representation of one validator's balance history.
+ *
+ * Invariants:
+ * - `baseEpoch` is the first observed epoch; `baseBalance` its balance.
+ * - `deltas` is sorted ascending by epoch and contains only non-zero changes.
+ * - `zeroRuns` is sorted ascending by `startEpoch`; runs never overlap a delta
+ *   epoch. Together, deltas + zeroRuns + base fully reconstruct the series.
+ * - `lastEpoch` is the last epoch covered by this block (inclusive).
+ */
+export interface CompressedBalance {
+  baseBalance: bigint;
+  baseEpoch: number;
+  lastEpoch: number;
+  deltas: DeltaEntry[];
+  zeroRuns: RunLengthEntry[];
+}
+
+/** Result of a delta_summary range query. */
+export interface DeltaSummary {
+  /** Sum of positive deltas (gwei) in range — rewards. */
+  rewards: bigint;
+  /** Absolute sum of negative deltas (gwei) in range — penalties. */
+  penalties: bigint;
+  /** Net change across the range (rewards - penalties). */
+  netChange: bigint;
+}
+
+/**
+ * Persisted record shape in IndexedDB. `bigint` is not structured-clonable in
+ * every engine path we target, and is not indexable, so balances are stored as
+ * decimal strings and rehydrated on read.
+ */
+export interface StoredBalanceBlock {
+  /** Composite key: `${validatorIndex}:${baseEpoch}`. */
+  key: string;
+  validatorIndex: number;
+  baseEpoch: number;
+  lastEpoch: number;
+  baseBalance: string;
+  deltas: Array<{ epoch: number; delta: string }>;
+  zeroRuns: RunLengthEntry[];
+  /** Wall-clock time the block was written; used for retention GC. */
+  updatedAt: number;
+}
+
+// ---- Worker message protocol --------------------------------------------
+
+export type BalanceQueryKind = 'BALANCE_AT' | 'FIRST_IN_RANGE' | 'DELTA_SUMMARY' | 'FULL_DECOMPRESS';
+
+export type BalanceQueryRequest =
+  | { type: 'BALANCE_AT'; payload: { requestId: string; validatorIndex: number; epoch: number } }
+  | { type: 'FIRST_IN_RANGE'; payload: { requestId: string; validatorIndex: number; fromEpoch: number; toEpoch: number } }
+  | { type: 'DELTA_SUMMARY'; payload: { requestId: string; validatorIndex: number; fromEpoch: number; toEpoch: number } }
+  | { type: 'FULL_DECOMPRESS'; payload: { requestId: string; validatorIndex: number } };
+
+export type BalanceQueryResponse =
+  | { type: 'BALANCE_AT'; payload: { requestId: string; balance: string | null } }
+  | { type: 'FIRST_IN_RANGE'; payload: { requestId: string; epoch: number; balance: string } | { requestId: string; epoch: null; balance: null } }
+  | { type: 'DELTA_SUMMARY'; payload: { requestId: string; rewards: string; penalties: string; netChange: string } }
+  | { type: 'FULL_DECOMPRESS'; payload: { requestId: string; series: Array<{ epoch: number; balanceGwei: string }> } }
+  | { type: 'ERROR'; payload: { requestId: string; message: string } };

--- a/src/utils/deltaCompressor.ts
+++ b/src/utils/deltaCompressor.ts
@@ -1,0 +1,244 @@
+// Delta + run-length compressor for validator balance histories.
+//
+// A validator emits one balance snapshot per epoch (~6.4 min). Across a day
+// that is ~225 snapshots; across 1,000 epochs the balance typically changes
+// only ~100 times. We exploit that by storing:
+//   - a single base balance at the first epoch,
+//   - a chain of non-zero deltas (balance_n - balance_n-1), and
+//   - run-length-encoded stretches of unchanged ("zero-delta") epochs.
+//
+// Reconstruction: balance_at(epoch) = baseBalance + Σ(deltas with epoch ≤ E).
+// Zero runs carry no value; they exist only to record that an epoch was
+// observed without a change, so full reconstruction can recover the exact
+// (and contiguous) epoch series.
+//
+// Assumption: epochs within a block are contiguous and strictly increasing,
+// which is how beacon-chain epochs arrive. Zero runs are therefore expanded
+// as startEpoch + k for k in [0, zeroLength).
+
+import type {
+  BalanceSnapshot,
+  CompressedBalance,
+  DeltaEntry,
+  DeltaSummary,
+  RunLengthEntry,
+} from '@/src/types/balance';
+
+const ZERO = BigInt(0);
+
+/** Prepared form of a CompressedBalance with prefix sums for O(log n) reads. */
+export interface PreparedBalance {
+  baseBalance: bigint;
+  baseEpoch: number;
+  lastEpoch: number;
+  deltas: DeltaEntry[];
+  zeroRuns: RunLengthEntry[];
+  /** Ascending delta epochs, parallel to `prefix`. */
+  deltaEpochs: number[];
+  /** prefix[i] = sum of deltas[0..i] inclusive. */
+  prefix: bigint[];
+}
+
+function isEmpty(c: CompressedBalance): boolean {
+  return c.lastEpoch < c.baseEpoch && c.deltas.length === 0 && c.zeroRuns.length === 0;
+}
+
+/** An empty block sentinel — produced from empty input, decodes to []. */
+export function emptyBlock(): CompressedBalance {
+  return { baseBalance: ZERO, baseEpoch: 0, lastEpoch: -1, deltas: [], zeroRuns: [] };
+}
+
+/**
+ * Compress a list of balance snapshots into base + delta-chain + zero RLE.
+ * Input need not be pre-sorted; duplicate epochs keep the last value.
+ */
+export function compress(historicalBalances: BalanceSnapshot[]): CompressedBalance {
+  if (historicalBalances.length === 0) return emptyBlock();
+
+  const sorted = [...historicalBalances].sort((a, b) => a.epoch - b.epoch);
+
+  // Collapse duplicate epochs, keeping the most recent observation.
+  const series: BalanceSnapshot[] = [];
+  for (const snap of sorted) {
+    const last = series[series.length - 1];
+    if (last && last.epoch === snap.epoch) series[series.length - 1] = snap;
+    else series.push(snap);
+  }
+
+  const base = series[0];
+  const deltas: DeltaEntry[] = [];
+  const zeroRuns: RunLengthEntry[] = [];
+
+  let prevBalance = base.balanceGwei;
+  let runStart: number | null = null;
+  let runLength = 0;
+
+  const flushRun = () => {
+    if (runStart !== null) {
+      zeroRuns.push({ startEpoch: runStart, zeroLength: runLength });
+      runStart = null;
+      runLength = 0;
+    }
+  };
+
+  for (let i = 1; i < series.length; i++) {
+    const { epoch, balanceGwei } = series[i];
+    const delta = balanceGwei - prevBalance;
+
+    if (delta === ZERO) {
+      if (runStart === null) {
+        runStart = epoch;
+        runLength = 1;
+      } else {
+        runLength++;
+      }
+    } else {
+      flushRun();
+      deltas.push({ epoch, delta });
+    }
+
+    prevBalance = balanceGwei;
+  }
+  flushRun();
+
+  return {
+    baseBalance: base.balanceGwei,
+    baseEpoch: base.epoch,
+    lastEpoch: series[series.length - 1].epoch,
+    deltas,
+    zeroRuns,
+  };
+}
+
+/** Build prefix sums so repeated reads on the same block are O(log n). */
+export function prepare(compressed: CompressedBalance): PreparedBalance {
+  const deltaEpochs: number[] = new Array(compressed.deltas.length);
+  const prefix: bigint[] = new Array(compressed.deltas.length);
+  let acc = ZERO;
+  for (let i = 0; i < compressed.deltas.length; i++) {
+    acc += compressed.deltas[i].delta;
+    deltaEpochs[i] = compressed.deltas[i].epoch;
+    prefix[i] = acc;
+  }
+  return {
+    baseBalance: compressed.baseBalance,
+    baseEpoch: compressed.baseEpoch,
+    lastEpoch: compressed.lastEpoch,
+    deltas: compressed.deltas,
+    zeroRuns: compressed.zeroRuns,
+    deltaEpochs,
+    prefix,
+  };
+}
+
+/** First index whose value is strictly greater than `target` (upper bound). */
+function upperBound(epochs: number[], target: number): number {
+  let lo = 0;
+  let hi = epochs.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (epochs[mid] <= target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/**
+ * Balance at `epoch` from a prepared block in O(log n). Returns null when the
+ * epoch precedes the block's coverage; balances beyond `lastEpoch` carry the
+ * last known value forward.
+ */
+export function balanceAt(prepared: PreparedBalance, epoch: number): bigint | null {
+  if (epoch < prepared.baseEpoch) return null;
+  const idx = upperBound(prepared.deltaEpochs, epoch) - 1;
+  const summed = idx >= 0 ? prepared.prefix[idx] : ZERO;
+  return prepared.baseBalance + summed;
+}
+
+/**
+ * Balance at `targetEpoch` via binary search on the delta chain.
+ * Throws RangeError if the epoch precedes the block.
+ */
+export function decompress(compressed: CompressedBalance, targetEpoch: number): bigint {
+  const result = balanceAt(prepare(compressed), targetEpoch);
+  if (result === null) {
+    throw new RangeError(`epoch ${targetEpoch} precedes base epoch ${compressed.baseEpoch}`);
+  }
+  return result;
+}
+
+/**
+ * First recorded balance within [fromEpoch, toEpoch], using binary search to
+ * locate the boundary. Returns the carried-forward balance at the lower bound
+ * if that epoch falls inside the block's coverage.
+ */
+export function firstBalanceInRange(
+  compressed: CompressedBalance,
+  fromEpoch: number,
+  toEpoch: number,
+): { epoch: number; balance: bigint } | null {
+  if (isEmpty(compressed) || fromEpoch > toEpoch) return null;
+
+  const lo = Math.max(fromEpoch, compressed.baseEpoch);
+  if (lo > Math.min(toEpoch, compressed.lastEpoch)) return null;
+
+  const prepared = prepare(compressed);
+  const balance = balanceAt(prepared, lo);
+  if (balance === null) return null;
+  return { epoch: lo, balance };
+}
+
+/**
+ * Accumulate rewards/penalties/net change across [fromEpoch, toEpoch] in a
+ * single pass over the deltas that fall in range (located via binary search).
+ */
+export function deltaSummary(
+  compressed: CompressedBalance,
+  fromEpoch: number,
+  toEpoch: number,
+): DeltaSummary {
+  let rewards = ZERO;
+  let penalties = ZERO;
+
+  if (!isEmpty(compressed) && fromEpoch <= toEpoch) {
+    const epochs = compressed.deltas.map((d) => d.epoch);
+    const start = upperBound(epochs, fromEpoch - 1); // first epoch ≥ fromEpoch
+    for (let i = start; i < compressed.deltas.length; i++) {
+      const { epoch, delta } = compressed.deltas[i];
+      if (epoch > toEpoch) break;
+      if (delta > ZERO) rewards += delta;
+      else penalties += -delta;
+    }
+  }
+
+  return { rewards, penalties, netChange: rewards - penalties };
+}
+
+/**
+ * Fully reconstruct the (contiguous) snapshot series for chart rendering.
+ * Walks the union of base, delta, and zero-run epochs in ascending order,
+ * carrying the running balance forward.
+ */
+export function fullDecompress(compressed: CompressedBalance): BalanceSnapshot[] {
+  if (isEmpty(compressed)) return [];
+
+  const covered = new Set<number>([compressed.baseEpoch]);
+  const deltaMap = new Map<number, bigint>();
+  for (const d of compressed.deltas) {
+    covered.add(d.epoch);
+    deltaMap.set(d.epoch, d.delta);
+  }
+  for (const run of compressed.zeroRuns) {
+    for (let k = 0; k < run.zeroLength; k++) covered.add(run.startEpoch + k);
+  }
+
+  const epochs = [...covered].sort((a, b) => a - b);
+  const series: BalanceSnapshot[] = new Array(epochs.length);
+  let balance = compressed.baseBalance;
+  for (let i = 0; i < epochs.length; i++) {
+    const epoch = epochs[i];
+    if (epoch !== compressed.baseEpoch) balance += deltaMap.get(epoch) ?? ZERO;
+    series[i] = { epoch, balanceGwei: balance };
+  }
+  return series;
+}

--- a/src/workers/balanceQueryWorker.ts
+++ b/src/workers/balanceQueryWorker.ts
@@ -1,0 +1,114 @@
+// Web worker for validator balance range queries.
+//
+// Decompression and range scans run here so large histories never block the
+// UI thread. The worker reads compressed blocks from IndexedDB (available in
+// worker scope), merges them, and answers balance_at / first_in_range /
+// delta_summary / full_decompress queries. Recently-read validators are kept
+// in a small cache so repeated queries skip the IndexedDB round-trip.
+//
+// bigint is not structured-clonable across the worker boundary in every
+// engine, so all balances cross as decimal strings.
+
+import type {
+  BalanceQueryRequest,
+  BalanceQueryResponse,
+  CompressedBalance,
+} from '@/src/types/balance';
+import { getMergedBalance } from '@/src/services/balanceIndexedDB';
+import {
+  balanceAt,
+  deltaSummary,
+  firstBalanceInRange,
+  fullDecompress,
+  prepare,
+  type PreparedBalance,
+} from '@/src/utils/deltaCompressor';
+
+interface CacheEntry {
+  compressed: CompressedBalance;
+  prepared: PreparedBalance;
+}
+
+const CACHE_LIMIT = 64;
+const cache = new Map<number, CacheEntry>();
+
+async function load(validatorIndex: number): Promise<CacheEntry> {
+  const cached = cache.get(validatorIndex);
+  if (cached) {
+    // Refresh LRU recency.
+    cache.delete(validatorIndex);
+    cache.set(validatorIndex, cached);
+    return cached;
+  }
+
+  const compressed = await getMergedBalance(validatorIndex);
+  const entry: CacheEntry = { compressed, prepared: prepare(compressed) };
+  cache.set(validatorIndex, entry);
+  if (cache.size > CACHE_LIMIT) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  return entry;
+}
+
+function post(message: BalanceQueryResponse): void {
+  (self as unknown as Worker).postMessage(message);
+}
+
+self.onmessage = async (e: MessageEvent<BalanceQueryRequest>) => {
+  const msg = e.data;
+  const { requestId } = msg.payload;
+
+  try {
+    switch (msg.type) {
+      case 'BALANCE_AT': {
+        const { prepared } = await load(msg.payload.validatorIndex);
+        const balance = balanceAt(prepared, msg.payload.epoch);
+        post({
+          type: 'BALANCE_AT',
+          payload: { requestId, balance: balance === null ? null : balance.toString() },
+        });
+        break;
+      }
+      case 'FIRST_IN_RANGE': {
+        const { compressed } = await load(msg.payload.validatorIndex);
+        const found = firstBalanceInRange(compressed, msg.payload.fromEpoch, msg.payload.toEpoch);
+        post({
+          type: 'FIRST_IN_RANGE',
+          payload: found
+            ? { requestId, epoch: found.epoch, balance: found.balance.toString() }
+            : { requestId, epoch: null, balance: null },
+        });
+        break;
+      }
+      case 'DELTA_SUMMARY': {
+        const { compressed } = await load(msg.payload.validatorIndex);
+        const summary = deltaSummary(compressed, msg.payload.fromEpoch, msg.payload.toEpoch);
+        post({
+          type: 'DELTA_SUMMARY',
+          payload: {
+            requestId,
+            rewards: summary.rewards.toString(),
+            penalties: summary.penalties.toString(),
+            netChange: summary.netChange.toString(),
+          },
+        });
+        break;
+      }
+      case 'FULL_DECOMPRESS': {
+        const { compressed } = await load(msg.payload.validatorIndex);
+        const series = fullDecompress(compressed).map((s) => ({
+          epoch: s.epoch,
+          balanceGwei: s.balanceGwei.toString(),
+        }));
+        post({ type: 'FULL_DECOMPRESS', payload: { requestId, series } });
+        break;
+      }
+    }
+  } catch (err) {
+    post({
+      type: 'ERROR',
+      payload: { requestId, message: err instanceof Error ? err.message : 'Unknown worker error' },
+    });
+  }
+};


### PR DESCRIPTION
# feat: Validator Balance Delta Stream Compressor for High-Frequency Epoch Updates

Closes #59

## Changes

| File | Role |
|------|------|
| `src/types/balance.ts` | `DeltaEntry`, `RunLengthEntry`, `CompressedBalance`, `DeltaSummary`, `StoredBalanceBlock`, worker protocol |
| `src/utils/deltaCompressor.ts` | `compress` / `decompress` / `deltaSummary` / `firstBalanceInRange` / `fullDecompress` + prefix-sum `prepare` |
| `src/services/balanceIndexedDB.ts` | Per-validator block persistence, block merge, retention GC |
| `src/workers/balanceQueryWorker.ts` | Off-thread query processing with a 64-validator LRU read cache |
| `src/hooks/useHistoricalBalances.ts` | Worker bridge, main-thread fallback, 50-validator LRU |
| `src/components/validators/BalanceHistoryChart.tsx` | Consumer chart on the compressed pipeline |

