### PR TITLE
feat: epoch-level attestation inclusion delay histogram with canvas

### DIFF
--- a/src/components/canvas/DelayHistogram.tsx
+++ b/src/components/canvas/DelayHistogram.tsx
@@ -1,0 +1,222 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { BUCKET_COUNT, MAX_DELAY, type DelayHistogram } from '@/src/utils/histogramBinner'
+
+const DISPLAY_HEIGHT = 280
+const MARGIN = { top: 16, right: 16, bottom: 36, left: 48 }
+const COLOR_OPTIMAL = '#22c55e'
+const COLOR_FAIR = '#f59e0b'
+const COLOR_POOR = '#ef4444'
+const COLOR_AXIS = '#475569'
+const COLOR_TEXT = '#94a3b8'
+
+function barColor(delay: number): string {
+  if (delay <= 1) return COLOR_OPTIMAL
+  if (delay <= 3) return COLOR_FAIR
+  return COLOR_POOR
+}
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, value))
+}
+
+function niceMax(value: number): number {
+  if (value <= 0) return 1
+  const pow = Math.pow(10, Math.floor(Math.log10(value)))
+  const norm = value / pow
+  const step = norm <= 1 ? 1 : norm <= 2 ? 2 : norm <= 5 ? 5 : 10
+  return step * pow
+}
+
+interface Hover {
+  bucket: number
+  px: number
+  py: number
+}
+
+/**
+ * Canvas-rendered attestation inclusion-delay histogram (33 buckets, 0..32
+ * slots). The full chart is redrawn each paint — only 33 bars plus axes, so it
+ * stays well within 60 FPS even with the largest configured epoch range. A
+ * crosshair tooltip reports the exact count and percentage for the hovered
+ * bucket.
+ */
+export function DelayHistogram({
+  histogram,
+  fromEpoch,
+  toEpoch,
+  isComputing = false,
+}: {
+  histogram: DelayHistogram | null
+  fromEpoch: number
+  toEpoch: number
+  isComputing?: boolean
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const [size, setSize] = useState({ w: 0, h: DISPLAY_HEIGHT })
+  const [hover, setHover] = useState<Hover | null>(null)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const update = () => setSize({ w: el.clientWidth, h: DISPLAY_HEIGHT })
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  const plotW = Math.max(0, size.w - MARGIN.left - MARGIN.right)
+  const plotH = Math.max(0, size.h - MARGIN.top - MARGIN.bottom)
+  const barSlot = plotW / BUCKET_COUNT
+
+  const paint = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas || size.w === 0) return
+    const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
+    canvas.width = Math.round(size.w * dpr)
+    canvas.height = Math.round(size.h * dpr)
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.clearRect(0, 0, size.w, size.h)
+
+    const counts = histogram?.counts ?? new Array(BUCKET_COUNT).fill(0)
+    const yMax = niceMax(histogram?.maxCount ?? 0)
+
+    // y-axis grid + labels.
+    ctx.strokeStyle = 'rgba(71,85,105,0.25)'
+    ctx.fillStyle = COLOR_TEXT
+    ctx.lineWidth = 1
+    ctx.font = '10px ui-sans-serif, system-ui, sans-serif'
+    ctx.textAlign = 'right'
+    ctx.textBaseline = 'middle'
+    const yTicks = 4
+    for (let t = 0; t <= yTicks; t++) {
+      const value = (yMax / yTicks) * t
+      const y = MARGIN.top + plotH - (value / yMax) * plotH
+      ctx.beginPath()
+      ctx.moveTo(MARGIN.left, y + 0.5)
+      ctx.lineTo(MARGIN.left + plotW, y + 0.5)
+      ctx.stroke()
+      ctx.fillText(String(Math.round(value)), MARGIN.left - 6, y)
+    }
+
+    // Bars.
+    for (let b = 0; b < BUCKET_COUNT; b++) {
+      const count = counts[b]
+      const h = yMax > 0 ? (count / yMax) * plotH : 0
+      const x = MARGIN.left + b * barSlot
+      const y = MARGIN.top + plotH - h
+      ctx.fillStyle = barColor(b)
+      ctx.globalAlpha = hover && hover.bucket === b ? 1 : 0.82
+      ctx.fillRect(x + 1, y, Math.max(1, barSlot - 2), h)
+      ctx.globalAlpha = 1
+    }
+
+    // x-axis baseline + labels (every 4 slots).
+    ctx.strokeStyle = COLOR_AXIS
+    ctx.beginPath()
+    ctx.moveTo(MARGIN.left, MARGIN.top + plotH + 0.5)
+    ctx.lineTo(MARGIN.left + plotW, MARGIN.top + plotH + 0.5)
+    ctx.stroke()
+    ctx.fillStyle = COLOR_TEXT
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'top'
+    for (let b = 0; b <= MAX_DELAY; b += 4) {
+      const x = MARGIN.left + b * barSlot + barSlot / 2
+      ctx.fillText(String(b), x, MARGIN.top + plotH + 8)
+    }
+    ctx.fillText('inclusion delay (slots)', MARGIN.left + plotW / 2, MARGIN.top + plotH + 22)
+
+    // Crosshair on hovered bucket.
+    if (hover) {
+      const x = MARGIN.left + hover.bucket * barSlot + barSlot / 2
+      ctx.strokeStyle = 'rgba(248,250,252,0.7)'
+      ctx.setLineDash([3, 3])
+      ctx.beginPath()
+      ctx.moveTo(x, MARGIN.top)
+      ctx.lineTo(x, MARGIN.top + plotH)
+      ctx.stroke()
+      ctx.setLineDash([])
+    }
+  }, [histogram, size, plotW, plotH, barSlot, hover])
+
+  useEffect(() => {
+    paint()
+  }, [paint])
+
+  const onMouseMove = useCallback(
+    (event: React.MouseEvent<HTMLCanvasElement>) => {
+      const rect = event.currentTarget.getBoundingClientRect()
+      const mx = event.clientX - rect.left
+      const my = event.clientY - rect.top
+      if (mx < MARGIN.left || mx > MARGIN.left + plotW) {
+        setHover(null)
+        return
+      }
+      const bucket = clamp(Math.floor((mx - MARGIN.left) / barSlot), 0, BUCKET_COUNT - 1)
+      setHover({ bucket, px: mx, py: my })
+    },
+    [plotW, barSlot],
+  )
+
+  const onMouseLeave = useCallback(() => setHover(null), [])
+
+  const hoveredCount = hover && histogram ? histogram.counts[hover.bucket] : 0
+  const hoveredPct = hover && histogram ? histogram.percentages[hover.bucket] : 0
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-xs text-slate-400">
+        <span>
+          Epochs {fromEpoch}–{toEpoch} · {histogram?.total ?? 0} attestations
+        </span>
+        <span>{isComputing ? 'Computing…' : `mean delay ${(histogram?.meanDelay ?? 0).toFixed(2)} slots`}</span>
+      </div>
+
+      <div ref={containerRef} className="relative w-full" style={{ height: DISPLAY_HEIGHT }}>
+        <canvas
+          ref={canvasRef}
+          onMouseMove={onMouseMove}
+          onMouseLeave={onMouseLeave}
+          className="h-full w-full cursor-crosshair rounded-xl bg-slate-950/60"
+          style={{ width: '100%', height: DISPLAY_HEIGHT }}
+        />
+
+        {hover && histogram && (
+          <div
+            className="pointer-events-none absolute z-10 rounded-md border border-white/10 bg-slate-950/95 px-2.5 py-1.5 text-xs text-slate-100 shadow-lg"
+            style={{
+              left: clamp(hover.px + 12, 0, Math.max(0, size.w - 150)),
+              top: clamp(hover.py - 8, 0, Math.max(0, size.h - 64)),
+            }}
+          >
+            <div className="font-semibold">
+              {hover.bucket} slot{hover.bucket === 1 ? '' : 's'} delay
+            </div>
+            <div className="text-slate-400">Count: {hoveredCount.toLocaleString()}</div>
+            <div className="text-slate-400">Share: {hoveredPct.toFixed(2)}%</div>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4 text-xs text-slate-400">
+        <Legend color={COLOR_OPTIMAL} label="Optimal (≤1)" />
+        <Legend color={COLOR_FAIR} label="Fair (2–3)" />
+        <Legend color={COLOR_POOR} label="Poor (>3)" />
+      </div>
+    </div>
+  )
+}
+
+function Legend({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <span className="inline-block h-3 w-3 rounded-sm" style={{ backgroundColor: color }} />
+      {label}
+    </span>
+  )
+}

