### PR TITLE
feat: effective balance reconciliation engine for partial withdrawal …

### DIFF
--- a/app/validators/dashboard/page.tsx
+++ b/app/validators/dashboard/page.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { ValidatorDashboard } from '@/src/components/validators/ValidatorDashboard'
+
+function DashboardRoute() {
+  const params = useSearchParams()
+  const rawValidators = params.get('validators')
+  const validatorIndices = rawValidators
+    ? rawValidators
+        .split(',')
+        .map((v) => Number(v.trim()))
+        .filter((n) => Number.isFinite(n) && n >= 0)
+    : undefined
+  const beaconNodeUrl = params.get('beacon') ?? undefined
+
+  return (
+    <main className="mx-auto min-h-screen max-w-5xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold text-white">Validator Dashboard</h1>
+      <ValidatorDashboard
+        validatorIndices={validatorIndices && validatorIndices.length > 0 ? validatorIndices : undefined}
+        beaconNodeUrl={beaconNodeUrl}
+      />
+    </main>
+  )
+}
+
+export default function ValidatorDashboardPage() {
+  return (
+    <div className="min-h-screen bg-slate-950">
+      <Suspense fallback={<div className="p-8 text-slate-400">Loading…</div>}>
+        <DashboardRoute />
+      </Suspense>
+    </div>
+  )
+}

