### PR TITLE
feat: add sanitized clipboard utilities

### DIFF
--- a/src/components/common/PermissionToast.tsx
+++ b/src/components/common/PermissionToast.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+interface PermissionToastProps {
+  open: boolean
+  message: string
+  onDismiss?: () => void
+}
+
+export function PermissionToast({ open, message, onDismiss }: PermissionToastProps) {
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      className="fixed bottom-4 left-1/2 z-50 max-w-md -translate-x-1/2 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 shadow-lg"
+    >
+      <div className="flex items-start gap-3">
+        <span aria-hidden="true">⚠️</span>
+        <p className="flex-1">{message}</p>
+        {onDismiss ? (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="font-semibold text-amber-900 opacity-70 hover:opacity-100"
+            aria-label="Dismiss clipboard permission message"
+          >
+            ✕
+          </button>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useClipboardSanitized.ts
+++ b/src/hooks/useClipboardSanitized.ts
@@ -1,0 +1,164 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { writeClipboardText, readClipboardText, type ClipboardFallbackAttempt } from '@/utils/clipboardFallback'
+import { sanitize, type ClipboardExpectedFormat } from '@/utils/clipboardSanitizer'
+import { logClipboardAccess, type ClipboardAuditAction } from '@/utils/clipboardAuditLogger'
+
+export type ClipboardPermissionState = PermissionState | 'unsupported' | 'unknown'
+
+export interface ClipboardSanitizedOptions {
+  fieldName?: string
+  sensitive?: boolean
+  clearAfterMs?: number
+}
+
+export interface ClipboardActionState {
+  action: ClipboardAuditAction
+  fieldName: string
+  payloadLength: number
+  attempts: ClipboardFallbackAttempt[]
+}
+
+const defaultClearAfterMs = 30_000
+const clipboardDeniedMessage = 'Clipboard access is blocked. Enable clipboard permissions for this site, or use the browser paste shortcut.'
+
+async function queryClipboardWritePermission(): Promise<ClipboardPermissionState> {
+  if (typeof navigator === 'undefined' || !navigator.permissions?.query) {
+    return 'unsupported'
+  }
+
+  try {
+    const status = await navigator.permissions.query({ name: 'clipboard-write' as PermissionName })
+    return status.state
+  } catch {
+    return 'unsupported'
+  }
+}
+
+export function useClipboardSanitized(defaultOptions: ClipboardSanitizedOptions = {}) {
+  const [lastAction, setLastAction] = useState<ClipboardActionState | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+  const [permissionState, setPermissionState] = useState<ClipboardPermissionState>('unknown')
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimer = useCallback(() => {
+    if (clearTimerRef.current) {
+      clearTimeout(clearTimerRef.current)
+      clearTimerRef.current = null
+    }
+  }, [])
+
+  const clearSensitiveClipboard = useCallback(async (fieldName = defaultOptions.fieldName ?? 'clipboard') => {
+    try {
+      const result = await writeClipboardText('')
+      logClipboardAccess({
+        field_name: fieldName,
+        action: 'clear',
+        payload_length: 0,
+        sanitization_status: 'skipped',
+      })
+      setLastAction({ action: 'clear', fieldName, payloadLength: 0, attempts: result.attempts })
+      setError(null)
+    } catch (caught) {
+      const nextError = caught instanceof Error ? caught : new Error(String(caught))
+      setError(nextError)
+      throw nextError
+    }
+  }, [defaultOptions.fieldName])
+
+  const write = useCallback(async (
+    text: string,
+    expectedFormat: ClipboardExpectedFormat,
+    options: ClipboardSanitizedOptions = {},
+  ) => {
+    const fieldName = options.fieldName ?? defaultOptions.fieldName ?? 'clipboard'
+    const sensitive = options.sensitive ?? defaultOptions.sensitive ?? true
+    const clearAfterMs = options.clearAfterMs ?? defaultOptions.clearAfterMs ?? defaultClearAfterMs
+
+    try {
+      const nextPermissionState = await queryClipboardWritePermission()
+      setPermissionState(nextPermissionState)
+
+      if (nextPermissionState === 'denied') {
+        throw new Error(clipboardDeniedMessage)
+      }
+
+      const { sanitized } = sanitize(text, expectedFormat)
+      const result = await writeClipboardText(sanitized)
+
+      logClipboardAccess({
+        field_name: fieldName,
+        action: 'write',
+        payload_length: sanitized.length,
+        sanitization_status: 'sanitized',
+      })
+      setLastAction({ action: 'write', fieldName, payloadLength: sanitized.length, attempts: result.attempts })
+      setError(null)
+
+      clearTimer()
+      if (sensitive && clearAfterMs > 0) {
+        clearTimerRef.current = setTimeout(() => {
+          void clearSensitiveClipboard(fieldName)
+        }, clearAfterMs)
+      }
+
+      return sanitized
+    } catch (caught) {
+      const nextError = caught instanceof Error ? caught : new Error(String(caught))
+      logClipboardAccess({
+        field_name: fieldName,
+        action: 'write',
+        payload_length: text.length,
+        sanitization_status: 'rejected',
+      })
+      setError(nextError)
+      throw nextError
+    }
+  }, [clearSensitiveClipboard, clearTimer, defaultOptions.clearAfterMs, defaultOptions.fieldName, defaultOptions.sensitive])
+
+  const read = useCallback(async (
+    expectedFormat: ClipboardExpectedFormat,
+    options: ClipboardSanitizedOptions = {},
+  ) => {
+    const fieldName = options.fieldName ?? defaultOptions.fieldName ?? 'clipboard'
+
+    try {
+      const result = await readClipboardText()
+      const raw = result.value ?? ''
+      const { sanitized } = sanitize(raw, expectedFormat)
+
+      logClipboardAccess({
+        field_name: fieldName,
+        action: 'read',
+        payload_length: sanitized.length,
+        sanitization_status: 'sanitized',
+      })
+      setLastAction({ action: 'read', fieldName, payloadLength: sanitized.length, attempts: result.attempts })
+      setError(null)
+      return sanitized
+    } catch (caught) {
+      const nextError = caught instanceof Error ? caught : new Error(String(caught))
+      logClipboardAccess({
+        field_name: fieldName,
+        action: 'read',
+        payload_length: 0,
+        sanitization_status: 'rejected',
+      })
+      setError(nextError)
+      throw nextError
+    }
+  }, [defaultOptions.fieldName])
+
+  useEffect(() => clearTimer, [clearTimer])
+
+  return {
+    read,
+    write,
+    clear: clearSensitiveClipboard,
+    lastAction,
+    error,
+    permissionState,
+    permissionDeniedMessage: clipboardDeniedMessage,
+  }
+}

--- a/src/services/auditLogService.ts
+++ b/src/services/auditLogService.ts
@@ -1,0 +1,8 @@
+export {
+  clearClipboardAuditLog,
+  getClipboardAuditLog,
+  logClipboardAccess,
+  type ClipboardAuditAction,
+  type ClipboardAuditEvent,
+  type ClipboardSanitizationStatus,
+} from '@/utils/clipboardAuditLogger'

--- a/src/utils/clipboardAuditLogger.ts
+++ b/src/utils/clipboardAuditLogger.ts
@@ -1,0 +1,36 @@
+export type ClipboardAuditAction = 'read' | 'write' | 'clear'
+export type ClipboardSanitizationStatus = 'sanitized' | 'rejected' | 'skipped'
+
+export interface ClipboardAuditEvent {
+  timestamp: string
+  field_name: string
+  action: ClipboardAuditAction
+  payload_length: number
+  sanitization_status: ClipboardSanitizationStatus
+}
+
+const maxEvents = 1000
+const events: ClipboardAuditEvent[] = []
+
+export function logClipboardAccess(event: Omit<ClipboardAuditEvent, 'timestamp'>): ClipboardAuditEvent {
+  const entry = {
+    ...event,
+    timestamp: new Date().toISOString(),
+  }
+
+  events.push(entry)
+
+  if (events.length > maxEvents) {
+    events.splice(0, events.length - maxEvents)
+  }
+
+  return entry
+}
+
+export function getClipboardAuditLog(): ClipboardAuditEvent[] {
+  return [...events]
+}
+
+export function clearClipboardAuditLog(): void {
+  events.length = 0
+}

--- a/src/utils/clipboardFallback.ts
+++ b/src/utils/clipboardFallback.ts
@@ -1,0 +1,123 @@
+export interface ClipboardFallbackAttempt {
+  method: string
+  success: boolean
+  error?: string
+}
+
+export interface ClipboardFallbackResult<T> {
+  value?: T
+  attempts: ClipboardFallbackAttempt[]
+}
+
+function recordFailure(attempts: ClipboardFallbackAttempt[], method: string, error: unknown): void {
+  attempts.push({
+    method,
+    success: false,
+    error: error instanceof Error ? error.message : String(error),
+  })
+}
+
+function createHiddenTextarea(value = ''): HTMLTextAreaElement {
+  const textarea = document.createElement('textarea')
+  textarea.value = value
+  textarea.setAttribute('readonly', 'true')
+  textarea.style.position = 'fixed'
+  textarea.style.left = '-9999px'
+  textarea.style.top = '0'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.focus()
+  textarea.select()
+  return textarea
+}
+
+export async function writeClipboardText(text: string): Promise<ClipboardFallbackResult<void>> {
+  const attempts: ClipboardFallbackAttempt[] = []
+
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      attempts.push({ method: 'navigator.clipboard.writeText', success: true })
+      return { attempts }
+    } catch (error) {
+      recordFailure(attempts, 'navigator.clipboard.writeText', error)
+    }
+  }
+
+  if (typeof document !== 'undefined' && document.queryCommandSupported?.('copy')) {
+    const previousActiveElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const textarea = createHiddenTextarea(text)
+
+    try {
+      if (document.execCommand('copy')) {
+        attempts.push({ method: 'document.execCommand(copy)', success: true })
+        return { attempts }
+      }
+
+      throw new Error('document.execCommand(copy) returned false')
+    } catch (error) {
+      recordFailure(attempts, 'document.execCommand(copy)', error)
+    } finally {
+      textarea.remove()
+      previousActiveElement?.focus()
+    }
+  }
+
+  throw new Error(`Unable to write clipboard text. Attempts: ${attempts.map(attempt => attempt.method).join(', ')}`)
+}
+
+export async function readClipboardText(): Promise<ClipboardFallbackResult<string>> {
+  const attempts: ClipboardFallbackAttempt[] = []
+
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.readText) {
+    try {
+      const value = await navigator.clipboard.readText()
+      attempts.push({ method: 'navigator.clipboard.readText', success: true })
+      return { value, attempts }
+    } catch (error) {
+      recordFailure(attempts, 'navigator.clipboard.readText', error)
+    }
+  }
+
+  if (typeof document !== 'undefined' && document.queryCommandSupported?.('paste')) {
+    const previousActiveElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const textarea = createHiddenTextarea()
+
+    try {
+      if (document.execCommand('paste')) {
+        attempts.push({ method: 'document.execCommand(paste)', success: true })
+        return { value: textarea.value, attempts }
+      }
+
+      throw new Error('document.execCommand(paste) returned false')
+    } catch (error) {
+      recordFailure(attempts, 'document.execCommand(paste)', error)
+    } finally {
+      textarea.remove()
+      previousActiveElement?.focus()
+    }
+  }
+
+  if (typeof document !== 'undefined') {
+    const value = await new Promise<string>((resolve, reject) => {
+      const timeout = window.setTimeout(() => {
+        document.removeEventListener('paste', handlePaste)
+        reject(new Error('Timed out waiting for ClipboardEvent paste data'))
+      }, 1000)
+
+      function handlePaste(event: ClipboardEvent) {
+        window.clearTimeout(timeout)
+        document.removeEventListener('paste', handlePaste)
+        event.preventDefault()
+        resolve(event.clipboardData?.getData('text/plain') ?? '')
+      }
+
+      document.addEventListener('paste', handlePaste, { once: true })
+    })
+
+    attempts.push({ method: 'ClipboardEvent(paste)', success: true })
+    return { value, attempts }
+  }
+
+  throw new Error(`Unable to read clipboard text. Attempts: ${attempts.map(attempt => attempt.method).join(', ')}`)
+}

