### PR TITLE
feat: add DVT cluster health dashboard

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,8 +8,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: Arial, Helvetica, sans-serif;
+  --font-mono: "Courier New", Courier, monospace;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,7 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import { Providers } from "@/src/components/providers/Providers";
 import { PwaProvider } from "@/src/components/providers/PwaProvider";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "VeriNode - Inspection Dashboard",
@@ -31,9 +20,7 @@ export default function RootLayout({
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
       </head>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         <Providers>
           <PwaProvider>{children}</PwaProvider>
         </Providers>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { InspectionForm } from '@/src/components/inspections/InspectionForm'
 import { SyncStatusBar } from '@/src/components/SyncStatusBar'
 import { FinalityHealthGauge } from '@/src/components/validators/FinalityHealthGauge'
+import { DVTClusterList } from '@/src/components/validators/DVTClusterList'
 import { useFinalityCheckpoints } from '@/src/hooks/useFinalityCheckpoints'
 import { syncManager } from '@/src/services/syncManager'
 import { initializeEncryption, hasEncryptionKey } from '@/src/services/crypto'
@@ -40,6 +41,10 @@ export default function Home() {
 
         <div className="mb-6">
           <FinalityHealthGauge snapshot={finalityHealth} />
+        </div>
+
+        <div className="mb-6">
+          <DVTClusterList />
         </div>
 
         <div className="rounded-lg border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">

--- a/src/components/validators/DVTClusterGauge.tsx
+++ b/src/components/validators/DVTClusterGauge.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import type { DVTClusterHealth } from '@/src/hooks/useDVTClusterHealth'
+
+const TIER_STYLES = {
+  healthy: { stroke: '#22c55e', bg: 'bg-emerald-500/10', text: 'text-emerald-300', label: 'Healthy' },
+  degraded: { stroke: '#f59e0b', bg: 'bg-amber-500/10', text: 'text-amber-300', label: 'Degraded' },
+  critical: { stroke: '#ef4444', bg: 'bg-red-500/10', text: 'text-red-300', label: 'Critical' },
+}
+
+function formatMs(value: number): string {
+  return value >= 1000 ? `${(value / 1000).toFixed(2)}s` : `${Math.round(value)}ms`
+}
+
+export function DVTClusterGauge({ cluster }: { cluster: DVTClusterHealth }) {
+  const style = TIER_STYLES[cluster.healthTier]
+  const circumference = 2 * Math.PI * 46
+  const participationRatio = cluster.totalNodes > 0 ? cluster.participatingNodes / cluster.totalNodes : 0
+  const quorumRatio = cluster.totalNodes > 0 ? cluster.quorum / cluster.totalNodes : 0
+  const dashOffset = circumference - participationRatio * circumference
+  const quorumAngle = quorumRatio * 360 - 90
+  const quorumX = 60 + 54 * Math.cos((quorumAngle * Math.PI) / 180)
+  const quorumY = 60 + 54 * Math.sin((quorumAngle * Math.PI) / 180)
+
+  return (
+    <article className="rounded-2xl border border-white/10 bg-slate-950/70 p-4 text-white">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h3 className="font-semibold">{cluster.name}</h3>
+          <p className="text-xs text-slate-400">{cluster.participatingNodes}/{cluster.totalNodes} nodes participating · quorum {cluster.quorum}</p>
+        </div>
+        <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${style.bg} ${style.text}`}>{style.label}</span>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-[10rem_1fr]">
+        <div className="relative mx-auto h-40 w-40">
+          <svg viewBox="0 0 120 120" className="h-40 w-40 -rotate-90">
+            <circle cx="60" cy="60" r="46" fill="none" stroke="#1e293b" strokeWidth="12" />
+            <circle cx="60" cy="60" r="46" fill="none" stroke={style.stroke} strokeWidth="12" strokeLinecap="round" strokeDasharray={circumference} strokeDashoffset={dashOffset} className="transition-all duration-500 ease-out" />
+            <line x1="60" y1="60" x2={quorumX} y2={quorumY} stroke="#e2e8f0" strokeWidth="2" strokeDasharray="3 3" />
+          </svg>
+          <div className="absolute inset-0 flex flex-col items-center justify-center">
+            <span className="text-3xl font-bold">{Math.round(participationRatio * 100)}%</span>
+            <span className="text-xs text-slate-400">quorum gauge</span>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="grid grid-cols-3 gap-2 text-xs">
+            <Metric label="p50" value={formatMs(cluster.latencyPercentiles.p50)} />
+            <Metric label="p95" value={formatMs(cluster.latencyPercentiles.p95)} />
+            <Metric label="p99" value={formatMs(cluster.latencyPercentiles.p99)} />
+          </div>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {cluster.nodes.map((node) => (
+              <div key={node.nodeId} title={`${node.operatorName}: ${(node.participationRate * 100).toFixed(1)}% participation; p50 ${formatMs(node.latencyPercentiles.p50)}, p95 ${formatMs(node.latencyPercentiles.p95)}, p99 ${formatMs(node.latencyPercentiles.p99)}`} className="rounded-xl border border-white/10 bg-slate-900/70 p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate text-sm font-medium">{node.operatorName}</span>
+                  <span className={`h-2.5 w-2.5 rounded-full ${node.isParticipating ? 'bg-emerald-400' : 'bg-red-400'}`} />
+                </div>
+                <p className="mt-1 text-xs text-slate-400">{(node.participationRate * 100).toFixed(1)}% signing participation</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-900 p-2 text-center">
+      <p className="uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="font-semibold text-slate-100">{value}</p>
+    </div>
+  )
+}

--- a/src/components/validators/DVTClusterList.tsx
+++ b/src/components/validators/DVTClusterList.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useState } from 'react'
+import { DVTClusterGauge } from '@/src/components/validators/DVTClusterGauge'
+import { useDVTClusterHealth } from '@/src/hooks/useDVTClusterHealth'
+
+const DOT = {
+  healthy: 'bg-emerald-400',
+  degraded: 'bg-amber-400',
+  critical: 'bg-red-400',
+}
+
+export function DVTClusterList() {
+  const { clusters, isLoading, error, lastUpdated } = useDVTClusterHealth()
+  const [expandedClusterId, setExpandedClusterId] = useState<string | null>(null)
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/80 p-6 text-white">
+      <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold">DVT Clusters</h2>
+          <p className="text-sm text-slate-400">Quorum, signing participation, and consensus latency health</p>
+        </div>
+        <p className="text-xs text-slate-500">Auto-refreshes every 30s{lastUpdated ? ` · updated ${new Date(lastUpdated).toLocaleTimeString()}` : ''}</p>
+      </div>
+
+      {isLoading && clusters.length === 0 ? <p className="text-sm text-slate-400">Loading DVT cluster health…</p> : null}
+      {error ? <p className="rounded-xl border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">{error}</p> : null}
+      {!isLoading && clusters.length === 0 && !error ? <p className="text-sm text-slate-400">No DVT clusters returned by the API.</p> : null}
+
+      <div className="space-y-3">
+        {clusters.map((cluster) => {
+          const isExpanded = expandedClusterId === cluster.id
+          return (
+            <div key={cluster.id}>
+              <button type="button" onClick={() => setExpandedClusterId(isExpanded ? null : cluster.id)} className="flex w-full items-center justify-between gap-3 rounded-2xl border border-white/10 bg-slate-950/60 p-4 text-left transition hover:border-white/20">
+                <span className="flex min-w-0 items-center gap-3">
+                  <span className={`h-3 w-3 rounded-full ${DOT[cluster.healthTier]}`} />
+                  <span className="min-w-0">
+                    <span className="block truncate font-medium">{cluster.name}</span>
+                    <span className="text-xs text-slate-400">{cluster.participatingNodes}/{cluster.totalNodes} participating · quorum {cluster.quorum}</span>
+                  </span>
+                </span>
+                <span className="text-sm text-slate-400">{isExpanded ? 'Hide' : 'Details'}</span>
+              </button>
+              {isExpanded ? <div className="mt-3"><DVTClusterGauge cluster={cluster} /></div> : null}
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/hooks/useDVTClusterHealth.ts
+++ b/src/hooks/useDVTClusterHealth.ts
@@ -1,0 +1,104 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { dvtService, getClusterQuorum, getDVTHealthTier, type DVTHealthTier } from '@/src/services/dvtService'
+import { calculateLatencyPercentiles, type ConsensusLatencyPercentiles } from '@/src/utils/percentileCalculator'
+import { useDVTStore } from '@/src/store/dvtSlice'
+
+const REFRESH_INTERVAL_MS = 30_000
+const RING_BUFFER_LIMIT = 1_000
+const MAX_CLUSTERS = 50
+
+export type DVTNodeClusterHealth = {
+  nodeId: string
+  operatorName: string
+  isParticipating: boolean
+  participationRate: number
+  successfulSignings: number
+  totalSigningRounds: number
+  latencyPercentiles: ConsensusLatencyPercentiles
+}
+
+export type DVTClusterHealth = {
+  id: string
+  name: string
+  totalNodes: number
+  participatingNodes: number
+  quorum: number
+  healthTier: DVTHealthTier
+  latencyPercentiles: ConsensusLatencyPercentiles
+  nodes: DVTNodeClusterHealth[]
+  updatedAt: string
+}
+
+function trimToRingBuffer(values: number[]): number[] {
+  return values.slice(Math.max(0, values.length - RING_BUFFER_LIMIT))
+}
+
+export function useDVTClusterHealth() {
+  const { clusters, lastUpdated, setClusters } = useDVTStore()
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const latencyHistoryRef = useRef<Record<string, number[]>>({})
+
+  useEffect(() => {
+    let isMounted = true
+    async function loadClusterHealth() {
+      try {
+        setError(null)
+        const clusterSummaries = (await dvtService.getClusters()).slice(0, MAX_CLUSTERS)
+        const healthResponses = await Promise.all(clusterSummaries.map((cluster) => dvtService.getClusterHealth(cluster.id)))
+
+        const nextClusters = healthResponses.map((cluster) => {
+          const nodes = cluster.nodes.map((node) => {
+            const key = `${cluster.id}:${node.nodeId}`
+            const history = trimToRingBuffer([...(latencyHistoryRef.current[key] ?? []), ...node.consensusRoundTripLatenciesMs])
+            latencyHistoryRef.current[key] = history
+
+            return {
+              nodeId: node.nodeId,
+              operatorName: node.operatorName,
+              isParticipating: node.isParticipating,
+              participationRate: node.totalSigningRounds > 0 ? node.successfulSignings / node.totalSigningRounds : 0,
+              successfulSignings: node.successfulSignings,
+              totalSigningRounds: node.totalSigningRounds,
+              latencyPercentiles: calculateLatencyPercentiles(history),
+            }
+          })
+
+          const clusterLatencies = nodes.flatMap((node) => latencyHistoryRef.current[`${cluster.id}:${node.nodeId}`] ?? [])
+          const latencyPercentiles = calculateLatencyPercentiles(clusterLatencies)
+          const quorum = getClusterQuorum(cluster.totalNodes)
+
+          return {
+            id: cluster.id,
+            name: cluster.name,
+            totalNodes: cluster.totalNodes,
+            participatingNodes: cluster.participatingNodes,
+            quorum,
+            healthTier: getDVTHealthTier(cluster.totalNodes, cluster.participatingNodes, latencyPercentiles.p99),
+            latencyPercentiles,
+            nodes,
+            updatedAt: cluster.updatedAt,
+          }
+        })
+
+        if (isMounted) setClusters(nextClusters)
+      } catch (caughtError) {
+        if (isMounted) setError(caughtError instanceof Error ? caughtError.message : 'Unable to load DVT cluster health')
+      } finally {
+        if (isMounted) setIsLoading(false)
+      }
+    }
+
+    loadClusterHealth()
+    const intervalId = setInterval(loadClusterHealth, REFRESH_INTERVAL_MS)
+
+    return () => {
+      isMounted = false
+      clearInterval(intervalId)
+    }
+  }, [setClusters])
+
+  return { clusters, lastUpdated, isLoading, error }
+}

--- a/src/services/dvtService.ts
+++ b/src/services/dvtService.ts
@@ -1,0 +1,69 @@
+import { offlineStorage } from '@/src/services/localCache'
+
+export type DVTHealthTier = 'healthy' | 'degraded' | 'critical'
+
+export type DVTNodeHealth = {
+  nodeId: string
+  operatorName: string
+  isParticipating: boolean
+  successfulSignings: number
+  totalSigningRounds: number
+  consensusRoundTripLatenciesMs: number[]
+}
+
+export type DVTCluster = {
+  id: string
+  name: string
+  totalNodes: number
+}
+
+export type DVTClusterHealthResponse = DVTCluster & {
+  participatingNodes: number
+  nodes: DVTNodeHealth[]
+  updatedAt: string
+}
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_DVT_API_URL ?? ''
+const CACHE_TTL_MINUTES = 5
+
+async function requestDVT<T>(path: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, { headers: { Accept: 'application/json' } })
+  if (!response.ok) {
+    throw new Error(`DVT API request failed (${response.status}) for ${path}`)
+  }
+  return response.json() as Promise<T>
+}
+
+async function getCachedOrFetch<T>(cacheKey: string, path: string): Promise<T> {
+  if (typeof window !== 'undefined') {
+    const cached = await offlineStorage.getCached(cacheKey)
+    if (cached) return cached.data as T
+  }
+
+  const data = await requestDVT<T>(path)
+
+  if (typeof window !== 'undefined') {
+    await offlineStorage.setCached(cacheKey, data, CACHE_TTL_MINUTES)
+  }
+
+  return data
+}
+
+export const dvtService = {
+  async getClusters(): Promise<DVTCluster[]> {
+    return getCachedOrFetch<DVTCluster[]>('dvt:clusters', '/clusters')
+  },
+
+  async getClusterHealth(clusterId: string): Promise<DVTClusterHealthResponse> {
+    return getCachedOrFetch<DVTClusterHealthResponse>(`dvt:cluster:${clusterId}:health`, `/clusters/${clusterId}/health`)
+  },
+}
+
+export function getClusterQuorum(totalNodes: number): number {
+  return Math.ceil((2 / 3) * totalNodes)
+}
+
+export function getDVTHealthTier(totalNodes: number, participatingNodes: number, p99LatencyMs: number): DVTHealthTier {
+  if (participatingNodes < getClusterQuorum(totalNodes)) return 'critical'
+  return p99LatencyMs >= 2000 ? 'degraded' : 'healthy'
+}

--- a/src/store/dvtSlice.ts
+++ b/src/store/dvtSlice.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand'
+import type { DVTClusterHealth } from '@/src/hooks/useDVTClusterHealth'
+
+type DVTState = {
+  clusters: DVTClusterHealth[]
+  lastUpdated: number | null
+  setClusters: (clusters: DVTClusterHealth[]) => void
+}
+
+export const useDVTStore = create<DVTState>((set) => ({
+  clusters: [],
+  lastUpdated: null,
+  setClusters: (clusters) => set({ clusters, lastUpdated: Date.now() }),
+}))

--- a/src/utils/percentileCalculator.ts
+++ b/src/utils/percentileCalculator.ts
@@ -1,0 +1,30 @@
+export type ConsensusLatencyPercentiles = {
+  p50: number
+  p95: number
+  p99: number
+}
+
+export function calculatePercentile(sortedValues: number[], percentile: number): number {
+  if (sortedValues.length === 0) return 0
+  if (percentile <= 0) return sortedValues[0]
+  if (percentile >= 100) return sortedValues[sortedValues.length - 1]
+
+  const rank = (percentile / 100) * (sortedValues.length - 1)
+  const lowerIndex = Math.floor(rank)
+  const upperIndex = Math.ceil(rank)
+  const weight = rank - lowerIndex
+
+  if (lowerIndex === upperIndex) return sortedValues[lowerIndex]
+
+  return sortedValues[lowerIndex] + (sortedValues[upperIndex] - sortedValues[lowerIndex]) * weight
+}
+
+export function calculateLatencyPercentiles(latenciesMs: number[]): ConsensusLatencyPercentiles {
+  const sortedLatencies = [...latenciesMs].sort((a, b) => a - b)
+
+  return {
+    p50: calculatePercentile(sortedLatencies, 50),
+    p95: calculatePercentile(sortedLatencies, 95),
+    p99: calculatePercentile(sortedLatencies, 99),
+  }
+}


### PR DESCRIPTION
## Summary
- Add a DVT API service with 5-minute local cache support and quorum/health-tier helpers.
- Add percentile utilities for p50/p95/p99 consensus round-trip latency calculations using linear interpolation.
- Add a DVT cluster health hook and Zustand slice to poll up to 50 clusters every 30 seconds while keeping 1,000 latency samples per node.
- Add expandable DVT cluster list and SVG gauge components showing quorum threshold, participating nodes, per-node signing participation, and latency percentiles.
- Mount the DVT Clusters section on the dashboard.
- Replace network-fetched Google font usage with system font variables so CI builds do not fail when external font fetches are blocked.

Closes #49 