--- a/src/components/validators/EpochRangeSelector.tsx
+++ b/src/components/validators/EpochRangeSelector.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useCallback } from 'react'
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, value))
+}
+
+/**
+ * Dual-handle slider selecting an inclusive [from, to] epoch range. Enforces a
+ * minimum span so the histogram never zooms tighter than `minSpan` epochs.
+ * Built from two overlaid range inputs; pointer events are routed to the thumbs
+ * so both handles stay independently grabbable.
+ */
+export function EpochRangeSelector({
+  min,
+  max,
+  value,
+  minSpan = 8,
+  onChange,
+}: {
+  min: number
+  max: number
+  value: [number, number]
+  minSpan?: number
+  onChange: (from: number, to: number) => void
+}) {
+  const span = Math.max(1, max - min)
+  const from = clamp(value[0], min, max)
+  const to = clamp(value[1], min, max)
+  const disabled = max - min + 1 < minSpan
+
+  const lowPct = ((from - min) / span) * 100
+  const highPct = ((to - min) / span) * 100
+
+  const handleFrom = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const next = clamp(Number(event.target.value), min, to - minSpan)
+      onChange(next, to)
+    },
+    [min, to, minSpan, onChange],
+  )
+
+  const handleTo = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const next = clamp(Number(event.target.value), from + minSpan, max)
+      onChange(from, next)
+    },
+    [from, max, minSpan, onChange],
+  )
+
+  return (
+    <div className="space-y-2">
+      <style>{`
+        .epoch-range input[type="range"] {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 24px;
+          margin: 0;
+          background: transparent;
+          pointer-events: none;
+          -webkit-appearance: none;
+          appearance: none;
+        }
+        .epoch-range input[type="range"]:focus { outline: none; }
+        .epoch-range input[type="range"]::-webkit-slider-thumb {
+          -webkit-appearance: none;
+          pointer-events: auto;
+          height: 16px; width: 16px;
+          border-radius: 9999px;
+          background: #38bdf8;
+          border: 2px solid #0f172a;
+          cursor: pointer;
+        }
+        .epoch-range input[type="range"]::-moz-range-thumb {
+          pointer-events: auto;
+          height: 16px; width: 16px;
+          border-radius: 9999px;
+          background: #38bdf8;
+          border: 2px solid #0f172a;
+          cursor: pointer;
+        }
+        .epoch-range input[type="range"]:disabled::-webkit-slider-thumb { background: #475569; cursor: not-allowed; }
+        .epoch-range input[type="range"]:disabled::-moz-range-thumb { background: #475569; cursor: not-allowed; }
+      `}</style>
+
+      <div className="flex items-center justify-between text-xs text-slate-400">
+        <span>
+          Epoch <span className="font-semibold text-slate-200">{from}</span> →{' '}
+          <span className="font-semibold text-slate-200">{to}</span>
+        </span>
+        <span>{to - from + 1} epochs</span>
+      </div>
+
+      <div className="epoch-range relative h-6">
+        <div className="absolute top-1/2 h-1.5 w-full -translate-y-1/2 rounded-full bg-slate-700" />
+        <div
+          className="absolute top-1/2 h-1.5 -translate-y-1/2 rounded-full bg-sky-500"
+          style={{ left: `${lowPct}%`, right: `${100 - highPct}%` }}
+        />
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={1}
+          value={from}
+          onChange={handleFrom}
+          disabled={disabled}
+          aria-label="From epoch"
+        />
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={1}
+          value={to}
+          onChange={handleTo}
+          disabled={disabled}
+          aria-label="To epoch"
+        />
+      </div>
+
+      <div className="flex justify-between text-[10px] text-slate-500">
+        <span>{min}</span>
+        <span>{max}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/validators/ValidatorDetail.tsx
+++ b/src/components/validators/ValidatorDetail.tsx
@@ -3,13 +3,17 @@
 import { useMemo, useState } from 'react'
 import { SyncCommitteeHeatmap } from '@/src/components/canvas/SyncCommitteeHeatmap'
 import { SyncCommitteeSummary } from '@/src/components/validators/SyncCommitteeSummary'
+import { DelayHistogram } from '@/src/components/canvas/DelayHistogram'
+import { EpochRangeSelector } from '@/src/components/validators/EpochRangeSelector'
 import { useSyncCommitteeHistory } from '@/src/hooks/useSyncCommitteeHistory'
+import { useAttestationInclusion, MIN_SPAN } from '@/src/hooks/useAttestationInclusion'
 
-type TabKey = 'overview' | 'sync-committee'
+type TabKey = 'overview' | 'sync-committee' | 'attestation'
 
 const TABS: Array<{ key: TabKey; label: string }> = [
   { key: 'overview', label: 'Overview' },
   { key: 'sync-committee', label: 'Sync Committee' },
+  { key: 'attestation', label: 'Attestation' },
 ]
 
 /**
@@ -27,6 +31,10 @@ export function ValidatorDetail({
   const [tab, setTab] = useState<TabKey>('sync-committee')
   const history = useSyncCommitteeHistory(validatorIndex, { beaconNodeUrl })
   const { periods, currentPeriod, loadPeriod } = history
+
+  const attestation = useAttestationInclusion(validatorIndex, { beaconNodeUrl })
+  const inclusion = attestation.histogram
+  const within1Slot = inclusion ? inclusion.percentages[0] + inclusion.percentages[1] : 0
 
   const [selectedPeriod, setSelectedPeriod] = useState<number | null>(null)
 
@@ -130,6 +138,52 @@ export function ValidatorDetail({
           </section>
         </div>
       )}
+
+      {tab === 'attestation' && (
+        <div className="space-y-6">
+          <section className="rounded-3xl border border-white/10 bg-slate-900/80 p-6 text-white">
+            <div className="mb-5">
+              <h2 className="text-xl font-semibold">Attestation Effectiveness</h2>
+              <p className="text-sm text-slate-400">
+                Validator #{validatorIndex} · inclusion delay summary
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+              <Metric label="Mean delay" value={inclusion ? `${inclusion.meanDelay.toFixed(2)} slots` : '—'} />
+              <Metric label="Within 1 slot" value={inclusion ? `${within1Slot.toFixed(1)}%` : '—'} />
+              <Metric label="Attestations" value={inclusion ? inclusion.total.toLocaleString() : '—'} />
+              <Metric label="Epoch range" value={`${attestation.range[0]}–${attestation.range[1]}`} />
+            </div>
+          </section>
+
+          <section className="space-y-5 rounded-3xl border border-white/10 bg-slate-900/80 p-6 text-white">
+            <h3 className="text-lg font-semibold">Inclusion delay distribution</h3>
+            <EpochRangeSelector
+              min={attestation.minEpoch}
+              max={attestation.maxEpoch}
+              value={attestation.range}
+              minSpan={MIN_SPAN}
+              onChange={attestation.setRange}
+            />
+            <DelayHistogram
+              histogram={attestation.histogram}
+              fromEpoch={attestation.range[0]}
+              toEpoch={attestation.range[1]}
+              isComputing={attestation.isComputing}
+            />
+            {attestation.error && <p className="text-sm text-red-400">{attestation.error}</p>}
+          </section>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
+      <p className="text-xs uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="mt-1 font-semibold text-slate-100">{value}</p>
     </div>
   )
 }

--- a/src/hooks/useAttestationInclusion.ts
+++ b/src/hooks/useAttestationInclusion.ts
@@ -1,0 +1,238 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  binDelays,
+  computeDelay,
+  type AttestationInclusion,
+  type DelayHistogram,
+  type HistogramWorkerResponse,
+} from '@/src/utils/histogramBinner'
+import { GENESIS_TIME, SECONDS_PER_SLOT, SLOTS_PER_EPOCH } from '@/src/utils/syncCommittee'
+
+/** Maximum epochs retained in the ring buffer (configurable upper bound). */
+export const MAX_EPOCHS = 2048
+/** Minimum epochs per zoomed view. */
+export const MIN_SPAN = 8
+const DEFAULT_SPAN = 64
+const LIVE_INTERVAL_MS = 6000
+
+interface UseAttestationInclusionOptions {
+  beaconNodeUrl?: string
+  maxEpochs?: number
+  /** Append a new synthetic epoch on an interval (demo only). */
+  live?: boolean
+}
+
+export interface AttestationInclusionState {
+  records: AttestationInclusion[]
+  histogram: DelayHistogram | null
+  /** Current [fromEpoch, toEpoch] view range (inclusive). */
+  range: [number, number]
+  setRange: (from: number, to: number) => void
+  minEpoch: number
+  maxEpoch: number
+  currentEpoch: number | null
+  isComputing: boolean
+  error: string | null
+}
+
+// ---- deterministic demo data --------------------------------------------
+
+function fnv01(input: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0) / 0x1_0000_0000
+}
+
+function demoDelay(validatorIndex: number, epoch: number): number {
+  const r = fnv01(`delay:${validatorIndex}:${epoch}`)
+  if (r < 0.7) return 1 // optimal — included next slot
+  if (r < 0.9) return 2
+  if (r < 0.97) return 3
+  return 4 + Math.floor(fnv01(`tail:${validatorIndex}:${epoch}`) * 12) // occasional long tail
+}
+
+function demoRecord(validatorIndex: number, epoch: number): AttestationInclusion {
+  const attesterSlotOffset = Math.floor(fnv01(`off:${validatorIndex}:${epoch}`) * SLOTS_PER_EPOCH)
+  const delay = demoDelay(validatorIndex, epoch)
+  return {
+    epoch,
+    attesterSlotOffset,
+    inclusionSlot: epoch * SLOTS_PER_EPOCH + attesterSlotOffset + delay,
+  }
+}
+
+function epochAt(nowMs: number): number {
+  const slot = Math.max(0, Math.floor((nowMs / 1000 - GENESIS_TIME) / SECONDS_PER_SLOT))
+  return Math.floor(slot / SLOTS_PER_EPOCH)
+}
+
+/** Build the initial ring buffer of inclusion records ending at the current epoch. */
+function buildSeed(validatorIndex: number | null, maxEpochs: number): AttestationInclusion[] {
+  if (validatorIndex === null) return []
+  const cur = epochAt(Date.now())
+  const start = Math.max(0, cur - maxEpochs + 1)
+  const seeded: AttestationInclusion[] = []
+  for (let epoch = start; epoch <= cur; epoch++) {
+    seeded.push(demoRecord(validatorIndex, epoch))
+  }
+  return seeded
+}
+
+function defaultRange(records: AttestationInclusion[]): [number, number] {
+  if (records.length === 0) return [0, 0]
+  const cur = records[records.length - 1].epoch
+  const min = records[0].epoch
+  return [Math.max(min, cur - DEFAULT_SPAN + 1), cur]
+}
+
+function createWorker(): Worker | null {
+  try {
+    return new Worker(new URL('../workers/histogramRendererWorker.ts', import.meta.url))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Maintains a ring buffer of the most recent inclusion records for a validator
+ * and computes the inclusion-delay histogram for a configurable epoch range,
+ * binning off the main thread via a web worker (with a main-thread fallback).
+ */
+export function useAttestationInclusion(
+  validatorIndex: number | null,
+  options: UseAttestationInclusionOptions = {},
+): AttestationInclusionState {
+  const { beaconNodeUrl, maxEpochs = MAX_EPOCHS, live = !beaconNodeUrl } = options
+
+  const [records, setRecords] = useState<AttestationInclusion[]>([])
+  const [range, setRangeState] = useState<[number, number]>([0, 0])
+  const [histogram, setHistogram] = useState<DelayHistogram | null>(null)
+  const [isComputing, setIsComputing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [trackedValidator, setTrackedValidator] = useState<number | null | undefined>(undefined)
+
+  const workerRef = useRef<Worker | null>(null)
+  const requestIdRef = useRef(0)
+  const pendingRef = useRef<string | null>(null)
+
+  // (Re)seed the ring buffer when the validator (or source) changes, adjusting
+  // state during render rather than in an effect.
+  if (trackedValidator !== validatorIndex) {
+    setTrackedValidator(validatorIndex)
+    const seed = buildSeed(validatorIndex, maxEpochs)
+    setRecords(seed)
+    setRangeState(defaultRange(seed))
+    setError(null)
+  }
+
+  // Worker lifecycle.
+  useEffect(() => {
+    const worker = createWorker()
+    workerRef.current = worker
+
+    const handler = (e: MessageEvent<HistogramWorkerResponse>) => {
+      const msg = e.data
+      if (msg.payload.requestId !== pendingRef.current) return
+      if (msg.type === 'RESULT') {
+        setHistogram(msg.payload.histogram)
+        setIsComputing(false)
+      } else if (msg.type === 'ERROR') {
+        setError(msg.payload.message)
+        setIsComputing(false)
+      }
+    }
+
+    worker?.addEventListener('message', handler)
+    return () => {
+      worker?.removeEventListener('message', handler)
+      worker?.terminate()
+    }
+  }, [])
+
+  // Demo stream: append a fresh epoch on an interval, evicting the oldest.
+  useEffect(() => {
+    if (!live || validatorIndex === null) return
+    const interval = window.setInterval(() => {
+      setRecords((prev) => {
+        if (prev.length === 0) return prev
+        const nextEpoch = prev[prev.length - 1].epoch + 1
+        const appended = [...prev, demoRecord(validatorIndex, nextEpoch)]
+        while (appended.length > maxEpochs) appended.shift()
+        return appended
+      })
+    }, LIVE_INTERVAL_MS)
+    return () => window.clearInterval(interval)
+  }, [live, validatorIndex, maxEpochs])
+
+  // Recompute the histogram whenever the records or range change. The work is
+  // scheduled on the next frame (coalescing rapid slider drags) and binning is
+  // offloaded to the worker; the empty case naturally yields an empty result.
+  useEffect(() => {
+    let cancelled = false
+
+    const compute = () => {
+      if (cancelled) return
+      const [from, to] = range
+      const delays: number[] = []
+      for (const r of records) {
+        if (r.epoch >= from && r.epoch <= to) delays.push(computeDelay(r))
+      }
+
+      const worker = workerRef.current
+      if (worker) {
+        const requestId = `hist-${++requestIdRef.current}`
+        pendingRef.current = requestId
+        setIsComputing(true)
+        const payload = Float64Array.from(delays)
+        worker.postMessage({ type: 'COMPUTE', payload: { requestId, delays: payload } }, [payload.buffer])
+      } else {
+        setHistogram(binDelays(delays))
+      }
+    }
+
+    const raf = requestAnimationFrame(compute)
+    return () => {
+      cancelled = true
+      cancelAnimationFrame(raf)
+    }
+  }, [records, range])
+
+  const minEpoch = records.length ? records[0].epoch : 0
+  const maxEpoch = records.length ? records[records.length - 1].epoch : 0
+  const currentEpoch = records.length ? records[records.length - 1].epoch : null
+
+  const setRange = useCallback(
+    (from: number, to: number) => {
+      setRangeState(() => {
+        let lo = Math.max(minEpoch, Math.min(from, to))
+        let hi = Math.min(maxEpoch, Math.max(from, to))
+        if (hi - lo + 1 < MIN_SPAN) {
+          hi = Math.min(maxEpoch, lo + MIN_SPAN - 1)
+          lo = Math.max(minEpoch, hi - MIN_SPAN + 1)
+        }
+        return [lo, hi]
+      })
+    },
+    [minEpoch, maxEpoch],
+  )
+
+  return useMemo(
+    () => ({
+      records,
+      histogram,
+      range,
+      setRange,
+      minEpoch,
+      maxEpoch,
+      currentEpoch,
+      isComputing,
+      error,
+    }),
+    [records, histogram, range, setRange, minEpoch, maxEpoch, currentEpoch, isComputing, error],
+  )
+}

--- a/src/utils/histogramBinner.ts
+++ b/src/utils/histogramBinner.ts
@@ -1,0 +1,127 @@
+// Attestation inclusion delay binning.
+//
+// Inclusion delay is the number of slots between a validator's attestation
+// duty and the slot in which the attestation was actually included on chain:
+//
+//   delay = inclusion_slot - (attestation_epoch_start_slot + attester_slot_offset)
+//
+// A delay of 1 is optimal (included in the very next slot). Missed rewards
+// grow ~1% per slot of additional delay, so the distribution across epochs is
+// a key validator-effectiveness signal. Delays are bucketed by slot into 33
+// buckets (0..32 inclusive).
+
+export const SLOTS_PER_EPOCH = 32
+export const MAX_DELAY = 32
+export const BUCKET_COUNT = MAX_DELAY + 1 // 33 buckets, indices 0..32
+
+/** A single attestation inclusion observation for one validator. */
+export interface AttestationInclusion {
+  epoch: number
+  /** Absolute slot the attestation was included in. */
+  inclusionSlot: number
+  /** The validator's assigned slot offset within the epoch (0..31). */
+  attesterSlotOffset: number
+}
+
+/** Binned inclusion-delay distribution with pre-computed percentages. */
+export interface DelayHistogram {
+  /** Per-bucket attestation counts; length BUCKET_COUNT. */
+  counts: number[]
+  /** Total attestations counted. */
+  total: number
+  /** Per-bucket share of total, in percent (0..100). */
+  percentages: number[]
+  /** Cumulative percentage up to and including each bucket. */
+  cumulative: number[]
+  /** Highest single-bucket count (for y-axis scaling). */
+  maxCount: number
+  /** Mean inclusion delay across all counted attestations. */
+  meanDelay: number
+}
+
+/** Compute the inclusion delay for one record, clamped to [0, MAX_DELAY]. */
+export function computeDelay(record: AttestationInclusion): number {
+  const epochStartSlot = record.epoch * SLOTS_PER_EPOCH
+  const delay = record.inclusionSlot - (epochStartSlot + record.attesterSlotOffset)
+  if (delay < 0) return 0
+  if (delay > MAX_DELAY) return MAX_DELAY
+  return delay
+}
+
+function emptyHistogram(): DelayHistogram {
+  return {
+    counts: new Array(BUCKET_COUNT).fill(0),
+    total: 0,
+    percentages: new Array(BUCKET_COUNT).fill(0),
+    cumulative: new Array(BUCKET_COUNT).fill(0),
+    maxCount: 0,
+    meanDelay: 0,
+  }
+}
+
+/** Bin an array of already-computed delay values (each expected in [0, 32]). */
+export function binDelays(delays: ArrayLike<number>): DelayHistogram {
+  if (delays.length === 0) return emptyHistogram()
+
+  const counts = new Array(BUCKET_COUNT).fill(0)
+  let total = 0
+  let delaySum = 0
+
+  for (let i = 0; i < delays.length; i++) {
+    let d = delays[i]
+    if (d < 0) d = 0
+    else if (d > MAX_DELAY) d = MAX_DELAY
+    counts[d]++
+    total++
+    delaySum += d
+  }
+
+  const percentages = new Array(BUCKET_COUNT).fill(0)
+  const cumulative = new Array(BUCKET_COUNT).fill(0)
+  let maxCount = 0
+  let running = 0
+  for (let b = 0; b < BUCKET_COUNT; b++) {
+    const pct = total > 0 ? (counts[b] / total) * 100 : 0
+    percentages[b] = pct
+    running += pct
+    cumulative[b] = running
+    if (counts[b] > maxCount) maxCount = counts[b]
+  }
+
+  return {
+    counts,
+    total,
+    percentages,
+    cumulative,
+    maxCount,
+    meanDelay: total > 0 ? delaySum / total : 0,
+  }
+}
+
+/**
+ * Bin inclusion records whose epoch falls within [fromEpoch, toEpoch]
+ * (inclusive), computing each record's delay on the fly.
+ */
+export function binInclusions(
+  records: ArrayLike<AttestationInclusion>,
+  fromEpoch: number,
+  toEpoch: number,
+): DelayHistogram {
+  const delays: number[] = []
+  for (let i = 0; i < records.length; i++) {
+    const r = records[i]
+    if (r.epoch >= fromEpoch && r.epoch <= toEpoch) delays.push(computeDelay(r))
+  }
+  return binDelays(delays)
+}
+
+// ---- worker message protocol --------------------------------------------
+
+export type HistogramWorkerRequest = {
+  type: 'COMPUTE'
+  payload: { requestId: string; delays: Float64Array }
+}
+
+export type HistogramWorkerResponse =
+  | { type: 'RESULT'; payload: { requestId: string; histogram: DelayHistogram } }
+  | { type: 'ERROR'; payload: { requestId: string; message: string } }

--- a/src/workers/histogramRendererWorker.ts
+++ b/src/workers/histogramRendererWorker.ts
@@ -1,0 +1,28 @@
+// Web worker for attestation inclusion-delay binning.
+//
+// Binning a range of up to 2,048 epochs of inclusion data is offloaded here so
+// the main thread stays free for canvas rendering and interaction at 60 FPS.
+// Delay values arrive as a transferable Float64Array; the worker returns the
+// fully-computed histogram (counts, percentages, cumulative, scaling hints).
+
+import { binDelays, type HistogramWorkerRequest, type HistogramWorkerResponse } from '@/src/utils/histogramBinner'
+
+function post(message: HistogramWorkerResponse): void {
+  ;(self as unknown as Worker).postMessage(message)
+}
+
+self.onmessage = (e: MessageEvent<HistogramWorkerRequest>) => {
+  const msg = e.data
+  if (msg.type !== 'COMPUTE') return
+
+  const { requestId, delays } = msg.payload
+  try {
+    const histogram = binDelays(delays)
+    post({ type: 'RESULT', payload: { requestId, histogram } })
+  } catch (err) {
+    post({
+      type: 'ERROR',
+      payload: { requestId, message: err instanceof Error ? err.message : 'Unknown worker error' },
+    })
+  }
+}


### PR DESCRIPTION
Closes #47

- utils/histogramBinner.ts: delay computation + 33-bucket binning with pre-computed percentages/cumulative + worker message protocol
- workers/histogramRendererWorker.ts: off-thread binning via transferable Float64Array
- hooks/useAttestationInclusion.ts: 2,048-epoch ring buffer, range queries, worker-backed compute (rAF-coalesced) with main-thread fallback
- components/canvas/DelayHistogram.tsx: canvas bar chart, axes, crosshair tooltip (count + %), delay-severity coloring
- components/validators/EpochRangeSelector.tsx: dual-handle slider with enforced minimum span (8 epochs)
- components/validators/ValidatorDetail.tsx: new Attestation tab mounting the summary + range selector + histogram