--- a/src/utils/clipboardSanitizer.ts
+++ b/src/utils/clipboardSanitizer.ts
@@ -1,0 +1,106 @@
+export type ClipboardExpectedFormat = 'hex' | 'bech32' | 'base64' | 'mnemonic'
+
+export class InvalidClipboardContent extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidClipboardContent'
+  }
+}
+
+const unicodeControlPattern = /[\u200B-\u200F\u2028-\u2029\uFEFF]/g
+const hexPattern = /^0x[0-9a-fA-F]+$/
+const bech32Pattern = /^(st|stx)[023456789acdefghjklmnpqrstuvwxyz]+$/i
+const base64Pattern = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+const mnemonicWordPattern = /^[a-z]+(?:\s+[a-z]+)*$/i
+
+export interface SanitizedClipboardContent {
+  sanitized: string
+  warnings: string[]
+}
+
+export function stripUnicodeControl(value: string): string {
+  return value.replace(unicodeControlPattern, '')
+}
+
+function validateHex(value: string): void {
+  if (!value.startsWith('0x')) {
+    throw new InvalidClipboardContent('Clipboard content must be 0x-prefixed hex.')
+  }
+
+  if (value.length <= 2 || (value.length - 2) % 2 !== 0) {
+    throw new InvalidClipboardContent('Clipboard hex content must contain an even number of hex characters.')
+  }
+
+  if (!hexPattern.test(value)) {
+    throw new InvalidClipboardContent('Clipboard hex content contains non-hex characters.')
+  }
+}
+
+function validateBech32(value: string): void {
+  if (!bech32Pattern.test(value)) {
+    throw new InvalidClipboardContent('Clipboard content must be a bech32 value starting with st or stx.')
+  }
+}
+
+function validateBase64(value: string): void {
+  if (value.length === 0 || value.length % 4 !== 0 || !base64Pattern.test(value)) {
+    throw new InvalidClipboardContent('Clipboard content must be valid base64 with correct padding.')
+  }
+}
+
+function validateMnemonic(value: string): void {
+  const normalized = value.replace(/\s+/g, ' ')
+  const wordCount = normalized.length === 0 ? 0 : normalized.split(' ').length
+
+  if (!mnemonicWordPattern.test(normalized) || ![12, 15, 18, 21, 24].includes(wordCount)) {
+    throw new InvalidClipboardContent('Clipboard mnemonic must contain 12, 15, 18, 21, or 24 words.')
+  }
+}
+
+export function validateFormat(value: string, expectedFormat: ClipboardExpectedFormat): void {
+  switch (expectedFormat) {
+    case 'hex':
+      validateHex(value)
+      return
+    case 'bech32':
+      validateBech32(value)
+      return
+    case 'base64':
+      validateBase64(value)
+      return
+    case 'mnemonic':
+      validateMnemonic(value)
+      return
+    default: {
+      const exhaustive: never = expectedFormat
+      throw new InvalidClipboardContent(`Unsupported clipboard format: ${exhaustive}`)
+    }
+  }
+}
+
+export function sanitize(raw: string, expectedFormat: ClipboardExpectedFormat): SanitizedClipboardContent {
+  const warnings: string[] = []
+  const trimmed = raw.trim()
+
+  if (trimmed !== raw) {
+    warnings.push('Removed leading or trailing whitespace.')
+  }
+
+  let sanitized = stripUnicodeControl(trimmed)
+
+  if (sanitized !== trimmed) {
+    warnings.push('Removed invisible Unicode control characters.')
+  }
+
+  if (expectedFormat === 'mnemonic') {
+    const normalized = sanitized.replace(/\s+/g, ' ')
+    if (normalized !== sanitized) {
+      warnings.push('Collapsed mnemonic whitespace.')
+      sanitized = normalized
+    }
+  }
+
+  validateFormat(sanitized, expectedFormat)
+
+  return { sanitized, warnings }
+}


### PR DESCRIPTION
closes #61

## Summary
- Add clipboard sanitization utilities that trim payloads, remove invisible Unicode controls, validate hex/bech32/base64/mnemonic formats, and raise InvalidClipboardContent for rejected values.
- Add clipboard fallback read/write helpers covering async Clipboard API, execCommand-based textarea fallback, and ClipboardEvent paste reads.
- Add useClipboardSanitized with permission handling, audit logging, sensitive auto-clear timers, and exposed read/write/clear state.
- Add a clipboard audit logger ring buffer and audit service exports.
- Add PermissionToast for clipboard permission-denied instructions.

## Testing
- npm run lint
- npx tsc --noEmit