--- a/src/components/validators/BalanceReconciliationTable.tsx
+++ b/src/components/validators/BalanceReconciliationTable.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useMemo } from 'react'
+import { formatEth } from '@/src/utils/balanceMath'
+import {
+  useValidatorBalances,
+  type ValidatorReconciliation,
+} from '@/src/hooks/useValidatorBalances'
+
+const ZERO = BigInt(0)
+
+/** Stacked proportion bar of rewards / penalties / withdrawals for a validator. */
+function DeltaBar({ entry }: { entry: ValidatorReconciliation }) {
+  const { totalRewardsGwei, totalPenaltiesGwei, totalWithdrawalsGwei } = entry.summary
+  const total = totalRewardsGwei + totalPenaltiesGwei + totalWithdrawalsGwei
+  const pct = (v: bigint) => (total > ZERO ? (Number(v) / Number(total)) * 100 : 0)
+
+  return (
+    <div className="flex h-2 w-28 overflow-hidden rounded-full bg-slate-800" title="rewards / penalties / withdrawals">
+      <span style={{ width: `${pct(totalRewardsGwei)}%` }} className="bg-emerald-500" />
+      <span style={{ width: `${pct(totalPenaltiesGwei)}%` }} className="bg-red-500" />
+      <span style={{ width: `${pct(totalWithdrawalsGwei)}%` }} className="bg-sky-500" />
+    </div>
+  )
+}
+
+/**
+ * Per-validator effective-vs-actual balance breakdown. Each row shows the
+ * actual and effective balance, capped status, and the decomposed
+ * reward/penalty/withdrawal totals with a proportion bar.
+ */
+export function BalanceReconciliationTable({
+  validatorIndices,
+  beaconNodeUrl,
+}: {
+  validatorIndices: number[]
+  beaconNodeUrl?: string
+}) {
+  const { byValidator, validators, isLoading, error } = useValidatorBalances(validatorIndices, {
+    beaconNodeUrl,
+  })
+
+  const rows = useMemo(
+    () => validators.map((vi) => ({ vi, entry: byValidator[vi] })).filter((r) => r.entry),
+    [validators, byValidator],
+  )
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-950/40">
+      {error && <p className="px-4 py-3 text-sm text-red-400">{error}</p>}
+      {isLoading && rows.length === 0 ? (
+        <p className="px-4 py-8 text-center text-sm text-slate-400">Reconciling balances…</p>
+      ) : rows.length === 0 ? (
+        <p className="px-4 py-8 text-center text-sm text-slate-400">No validators to reconcile.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[680px] text-left text-sm">
+            <thead className="text-xs uppercase tracking-wide text-slate-500">
+              <tr className="border-b border-white/10">
+                <th className="px-4 py-3 font-medium">Validator</th>
+                <th className="px-4 py-3 font-medium">Actual</th>
+                <th className="px-4 py-3 font-medium">Effective</th>
+                <th className="px-4 py-3 font-medium">Rewards</th>
+                <th className="px-4 py-3 font-medium">Penalties</th>
+                <th className="px-4 py-3 font-medium">Withdrawals</th>
+                <th className="px-4 py-3 font-medium">Mix</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(({ vi, entry }) => {
+                const s = entry.summary
+                const latest = s.latest
+                return (
+                  <tr key={vi} className="border-b border-white/5 text-slate-200">
+                    <td className="px-4 py-3 font-mono">
+                      #{vi}
+                      {latest?.capped && (
+                        <span className="ml-2 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold text-amber-400">
+                          CAPPED
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums">
+                      {latest ? formatEth(latest.actualBalanceGwei) : '—'}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-slate-400">
+                      {latest ? formatEth(latest.effectiveBalanceGwei) : '—'}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-emerald-400">
+                      +{formatEth(s.totalRewardsGwei)}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-red-400">
+                      -{formatEth(s.totalPenaltiesGwei)}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-sky-400">
+                      {formatEth(s.totalWithdrawalsGwei)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <DeltaBar entry={entry} />
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/validators/ValidatorDashboard.tsx
+++ b/src/components/validators/ValidatorDashboard.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { BalanceReconciliationTable } from '@/src/components/validators/BalanceReconciliationTable'
+import { ValidatorUnlockCard } from '@/src/components/validators/ValidatorUnlockCard'
+import { useValidatorBalances } from '@/src/hooks/useValidatorBalances'
+
+const DEFAULT_VALIDATORS = [100, 101, 102, 103, 104, 105]
+
+/**
+ * Validator dashboard. Hosts the "Balance Reconciliation" accordion: a
+ * per-validator effective-vs-actual breakdown table, plus projected-unlock
+ * cards for any validators currently over the effective-balance cap.
+ */
+export function ValidatorDashboard({
+  validatorIndices = DEFAULT_VALIDATORS,
+  beaconNodeUrl,
+}: {
+  validatorIndices?: number[]
+  beaconNodeUrl?: string
+}) {
+  const [open, setOpen] = useState(true)
+  const { byValidator } = useValidatorBalances(validatorIndices, { beaconNodeUrl })
+
+  const cappedValidators = useMemo(
+    () => validatorIndices.filter((vi) => byValidator[vi]?.summary.latest?.capped),
+    [validatorIndices, byValidator],
+  )
+
+  return (
+    <div className="space-y-6">
+      <section className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 text-white">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="flex w-full items-center justify-between gap-4 p-6 text-left"
+          aria-expanded={open}
+        >
+          <div>
+            <h2 className="text-xl font-semibold">Balance Reconciliation</h2>
+            <p className="text-sm text-slate-400">
+              Effective vs actual balance · {validatorIndices.length} validators
+              {cappedValidators.length > 0 && ` · ${cappedValidators.length} capped`}
+            </p>
+          </div>
+          <span className="flex h-8 w-8 items-center justify-center rounded-full border border-white/10 text-lg text-slate-300">
+            {open ? '−' : '+'}
+          </span>
+        </button>
+
+        {open && (
+          <div className="space-y-6 px-6 pb-6">
+            <BalanceReconciliationTable validatorIndices={validatorIndices} beaconNodeUrl={beaconNodeUrl} />
+
+            {cappedValidators.length > 0 && (
+              <div className="space-y-3">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                  Projected unlocks
+                </h3>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {cappedValidators.map((vi) => (
+                    <ValidatorUnlockCard key={vi} validatorIndex={vi} beaconNodeUrl={beaconNodeUrl} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/components/validators/ValidatorUnlockCard.tsx
+++ b/src/components/validators/ValidatorUnlockCard.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { formatEth } from '@/src/utils/balanceMath'
+import { useReconciliationHistory, MAX_HISTORY } from '@/src/hooks/useReconciliationHistory'
+
+function formatDate(ms: number | null): string {
+  if (ms === null) return '—'
+  return new Date(ms).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function formatDays(days: number | null): string {
+  if (days === null) return '—'
+  if (days >= 365) return `${(days / 365).toFixed(1)} yr`
+  return `${days.toFixed(1)} d`
+}
+
+/**
+ * Projected-unlock timeline for a single (capped) validator. Shows the excess
+ * over the cap, the trailing reward rate driving the estimate, and the ETA
+ * with its ±15% error bounds. Non-capped validators render a quiet placeholder.
+ */
+export function ValidatorUnlockCard({
+  validatorIndex,
+  beaconNodeUrl,
+}: {
+  validatorIndex: number
+  beaconNodeUrl?: string
+}) {
+  const { projection, records, isLoading } = useReconciliationHistory(validatorIndex, { beaconNodeUrl })
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-slate-900/70 p-5 text-white">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h4 className="font-mono text-sm font-semibold">Validator #{validatorIndex}</h4>
+          <p className="text-xs text-slate-500">
+            {records.length}/{MAX_HISTORY} records
+          </p>
+        </div>
+        <span
+          className={`rounded-full px-2.5 py-1 text-[10px] font-semibold ${
+            projection.capped ? 'bg-amber-500/15 text-amber-400' : 'bg-slate-700/40 text-slate-400'
+          }`}
+        >
+          {projection.capped ? 'CAPPED' : 'UNCAPPED'}
+        </span>
+      </div>
+
+      {isLoading && records.length === 0 ? (
+        <p className="py-4 text-center text-sm text-slate-400">Projecting…</p>
+      ) : !projection.capped ? (
+        <p className="py-4 text-sm text-slate-400">
+          Balance is at or below the effective-balance cap — no unlock projection.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <Stat label="Excess over cap" value={`${formatEth(projection.excessGwei)} ETH`} />
+            <Stat label="Avg reward / day" value={`${formatEth(projection.avgDailyRewardGwei, 6)} ETH`} />
+            <Stat label="Projected ETA" value={formatDays(projection.etaDays)} tone="text-sky-300" />
+            <Stat label="Unlock date" value={formatDate(projection.unlockDate)} tone="text-sky-300" />
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3 text-xs text-slate-400">
+            <p className="mb-1 font-medium text-slate-300">±15% error bounds</p>
+            <div className="flex items-center justify-between">
+              <span>{formatDate(projection.unlockDateLow)}</span>
+              <span className="text-slate-600">→</span>
+              <span>{formatDate(projection.unlockDateHigh)}</span>
+            </div>
+            <div className="mt-1 flex items-center justify-between text-slate-500">
+              <span>{formatDays(projection.etaDaysLow)}</span>
+              <span>{formatDays(projection.etaDaysHigh)}</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function Stat({ label, value, tone = 'text-slate-100' }: { label: string; value: string; tone?: string }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
+      <p className="text-[11px] uppercase tracking-wide text-slate-500">{label}</p>
+      <p className={`mt-1 font-semibold ${tone}`}>{value}</p>
+    </div>
+  )
+}

--- a/src/hooks/useReconciliationHistory.ts
+++ b/src/hooks/useReconciliationHistory.ts
@@ -1,0 +1,114 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type {
+  ReconciliationRecord,
+  ReconciliationSummary,
+  UnlockProjection,
+  ValidatorBalanceSample,
+} from '@/src/types/validator'
+import { reconcile, reconcileSeries, summarize } from '@/src/utils/balanceReconciliation'
+import { projectUnlock } from '@/src/utils/unlockProjection'
+import { createDemoStakingService, createStakingService } from '@/src/services/stakingService'
+
+/** Per-validator reconciliation history is capped at this many records (FIFO). */
+export const MAX_HISTORY = 1000
+
+interface UseReconciliationHistoryOptions {
+  beaconNodeUrl?: string
+  historyDepth?: number
+}
+
+export interface ReconciliationHistoryState {
+  records: ReconciliationRecord[]
+  summary: ReconciliationSummary
+  projection: UnlockProjection
+  isLoading: boolean
+  error: string | null
+  /** Append a fresh sample, reconciling it and evicting the oldest at the cap. */
+  ingest: (sample: ValidatorBalanceSample) => void
+}
+
+/**
+ * Maintains a single validator's reconciliation record history with FIFO
+ * eviction at MAX_HISTORY (1,000) entries, plus a live `ingest` for streaming
+ * new epoch samples. Exposes the aggregate summary and unlock projection.
+ */
+export function useReconciliationHistory(
+  validatorIndex: number | null,
+  options: UseReconciliationHistoryOptions = {},
+): ReconciliationHistoryState {
+  const { beaconNodeUrl, historyDepth = MAX_HISTORY } = options
+  const cap = Math.min(historyDepth, MAX_HISTORY)
+
+  const provider = useMemo(
+    () => (beaconNodeUrl ? createStakingService(beaconNodeUrl) : createDemoStakingService()),
+    [beaconNodeUrl],
+  )
+
+  const [records, setRecords] = useState<ReconciliationRecord[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const lastSampleRef = useRef<ValidatorBalanceSample | null>(null)
+
+  // Clear stale records when the validator changes (adjust state during render).
+  const [trackedValidator, setTrackedValidator] = useState<number | null | undefined>(undefined)
+  if (trackedValidator !== validatorIndex) {
+    setTrackedValidator(validatorIndex)
+    setRecords([])
+  }
+
+  useEffect(() => {
+    lastSampleRef.current = null
+    if (validatorIndex === null) return
+
+    let cancelled = false
+    const run = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const samples = await provider.fetchSamples(validatorIndex, cap)
+        if (cancelled) return
+        const windowed = samples.slice(-cap)
+        const recs = reconcileSeries(windowed)
+        lastSampleRef.current = windowed.length ? windowed[windowed.length - 1] : null
+        setRecords(recs.slice(-cap))
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load reconciliation history')
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [validatorIndex, provider, cap])
+
+  const ingest = useCallback(
+    (sample: ValidatorBalanceSample) => {
+      const record = reconcile(lastSampleRef.current, sample)
+      lastSampleRef.current = sample
+      setRecords((prev) => {
+        const next = [...prev, record]
+        while (next.length > cap) next.shift()
+        return next
+      })
+    },
+    [cap],
+  )
+
+  const summary = useMemo(
+    () => summarize(validatorIndex ?? -1, records),
+    [validatorIndex, records],
+  )
+  const projection = useMemo(
+    () => projectUnlock(validatorIndex ?? -1, records),
+    [validatorIndex, records],
+  )
+
+  return { records, summary, projection, isLoading, error, ingest }
+}

--- a/src/hooks/useValidatorBalances.ts
+++ b/src/hooks/useValidatorBalances.ts
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type {
+  ReconciliationRecord,
+  ReconciliationSummary,
+  UnlockProjection,
+} from '@/src/types/validator'
+import { reconcileSeries, summarize } from '@/src/utils/balanceReconciliation'
+import { projectUnlock } from '@/src/utils/unlockProjection'
+import { createDemoStakingService, createStakingService } from '@/src/services/stakingService'
+
+/** Default history depth fetched per validator (FIFO-capped downstream). */
+const DEFAULT_DEPTH = 1000
+
+interface UseValidatorBalancesOptions {
+  beaconNodeUrl?: string
+  historyDepth?: number
+}
+
+/** Reconciled balance view for a single validator. */
+export interface ValidatorReconciliation {
+  records: ReconciliationRecord[]
+  summary: ReconciliationSummary
+  projection: UnlockProjection
+}
+
+export interface ValidatorBalancesState {
+  byValidator: Record<number, ValidatorReconciliation>
+  validators: number[]
+  isLoading: boolean
+  error: string | null
+}
+
+/**
+ * Fetches balance samples for a set of validators and reconciles each into a
+ * summary + unlock projection. This is the overview data source for the
+ * reconciliation table; per-validator live history lives in
+ * useReconciliationHistory.
+ */
+export function useValidatorBalances(
+  validatorIndices: number[],
+  options: UseValidatorBalancesOptions = {},
+): ValidatorBalancesState {
+  const { beaconNodeUrl, historyDepth = DEFAULT_DEPTH } = options
+
+  const provider = useMemo(
+    () => (beaconNodeUrl ? createStakingService(beaconNodeUrl) : createDemoStakingService()),
+    [beaconNodeUrl],
+  )
+
+  const [byValidator, setByValidator] = useState<Record<number, ValidatorReconciliation>>({})
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Stable primitive dependency so the effect re-runs only on a real change.
+  const indicesKey = validatorIndices.join(',')
+
+  // Clear stale data when the validator set changes (adjust state during render).
+  const [trackedKey, setTrackedKey] = useState<string | undefined>(undefined)
+  if (trackedKey !== indicesKey) {
+    setTrackedKey(indicesKey)
+    setByValidator({})
+  }
+
+  useEffect(() => {
+    const indices = indicesKey ? indicesKey.split(',').map(Number) : []
+    if (indices.length === 0) return
+
+    let cancelled = false
+    const run = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const entries = await Promise.all(
+          indices.map(async (vi) => {
+            const samples = (await provider.fetchSamples(vi, historyDepth)).slice(-historyDepth)
+            const records = reconcileSeries(samples)
+            const entry: ValidatorReconciliation = {
+              records,
+              summary: summarize(vi, records),
+              projection: projectUnlock(vi, records),
+            }
+            return [vi, entry] as const
+          }),
+        )
+        if (cancelled) return
+        setByValidator(Object.fromEntries(entries))
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load validator balances')
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [indicesKey, provider, historyDepth])
+
+  const validators = useMemo(
+    () => (indicesKey ? indicesKey.split(',').map(Number) : []),
+    [indicesKey],
+  )
+
+  return { byValidator, validators, isLoading, error }
+}

--- a/src/services/stakingService.ts
+++ b/src/services/stakingService.ts
@@ -1,0 +1,123 @@
+// Staking service — source of validator balance samples for reconciliation.
+//
+// Provides a deterministic demo generator (forward-simulated rewards,
+// penalties, and partial-withdrawal sweeps) and a beacon-API-backed factory.
+// Amounts are bigint gwei.
+
+import type { ValidatorBalanceSample } from '@/src/types/validator'
+import { EFFECTIVE_BALANCE_CAP_GWEI, excessOverCap } from '@/src/utils/balanceMath'
+
+const SLOTS_PER_EPOCH = 32
+const SECONDS_PER_SLOT = 12
+const GENESIS_TIME = 1_606_824_023
+const EPOCH_SECONDS = SLOTS_PER_EPOCH * SECONDS_PER_SLOT
+const SWEEP_PERIOD_EPOCHS = 225 // ~daily partial-withdrawal sweep
+
+export type StakingProvider = {
+  fetchSamples(validatorIndex: number, count: number): Promise<ValidatorBalanceSample[]>
+}
+
+function fnv01(input: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0) / 0x1_0000_0000
+}
+
+function epochTimestampMs(epoch: number): number {
+  return (GENESIS_TIME + epoch * EPOCH_SECONDS) * 1000
+}
+
+function currentEpoch(nowMs: number): number {
+  return Math.max(0, Math.floor((nowMs / 1000 - GENESIS_TIME) / EPOCH_SECONDS))
+}
+
+/**
+ * Forward-simulate `count` epoch-boundary samples for a validator. Even
+ * indices start above the cap (so they show as capped with a sweep stream);
+ * odd indices hover just below it.
+ */
+export function generateDemoSamples(
+  validatorIndex: number,
+  count: number,
+  options: { endEpoch?: number; nowMs?: number } = {},
+): ValidatorBalanceSample[] {
+  const nowMs = options.nowMs ?? Date.now()
+  const endEpoch = options.endEpoch ?? currentEpoch(nowMs)
+  const startEpoch = Math.max(0, endEpoch - count + 1)
+
+  const capped = validatorIndex % 2 === 0
+  const initialExcess = capped
+    ? BigInt(Math.round((1.5 + fnv01(`excess:${validatorIndex}`) * 2) * 1e9)) // 1.5–3.5 ETH over cap
+    : BigInt(0) - BigInt(Math.round((0.2 + fnv01(`gap:${validatorIndex}`) * 0.4) * 1e9)) // 0.2–0.6 ETH under
+
+  let actual = EFFECTIVE_BALANCE_CAP_GWEI + initialExcess
+  const sweepPhase = Math.floor(fnv01(`phase:${validatorIndex}`) * SWEEP_PERIOD_EPOCHS)
+
+  const samples: ValidatorBalanceSample[] = new Array(endEpoch - startEpoch + 1)
+  for (let i = 0, epoch = startEpoch; epoch <= endEpoch; epoch++, i++) {
+    const reward = 11_000 + Math.floor(fnv01(`r:${validatorIndex}:${epoch}`) * 9_000) // gwei
+    const missed = fnv01(`m:${validatorIndex}:${epoch}`) < 0.04
+    const penalty = missed ? 2_000 + Math.floor(fnv01(`p:${validatorIndex}:${epoch}`) * 3_000) : 0
+    actual += BigInt(reward - penalty)
+
+    // Partial-withdrawal sweep: skim the excess above the cap on the sweep epoch.
+    let withdrawal = BigInt(0)
+    const excess = excessOverCap(actual)
+    if (excess > BigInt(0) && epoch % SWEEP_PERIOD_EPOCHS === sweepPhase) {
+      // Sweep most of the excess, leaving a little so the validator stays capped.
+      withdrawal = (excess * BigInt(85)) / BigInt(100)
+      actual -= withdrawal
+    }
+
+    samples[i] = {
+      validatorIndex,
+      epoch,
+      timestamp: epochTimestampMs(epoch),
+      actualBalanceGwei: actual,
+      withdrawalGwei: withdrawal,
+    }
+  }
+  return samples
+}
+
+export function createDemoStakingService(): StakingProvider {
+  return {
+    async fetchSamples(validatorIndex, count) {
+      return generateDemoSamples(validatorIndex, count)
+    },
+  }
+}
+
+/**
+ * Beacon-API-backed provider. Reads the current validator balance; full
+ * historical decomposition requires a per-epoch state/withdrawal scan, so this
+ * returns a single current sample (callers fall back to the demo stream for
+ * history when no node is configured).
+ */
+export function createStakingService(baseUrl: string): StakingProvider {
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, '')
+  return {
+    async fetchSamples(validatorIndex) {
+      const response = await fetch(
+        `${normalizedBaseUrl}/eth/v1/beacon/states/head/validator_balances?id=${validatorIndex}`,
+      )
+      if (!response.ok) throw new Error('Unable to fetch validator balances')
+      const body = (await response.json()) as { data?: Array<{ balance?: string | number }> }
+      const balance = body.data?.[0]?.balance
+      const actualBalanceGwei = balance === undefined ? EFFECTIVE_BALANCE_CAP_GWEI : BigInt(balance)
+      const epoch = currentEpoch(Date.now())
+      return [
+        {
+          validatorIndex,
+          epoch,
+          timestamp: epochTimestampMs(epoch),
+          actualBalanceGwei,
+          withdrawalGwei: BigInt(0),
+        },
+      ]
+    },
+  }
+}

--- a/src/types/validator.ts
+++ b/src/types/validator.ts
@@ -1,0 +1,74 @@
+// Validator balance & reconciliation type definitions.
+//
+// All on-chain amounts are held as bigint gwei to avoid float drift; display
+// formatting to ETH happens at the edge (see utils/balanceMath).
+
+/**
+ * A raw balance observation for a validator at an epoch boundary. Effective
+ * balance updates only at epoch boundaries, so one sample per epoch suffices.
+ * `withdrawalGwei` is the amount swept out this epoch (0 when none).
+ */
+export interface ValidatorBalanceSample {
+  validatorIndex: number
+  epoch: number
+  /** Unix-ms timestamp of the epoch boundary. */
+  timestamp: number
+  /** Actual on-chain balance in gwei. */
+  actualBalanceGwei: bigint
+  /** Amount partial-withdrawn (swept) this epoch, in gwei. */
+  withdrawalGwei: bigint
+}
+
+/**
+ * The decomposition of one epoch's balance change relative to the previous
+ * sample. The net actual-balance delta is split into its consensus-layer
+ * reward, penalty, and withdrawal-credit components:
+ *
+ *   gross_delta   = actual_n - actual_{n-1} + withdrawal_n
+ *   rewards       = max(0, gross_delta)
+ *   penalties     = max(0, -gross_delta)
+ *   withdrawal    = withdrawal_n
+ */
+export interface ReconciliationRecord {
+  validatorIndex: number
+  epoch: number
+  timestamp: number
+  actualBalanceGwei: bigint
+  effectiveBalanceGwei: bigint
+  /** actual_n - actual_{n-1} (negative if balance fell). */
+  netDeltaGwei: bigint
+  rewardsGwei: bigint
+  penaltiesGwei: bigint
+  withdrawalCreditsGwei: bigint
+  /** True when actual balance exceeds the effective-balance cap. */
+  capped: boolean
+}
+
+/** Aggregate reconciliation summary for a validator over its tracked history. */
+export interface ReconciliationSummary {
+  validatorIndex: number
+  latest: ReconciliationRecord | null
+  totalRewardsGwei: bigint
+  totalPenaltiesGwei: bigint
+  totalWithdrawalsGwei: bigint
+  recordCount: number
+}
+
+/** Projected unlock estimate for a capped validator. */
+export interface UnlockProjection {
+  validatorIndex: number
+  /** Whether the validator is currently capped (excess above the cap). */
+  capped: boolean
+  excessGwei: bigint
+  /** Trailing-average reward rate in gwei/day used for the projection. */
+  avgDailyRewardGwei: bigint
+  /** Central ETA in days; null when not capped or no positive reward rate. */
+  etaDays: number | null
+  /** ±15% error bounds around `etaDays`. */
+  etaDaysLow: number | null
+  etaDaysHigh: number | null
+  /** Projected unlock timestamps (unix-ms); null when not projectable. */
+  unlockDate: number | null
+  unlockDateLow: number | null
+  unlockDateHigh: number | null
+}

--- a/src/utils/balanceMath.ts
+++ b/src/utils/balanceMath.ts
@@ -1,0 +1,58 @@
+// Shared validator balance math.
+//
+// Amounts are bigint gwei. The target compiles to ES2017, so bigint *literals*
+// (e.g. `32n`) are unavailable — all constants use the BigInt() constructor.
+
+export const GWEI_PER_ETH = BigInt(1_000_000_000)
+
+/**
+ * Effective-balance cap. Per the reconciliation invariants this is 32 ETH
+ * (effective_balance = min(actual_balance, 32 ETH)). Post-Electra (EIP-7251)
+ * raised the max effective balance to 2048 ETH for 0x02 validators — change
+ * this single constant to model that regime.
+ */
+export const EFFECTIVE_BALANCE_CAP_GWEI = BigInt(32) * GWEI_PER_ETH
+
+/** Epochs per day at 6.4-minute epochs (32 slots × 12 s). */
+export const EPOCHS_PER_DAY = 225
+
+export function maxBigInt(a: bigint, b: bigint): bigint {
+  return a > b ? a : b
+}
+
+export function minBigInt(a: bigint, b: bigint): bigint {
+  return a < b ? a : b
+}
+
+const ZERO = BigInt(0)
+
+/** Effective balance = min(actual, cap). */
+export function effectiveBalance(actualGwei: bigint, cap = EFFECTIVE_BALANCE_CAP_GWEI): bigint {
+  return minBigInt(actualGwei, cap)
+}
+
+/** Excess of actual balance over the cap, floored at 0. */
+export function excessOverCap(actualGwei: bigint, cap = EFFECTIVE_BALANCE_CAP_GWEI): bigint {
+  return maxBigInt(ZERO, actualGwei - cap)
+}
+
+/** Whether the validator's actual balance exceeds the cap. */
+export function isCapped(actualGwei: bigint, cap = EFFECTIVE_BALANCE_CAP_GWEI): boolean {
+  return actualGwei > cap
+}
+
+/** Convert gwei to a floating-point ETH value (display only). */
+export function gweiToEth(gwei: bigint): number {
+  return Number(gwei) / Number(GWEI_PER_ETH)
+}
+
+/** Format a gwei amount as an ETH string with `decimals` places (sign-aware). */
+export function formatEth(gwei: bigint, decimals = 4): string {
+  const negative = gwei < ZERO
+  const abs = negative ? -gwei : gwei
+  const whole = abs / GWEI_PER_ETH
+  const frac = abs % GWEI_PER_ETH
+  const fracStr = frac.toString().padStart(9, '0').slice(0, decimals)
+  const sign = negative ? '-' : ''
+  return decimals > 0 ? `${sign}${whole.toString()}.${fracStr}` : `${sign}${whole.toString()}`
+}

--- a/src/utils/balanceReconciliation.ts
+++ b/src/utils/balanceReconciliation.ts
@@ -1,0 +1,119 @@
+// Effective-balance reconciliation engine.
+//
+// The displayed effective balance drifts from the actual balance because
+// effective balance is capped (min(actual, cap)) and updates only at epoch
+// boundaries, while actual balance moves every epoch from rewards, penalties,
+// and partial-withdrawal sweeps. This engine decomposes each epoch's actual-
+// balance delta into those three components.
+//
+// Decomposition (vs the previous sample):
+//   net_delta   = actual_n - actual_{n-1}
+//   gross_delta = net_delta + withdrawal_n   (add back what was swept out)
+//   rewards     = max(0, gross_delta)        consensus-layer income
+//   penalties   = max(0, -gross_delta)       missed-duty / slashing losses
+//   withdrawal  = withdrawal_n               partial-withdrawal credit
+
+import type {
+  ReconciliationRecord,
+  ReconciliationSummary,
+  ValidatorBalanceSample,
+} from '@/src/types/validator'
+import { EFFECTIVE_BALANCE_CAP_GWEI, effectiveBalance, isCapped } from '@/src/utils/balanceMath'
+
+const ZERO = BigInt(0)
+
+/**
+ * Reconcile a single sample against the previous one. With no previous sample
+ * the record is a baseline (no decomposed delta beyond the current withdrawal).
+ */
+export function reconcile(
+  prev: ValidatorBalanceSample | null,
+  current: ValidatorBalanceSample,
+  cap = EFFECTIVE_BALANCE_CAP_GWEI,
+): ReconciliationRecord {
+  const effective = effectiveBalance(current.actualBalanceGwei, cap)
+  const capped = isCapped(current.actualBalanceGwei, cap)
+
+  if (!prev) {
+    return {
+      validatorIndex: current.validatorIndex,
+      epoch: current.epoch,
+      timestamp: current.timestamp,
+      actualBalanceGwei: current.actualBalanceGwei,
+      effectiveBalanceGwei: effective,
+      netDeltaGwei: ZERO,
+      rewardsGwei: ZERO,
+      penaltiesGwei: ZERO,
+      withdrawalCreditsGwei: current.withdrawalGwei,
+      capped,
+    }
+  }
+
+  const netDelta = current.actualBalanceGwei - prev.actualBalanceGwei
+  const grossDelta = netDelta + current.withdrawalGwei
+  const rewards = grossDelta > ZERO ? grossDelta : ZERO
+  const penalties = grossDelta < ZERO ? -grossDelta : ZERO
+
+  return {
+    validatorIndex: current.validatorIndex,
+    epoch: current.epoch,
+    timestamp: current.timestamp,
+    actualBalanceGwei: current.actualBalanceGwei,
+    effectiveBalanceGwei: effective,
+    netDeltaGwei: netDelta,
+    rewardsGwei: rewards,
+    penaltiesGwei: penalties,
+    withdrawalCreditsGwei: current.withdrawalGwei,
+    capped,
+  }
+}
+
+/**
+ * Reconcile an ordered series of samples into per-epoch records. Input is
+ * sorted ascending by epoch defensively; duplicate epochs keep the last.
+ */
+export function reconcileSeries(
+  samples: ValidatorBalanceSample[],
+  cap = EFFECTIVE_BALANCE_CAP_GWEI,
+): ReconciliationRecord[] {
+  if (samples.length === 0) return []
+
+  const sorted = [...samples].sort((a, b) => a.epoch - b.epoch)
+  const deduped: ValidatorBalanceSample[] = []
+  for (const sample of sorted) {
+    const last = deduped[deduped.length - 1]
+    if (last && last.epoch === sample.epoch) deduped[deduped.length - 1] = sample
+    else deduped.push(sample)
+  }
+
+  const records: ReconciliationRecord[] = new Array(deduped.length)
+  let prev: ValidatorBalanceSample | null = null
+  for (let i = 0; i < deduped.length; i++) {
+    records[i] = reconcile(prev, deduped[i], cap)
+    prev = deduped[i]
+  }
+  return records
+}
+
+/** Aggregate a set of records into a per-validator summary. */
+export function summarize(
+  validatorIndex: number,
+  records: ReconciliationRecord[],
+): ReconciliationSummary {
+  let totalRewards = ZERO
+  let totalPenalties = ZERO
+  let totalWithdrawals = ZERO
+  for (const r of records) {
+    totalRewards += r.rewardsGwei
+    totalPenalties += r.penaltiesGwei
+    totalWithdrawals += r.withdrawalCreditsGwei
+  }
+  return {
+    validatorIndex,
+    latest: records.length ? records[records.length - 1] : null,
+    totalRewardsGwei: totalRewards,
+    totalPenaltiesGwei: totalPenalties,
+    totalWithdrawalsGwei: totalWithdrawals,
+    recordCount: records.length,
+  }
+}

--- a/src/utils/unlockProjection.ts
+++ b/src/utils/unlockProjection.ts
@@ -1,0 +1,99 @@
+// Projected-unlock calculator for capped validators.
+//
+// When a validator's actual balance exceeds the effective-balance cap, the
+// excess is swept out gradually by partial withdrawals. The projection
+// estimates how long the excess represents in reward-equivalent time, per the
+// invariant:
+//
+//   eta_days = (actual_balance - cap) / avg_daily_reward_rate   ± 15%
+//
+// The reward rate is a 7-day trailing average of decomposed consensus rewards.
+
+import type { ReconciliationRecord, UnlockProjection } from '@/src/types/validator'
+import { EFFECTIVE_BALANCE_CAP_GWEI, excessOverCap, isCapped } from '@/src/utils/balanceMath'
+
+const ZERO = BigInt(0)
+const DAY_MS = 24 * 60 * 60 * 1000
+const TRAILING_DAYS = 7
+const ERROR_BOUND = 0.15
+
+function emptyProjection(validatorIndex: number, excess: bigint, avgDaily: bigint): UnlockProjection {
+  return {
+    validatorIndex,
+    capped: excess > ZERO,
+    excessGwei: excess,
+    avgDailyRewardGwei: avgDaily,
+    etaDays: null,
+    etaDaysLow: null,
+    etaDaysHigh: null,
+    unlockDate: null,
+    unlockDateLow: null,
+    unlockDateHigh: null,
+  }
+}
+
+/**
+ * Average daily reward (gwei/day) over the trailing 7 days of records, scaled
+ * by the actual span covered so short histories still yield a sane rate.
+ */
+export function trailingDailyReward(
+  records: ReconciliationRecord[],
+  trailingDays = TRAILING_DAYS,
+): bigint {
+  if (records.length === 0) return ZERO
+  const dataNow = records[records.length - 1].timestamp
+  const windowStart = dataNow - trailingDays * DAY_MS
+
+  let sumRewards = ZERO
+  let earliest = dataNow
+  for (const r of records) {
+    if (r.timestamp > windowStart) {
+      sumRewards += r.rewardsGwei
+      if (r.timestamp < earliest) earliest = r.timestamp
+    }
+  }
+  if (sumRewards <= ZERO) return ZERO
+
+  const spanDays = Math.min(trailingDays, Math.max(1, (dataNow - earliest) / DAY_MS))
+  return BigInt(Math.round(Number(sumRewards) / spanDays))
+}
+
+/**
+ * Project the unlock ETA for a validator from its reconciliation records.
+ * Returns excess + reward rate always; ETA/dates are null when the validator
+ * is not capped or has no positive trailing reward rate.
+ */
+export function projectUnlock(
+  validatorIndex: number,
+  records: ReconciliationRecord[],
+  options: { now?: number; cap?: bigint } = {},
+): UnlockProjection {
+  const { now = Date.now(), cap = EFFECTIVE_BALANCE_CAP_GWEI } = options
+
+  if (records.length === 0) return emptyProjection(validatorIndex, ZERO, ZERO)
+
+  const actual = records[records.length - 1].actualBalanceGwei
+  const excess = excessOverCap(actual, cap)
+  const avgDaily = trailingDailyReward(records)
+
+  if (!isCapped(actual, cap) || avgDaily <= ZERO) {
+    return emptyProjection(validatorIndex, excess, avgDaily)
+  }
+
+  const etaDays = Number(excess) / Number(avgDaily)
+  const etaDaysLow = etaDays * (1 - ERROR_BOUND)
+  const etaDaysHigh = etaDays * (1 + ERROR_BOUND)
+
+  return {
+    validatorIndex,
+    capped: true,
+    excessGwei: excess,
+    avgDailyRewardGwei: avgDaily,
+    etaDays,
+    etaDaysLow,
+    etaDaysHigh,
+    unlockDate: now + etaDays * DAY_MS,
+    unlockDateLow: now + etaDaysLow * DAY_MS,
+    unlockDateHigh: now + etaDaysHigh * DAY_MS,
+  }
+}


### PR DESCRIPTION
Closes #46

- types/validator.ts: balance sample, reconciliation record/summary, projection
- utils/balanceMath.ts: gwei/ETH helpers + effective-balance cap constant
- utils/balanceReconciliation.ts: per-epoch delta decomposition (gross = net + withdrawal; rewards/penalties split) + series + summary
- utils/unlockProjection.ts: (excess / 7-day trailing reward rate) ETA with +/-15% error bounds
- services/stakingService.ts: demo (forward-simulated sweeps) + beacon-API providers
- hooks/useValidatorBalances.ts: multi-validator reconciliation overview
- hooks/useReconciliationHistory.ts: per-validator history, FIFO eviction at 1,000
- components/validators/BalanceReconciliationTable.tsx: breakdown table + mix bar
- components/validators/ValidatorUnlockCard.tsx: projected unlock timeline
- components/validators/ValidatorDashboard.tsx + app/validators/dashboard/page.tsx: 'Balance Reconciliation' accordion mounted at /validators/dashboard