### PR TITLE
Feat/exit queue visualization

### DIFF
--- a/app/validators/dashboard/page.tsx
+++ b/app/validators/dashboard/page.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { ValidatorDashboard } from '@/src/components/validators/ValidatorDashboard'
+
+function DashboardRoute() {
+  const params = useSearchParams()
+  const rawValidators = params.get('validators')
+  const validatorIndices = rawValidators
+    ? rawValidators
+        .split(',')
+        .map((v) => Number(v.trim()))
+        .filter((n) => Number.isFinite(n) && n >= 0)
+    : undefined
+  const beaconNodeUrl = params.get('beacon') ?? undefined
+
+  return (
+    <main className="mx-auto min-h-screen max-w-5xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold text-white">Validator Dashboard</h1>
+      <ValidatorDashboard
+        validatorIndices={validatorIndices && validatorIndices.length > 0 ? validatorIndices : undefined}
+        beaconNodeUrl={beaconNodeUrl}
+      />
+    </main>
+  )
+}
+
+export default function ValidatorDashboardPage() {
+  return (
+    <div className="min-h-screen bg-slate-950">
+      <Suspense fallback={<div className="p-8 text-slate-400">Loading…</div>}>
+        <DashboardRoute />
+      </Suspense>
+    </div>
+  )
+}

--- a/src/components/charts/EWMATrendline.tsx
+++ b/src/components/charts/EWMATrendline.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useMemo } from 'react'
+
+const VIEW_W = 300
+
+/**
+ * Lightweight SVG sparkline: the raw series (faint) with its EWMA overlay
+ * (bold). Shared min/max scaling keeps the two lines comparable. Adapted for
+ * exit-queue churn/depth trends.
+ */
+export function EWMATrendline({
+  values,
+  ewma,
+  height = 64,
+  color = '#38bdf8',
+  label,
+}: {
+  values: number[]
+  ewma?: number[]
+  height?: number
+  color?: string
+  label?: string
+}) {
+  const { rawPoints, ewmaPoints } = useMemo(() => {
+    if (values.length < 2) return { rawPoints: '', ewmaPoints: '' }
+
+    const all = ewma && ewma.length ? values.concat(ewma) : values
+    const min = Math.min(...all)
+    const max = Math.max(...all)
+    const span = max - min || 1
+
+    const toPoints = (series: number[]): string => {
+      const n = series.length
+      if (n < 2) return ''
+      return series
+        .map((v, i) => {
+          const x = (i / (n - 1)) * VIEW_W
+          const y = height - ((v - min) / span) * height
+          return `${x.toFixed(2)},${y.toFixed(2)}`
+        })
+        .join(' ')
+    }
+
+    return { rawPoints: toPoints(values), ewmaPoints: ewma ? toPoints(ewma) : '' }
+  }, [values, ewma, height])
+
+  return (
+    <div className="space-y-1">
+      {label && <p className="text-[11px] uppercase tracking-wide text-slate-500">{label}</p>}
+      <svg
+        viewBox={`0 0 ${VIEW_W} ${height}`}
+        preserveAspectRatio="none"
+        className="h-16 w-full rounded-lg bg-slate-950/60"
+        role="img"
+        aria-label={label ?? 'trend'}
+      >
+        {rawPoints ? (
+          <>
+            <polyline
+              points={rawPoints}
+              fill="none"
+              stroke={color}
+              strokeOpacity={0.3}
+              strokeWidth={1}
+              vectorEffect="non-scaling-stroke"
+            />
+            {ewmaPoints && (
+              <polyline
+                points={ewmaPoints}
+                fill="none"
+                stroke={color}
+                strokeWidth={2}
+                strokeLinejoin="round"
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
+          </>
+        ) : (
+          <line
+            x1={0}
+            y1={height / 2}
+            x2={VIEW_W}
+            y2={height / 2}
+            stroke="#334155"
+            strokeDasharray="4 4"
+            vectorEffect="non-scaling-stroke"
+          />
+        )}
+      </svg>
+    </div>
+  )
+}

--- a/src/components/validators/BalanceReconciliationTable.tsx
+++ b/src/components/validators/BalanceReconciliationTable.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useMemo } from 'react'
+import { formatEth } from '@/src/utils/balanceMath'
+import {
+  useValidatorBalances,
+  type ValidatorReconciliation,
+} from '@/src/hooks/useValidatorBalances'
+
+const ZERO = BigInt(0)
+
+/** Stacked proportion bar of rewards / penalties / withdrawals for a validator. */
+function DeltaBar({ entry }: { entry: ValidatorReconciliation }) {
+  const { totalRewardsGwei, totalPenaltiesGwei, totalWithdrawalsGwei } = entry.summary
+  const total = totalRewardsGwei + totalPenaltiesGwei + totalWithdrawalsGwei
+  const pct = (v: bigint) => (total > ZERO ? (Number(v) / Number(total)) * 100 : 0)
+
+  return (
+    <div className="flex h-2 w-28 overflow-hidden rounded-full bg-slate-800" title="rewards / penalties / withdrawals">
+      <span style={{ width: `${pct(totalRewardsGwei)}%` }} className="bg-emerald-500" />
+      <span style={{ width: `${pct(totalPenaltiesGwei)}%` }} className="bg-red-500" />
+      <span style={{ width: `${pct(totalWithdrawalsGwei)}%` }} className="bg-sky-500" />
+    </div>
+  )
+}
+
+/**
+ * Per-validator effective-vs-actual balance breakdown. Each row shows the
+ * actual and effective balance, capped status, and the decomposed
+ * reward/penalty/withdrawal totals with a proportion bar.
+ */
+export function BalanceReconciliationTable({
+  validatorIndices,
+  beaconNodeUrl,
+}: {
+  validatorIndices: number[]
+  beaconNodeUrl?: string
+}) {
+  const { byValidator, validators, isLoading, error } = useValidatorBalances(validatorIndices, {
+    beaconNodeUrl,
+  })
+
+  const rows = useMemo(
+    () => validators.map((vi) => ({ vi, entry: byValidator[vi] })).filter((r) => r.entry),
+    [validators, byValidator],
+  )
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-950/40">
+      {error && <p className="px-4 py-3 text-sm text-red-400">{error}</p>}
+      {isLoading && rows.length === 0 ? (
+        <p className="px-4 py-8 text-center text-sm text-slate-400">Reconciling balances…</p>
+      ) : rows.length === 0 ? (
+        <p className="px-4 py-8 text-center text-sm text-slate-400">No validators to reconcile.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[680px] text-left text-sm">
+            <thead className="text-xs uppercase tracking-wide text-slate-500">
+              <tr className="border-b border-white/10">
+                <th className="px-4 py-3 font-medium">Validator</th>
+                <th className="px-4 py-3 font-medium">Actual</th>
+                <th className="px-4 py-3 font-medium">Effective</th>
+                <th className="px-4 py-3 font-medium">Rewards</th>
+                <th className="px-4 py-3 font-medium">Penalties</th>
+                <th className="px-4 py-3 font-medium">Withdrawals</th>
+                <th className="px-4 py-3 font-medium">Mix</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(({ vi, entry }) => {
+                const s = entry.summary
+                const latest = s.latest
+                return (
+                  <tr key={vi} className="border-b border-white/5 text-slate-200">
+                    <td className="px-4 py-3 font-mono">
+                      #{vi}
+                      {latest?.capped && (
+                        <span className="ml-2 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold text-amber-400">
+                          CAPPED
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums">
+                      {latest ? formatEth(latest.actualBalanceGwei) : '—'}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-slate-400">
+                      {latest ? formatEth(latest.effectiveBalanceGwei) : '—'}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-emerald-400">
+                      +{formatEth(s.totalRewardsGwei)}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-red-400">
+                      -{formatEth(s.totalPenaltiesGwei)}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-sky-400">
+                      {formatEth(s.totalWithdrawalsGwei)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <DeltaBar entry={entry} />
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/validators/ExitQueuePositionCard.tsx
+++ b/src/components/validators/ExitQueuePositionCard.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { EWMATrendline } from '@/src/components/charts/EWMATrendline'
+import { useExitQueuePosition } from '@/src/hooks/useExitQueuePosition'
+
+function formatEta(ms: number | null): string {
+  if (ms === null) return '—'
+  if (ms <= 0) return 'imminent'
+  const minutes = ms / 60_000
+  if (minutes < 60) return `${Math.round(minutes)} min`
+  const hours = minutes / 60
+  if (hours < 48) return `${hours.toFixed(1)} h`
+  return `${(hours / 24).toFixed(1)} d`
+}
+
+function formatDate(ms: number | null): string {
+  if (ms === null) return '—'
+  return new Date(ms).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+/**
+ * Exit-queue position card for one validator: current position offset, total
+ * queue depth, EWMA churn rate, and the projected exit epoch / ETA, with depth
+ * and churn trendlines. Surfaces the 4-epoch slashing delay when applicable.
+ */
+export function ExitQueuePositionCard({
+  validatorIndex,
+  beaconNodeUrl,
+}: {
+  validatorIndex: number
+  beaconNodeUrl?: string
+}) {
+  const { projection, samples, ewmaSeries, isLoading, error } = useExitQueuePosition(validatorIndex, {
+    beaconNodeUrl,
+  })
+
+  // Live clock for the ETA countdown (kept out of render to stay pure).
+  const [now, setNow] = useState(0)
+  useEffect(() => {
+    const tick = () => setNow(Date.now())
+    tick()
+    const id = window.setInterval(tick, 1000)
+    return () => window.clearInterval(id)
+  }, [])
+
+  const depthSeries = useMemo(() => samples.map((s) => s.queueDepth), [samples])
+  const churnSeries = useMemo(
+    () => samples.map((s) => Math.min(s.queueDepth, s.churnLimit)),
+    [samples],
+  )
+
+  const etaMs =
+    now > 0 && projection?.projectedExitTimestamp !== null && projection?.projectedExitTimestamp !== undefined
+      ? projection.projectedExitTimestamp - now
+      : null
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-slate-900/70 p-5 text-white">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h4 className="font-mono text-sm font-semibold">Validator #{validatorIndex}</h4>
+          <p className="text-xs text-slate-500">Exit queue position</p>
+        </div>
+        {projection?.slashed && (
+          <span className="rounded-full bg-red-500/15 px-2.5 py-1 text-[10px] font-semibold text-red-400">
+            SLASHED · +4 EPOCH DELAY
+          </span>
+        )}
+      </div>
+
+      {error && <p className="mb-3 text-sm text-red-400">{error}</p>}
+
+      {isLoading && samples.length === 0 ? (
+        <p className="py-6 text-center text-sm text-slate-400">Reading exit queue…</p>
+      ) : !projection ? (
+        <p className="py-6 text-center text-sm text-slate-400">No queue data.</p>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <Stat label="Position" value={projection.positionOffset.toLocaleString()} tone="text-sky-300" />
+            <Stat label="Queue depth" value={projection.queueDepth.toLocaleString()} />
+            <Stat label="Churn (EWMA)" value={`${projection.ewmaChurn.toFixed(1)}/epoch`} />
+            <Stat
+              label="Exit epoch"
+              value={projection.projectedExitEpoch?.toLocaleString() ?? '—'}
+              tone="text-sky-300"
+            />
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-slate-400">Projected exit</span>
+              <span className="font-semibold">{formatDate(projection.projectedExitTimestamp)}</span>
+            </div>
+            <div className="mt-1 flex items-center justify-between text-xs text-slate-500">
+              <span>
+                ETA {formatEta(etaMs)}
+                {projection.epochsRemaining !== null && ` · ${projection.epochsRemaining.toLocaleString()} epochs`}
+              </span>
+            </div>
+          </div>
+
+          <EWMATrendline values={depthSeries} label="Queue depth" color="#f59e0b" />
+          <EWMATrendline values={churnSeries} ewma={ewmaSeries} label="Churn rate · EWMA α=0.3" />
+        </div>
+      )}
+    </section>
+  )
+}
+
+function Stat({ label, value, tone = 'text-slate-100' }: { label: string; value: string; tone?: string }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
+      <p className="text-[11px] uppercase tracking-wide text-slate-500">{label}</p>
+      <p className={`mt-1 font-semibold ${tone}`}>{value}</p>
+    </div>
+  )
+}

--- a/src/components/validators/ValidatorDashboard.tsx
+++ b/src/components/validators/ValidatorDashboard.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { BalanceReconciliationTable } from '@/src/components/validators/BalanceReconciliationTable'
+import { ValidatorUnlockCard } from '@/src/components/validators/ValidatorUnlockCard'
+import { useValidatorBalances } from '@/src/hooks/useValidatorBalances'
+
+const DEFAULT_VALIDATORS = [100, 101, 102, 103, 104, 105]
+
+/**
+ * Validator dashboard. Hosts the "Balance Reconciliation" accordion: a
+ * per-validator effective-vs-actual breakdown table, plus projected-unlock
+ * cards for any validators currently over the effective-balance cap.
+ */
+export function ValidatorDashboard({
+  validatorIndices = DEFAULT_VALIDATORS,
+  beaconNodeUrl,
+}: {
+  validatorIndices?: number[]
+  beaconNodeUrl?: string
+}) {
+  const [open, setOpen] = useState(true)
+  const { byValidator } = useValidatorBalances(validatorIndices, { beaconNodeUrl })
+
+  const cappedValidators = useMemo(
+    () => validatorIndices.filter((vi) => byValidator[vi]?.summary.latest?.capped),
+    [validatorIndices, byValidator],
+  )
+
+  return (
+    <div className="space-y-6">
+      <section className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 text-white">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="flex w-full items-center justify-between gap-4 p-6 text-left"
+          aria-expanded={open}
+        >
+          <div>
+            <h2 className="text-xl font-semibold">Balance Reconciliation</h2>
+            <p className="text-sm text-slate-400">
+              Effective vs actual balance · {validatorIndices.length} validators
+              {cappedValidators.length > 0 && ` · ${cappedValidators.length} capped`}
+            </p>
+          </div>
+          <span className="flex h-8 w-8 items-center justify-center rounded-full border border-white/10 text-lg text-slate-300">
+            {open ? '−' : '+'}
+          </span>
+        </button>
+
+        {open && (
+          <div className="space-y-6 px-6 pb-6">
+            <BalanceReconciliationTable validatorIndices={validatorIndices} beaconNodeUrl={beaconNodeUrl} />
+
+            {cappedValidators.length > 0 && (
+              <div className="space-y-3">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                  Projected unlocks
+                </h3>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {cappedValidators.map((vi) => (
+                    <ValidatorUnlockCard key={vi} validatorIndex={vi} beaconNodeUrl={beaconNodeUrl} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/components/validators/ValidatorDashboard.tsx
+++ b/src/components/validators/ValidatorDashboard.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react'
 import { BalanceReconciliationTable } from '@/src/components/validators/BalanceReconciliationTable'
 import { ValidatorUnlockCard } from '@/src/components/validators/ValidatorUnlockCard'
+import { ExitQueuePositionCard } from '@/src/components/validators/ExitQueuePositionCard'
 import { useValidatorBalances } from '@/src/hooks/useValidatorBalances'
 
 const DEFAULT_VALIDATORS = [100, 101, 102, 103, 104, 105]
@@ -20,6 +21,7 @@ export function ValidatorDashboard({
   beaconNodeUrl?: string
 }) {
   const [open, setOpen] = useState(true)
+  const [queueOpen, setQueueOpen] = useState(true)
   const { byValidator } = useValidatorBalances(validatorIndices, { beaconNodeUrl })
 
   const cappedValidators = useMemo(
@@ -64,6 +66,33 @@ export function ValidatorDashboard({
                 </div>
               </div>
             )}
+          </div>
+        )}
+      </section>
+
+      <section className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 text-white">
+        <button
+          type="button"
+          onClick={() => setQueueOpen((o) => !o)}
+          className="flex w-full items-center justify-between gap-4 p-6 text-left"
+          aria-expanded={queueOpen}
+        >
+          <div>
+            <h2 className="text-xl font-semibold">Exit Queue</h2>
+            <p className="text-sm text-slate-400">
+              Queue position &amp; projected exit ETA · {validatorIndices.length} validators
+            </p>
+          </div>
+          <span className="flex h-8 w-8 items-center justify-center rounded-full border border-white/10 text-lg text-slate-300">
+            {queueOpen ? '−' : '+'}
+          </span>
+        </button>
+
+        {queueOpen && (
+          <div className="grid gap-4 px-6 pb-6 sm:grid-cols-2">
+            {validatorIndices.map((vi) => (
+              <ExitQueuePositionCard key={vi} validatorIndex={vi} beaconNodeUrl={beaconNodeUrl} />
+            ))}
           </div>
         )}
       </section>

--- a/src/components/validators/ValidatorUnlockCard.tsx
+++ b/src/components/validators/ValidatorUnlockCard.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { formatEth } from '@/src/utils/balanceMath'
+import { useReconciliationHistory, MAX_HISTORY } from '@/src/hooks/useReconciliationHistory'
+
+function formatDate(ms: number | null): string {
+  if (ms === null) return '—'
+  return new Date(ms).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function formatDays(days: number | null): string {
+  if (days === null) return '—'
+  if (days >= 365) return `${(days / 365).toFixed(1)} yr`
+  return `${days.toFixed(1)} d`
+}
+
+/**
+ * Projected-unlock timeline for a single (capped) validator. Shows the excess
+ * over the cap, the trailing reward rate driving the estimate, and the ETA
+ * with its ±15% error bounds. Non-capped validators render a quiet placeholder.
+ */
+export function ValidatorUnlockCard({
+  validatorIndex,
+  beaconNodeUrl,
+}: {
+  validatorIndex: number
+  beaconNodeUrl?: string
+}) {
+  const { projection, records, isLoading } = useReconciliationHistory(validatorIndex, { beaconNodeUrl })
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-slate-900/70 p-5 text-white">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h4 className="font-mono text-sm font-semibold">Validator #{validatorIndex}</h4>
+          <p className="text-xs text-slate-500">
+            {records.length}/{MAX_HISTORY} records
+          </p>
+        </div>
+        <span
+          className={`rounded-full px-2.5 py-1 text-[10px] font-semibold ${
+            projection.capped ? 'bg-amber-500/15 text-amber-400' : 'bg-slate-700/40 text-slate-400'
+          }`}
+        >
+          {projection.capped ? 'CAPPED' : 'UNCAPPED'}
+        </span>
+      </div>
+
+      {isLoading && records.length === 0 ? (
+        <p className="py-4 text-center text-sm text-slate-400">Projecting…</p>
+      ) : !projection.capped ? (
+        <p className="py-4 text-sm text-slate-400">
+          Balance is at or below the effective-balance cap — no unlock projection.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <Stat label="Excess over cap" value={`${formatEth(projection.excessGwei)} ETH`} />
+            <Stat label="Avg reward / day" value={`${formatEth(projection.avgDailyRewardGwei, 6)} ETH`} />
+            <Stat label="Projected ETA" value={formatDays(projection.etaDays)} tone="text-sky-300" />
+            <Stat label="Unlock date" value={formatDate(projection.unlockDate)} tone="text-sky-300" />
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3 text-xs text-slate-400">
+            <p className="mb-1 font-medium text-slate-300">±15% error bounds</p>
+            <div className="flex items-center justify-between">
+              <span>{formatDate(projection.unlockDateLow)}</span>
+              <span className="text-slate-600">→</span>
+              <span>{formatDate(projection.unlockDateHigh)}</span>
+            </div>
+            <div className="mt-1 flex items-center justify-between text-slate-500">
+              <span>{formatDays(projection.etaDaysLow)}</span>
+              <span>{formatDays(projection.etaDaysHigh)}</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function Stat({ label, value, tone = 'text-slate-100' }: { label: string; value: string; tone?: string }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
+      <p className="text-[11px] uppercase tracking-wide text-slate-500">{label}</p>
+      <p className={`mt-1 font-semibold ${tone}`}>{value}</p>
+    </div>
+  )
+}

--- a/src/hooks/useBeaconRPC.ts
+++ b/src/hooks/useBeaconRPC.ts
@@ -1,0 +1,137 @@
+'use client'
+
+import { useMemo } from 'react'
+import type { ExitQueueReading, NetworkQueueSnapshot } from '@/src/types/exitQueue'
+import { currentEpoch, epochStartMs } from '@/src/utils/epochTime'
+
+// Network churn parameters (validator-count exit churn).
+const ACTIVE_VALIDATORS = 900_000
+const CHURN_LIMIT_QUOTIENT = 65_536
+const MIN_PER_EPOCH_CHURN_LIMIT = 4
+const SLASHING_DELAY_EPOCHS = 4
+
+function churnLimit(): number {
+  return Math.max(MIN_PER_EPOCH_CHURN_LIMIT, Math.floor(ACTIVE_VALIDATORS / CHURN_LIMIT_QUOTIENT))
+}
+
+function fnv01(input: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0) / 0x1_0000_0000
+}
+
+export interface BeaconRPC {
+  /** Exit-queue reading for one validator at a given epoch. */
+  getValidatorQueue: (validatorIndex: number, epoch: number) => Promise<ExitQueueReading>
+  /** Raw validator balances (gwei) by index. */
+  getValidatorBalances: (ids: number[]) => Promise<Record<number, bigint>>
+}
+
+/**
+ * Deterministic demo RPC. Models a mass-slashing event ~25 epochs before the
+ * service was created, after which the queue drains at the churn limit.
+ */
+function createDemoBeaconRPC(): BeaconRPC {
+  const churn = churnLimit()
+  const anchorEpoch = currentEpoch(Date.now())
+  const slashEpoch = anchorEpoch - 25
+  const baseline = 180
+  const spike = 12_000
+
+  const depthAt = (epoch: number): number => {
+    const noise = Math.floor(fnv01(`d:${epoch}`) * 40)
+    if (epoch < slashEpoch) return baseline + noise
+    const drained = churn * (epoch - slashEpoch)
+    return Math.max(baseline, baseline + spike - drained) + noise
+  }
+
+  return {
+    async getValidatorQueue(validatorIndex, epoch) {
+      const slashed = validatorIndex % 2 === 0
+      const entryEpoch = slashEpoch + (slashed ? SLASHING_DELAY_EPOCHS : 0)
+      const initialAhead = 800 + (validatorIndex % 4000)
+      const positionOffset =
+        epoch < entryEpoch
+          ? initialAhead
+          : Math.max(0, initialAhead - churn * (epoch - entryEpoch))
+
+      const network: NetworkQueueSnapshot = {
+        epoch,
+        timestamp: epochStartMs(epoch),
+        queueDepth: depthAt(epoch),
+        churnLimit: churn,
+        voluntaryExits: Math.floor(fnv01(`v:${epoch}`) * 4),
+        slashedExits: epoch === slashEpoch ? spike : Math.floor(fnv01(`s:${epoch}`) * 2),
+      }
+
+      return { network, position: { validatorIndex, epoch, positionOffset, slashed } }
+    },
+
+    async getValidatorBalances(ids) {
+      const out: Record<number, bigint> = {}
+      for (const id of ids) out[id] = BigInt(32) * BigInt(1_000_000_000)
+      return out
+    },
+  }
+}
+
+/** Beacon-API-backed RPC. */
+function createHttpBeaconRPC(baseUrl: string): BeaconRPC {
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, '')
+  const churn = churnLimit()
+
+  return {
+    async getValidatorQueue(validatorIndex, epoch) {
+      const response = await fetch(
+        `${normalizedBaseUrl}/eth/v1/beacon/states/head/validators/${validatorIndex}`,
+      )
+      if (!response.ok) throw new Error('Unable to fetch validator state')
+      const body = (await response.json()) as {
+        data?: { validator?: { exit_epoch?: string | number; slashed?: boolean } }
+      }
+      const exitEpoch = Number(body.data?.validator?.exit_epoch ?? epoch)
+      const slashed = Boolean(body.data?.validator?.slashed)
+      // Approximate position from the assigned exit epoch and churn limit.
+      const positionOffset = Math.max(0, (exitEpoch - epoch) * churn)
+
+      const network: NetworkQueueSnapshot = {
+        epoch,
+        timestamp: epochStartMs(epoch),
+        queueDepth: positionOffset,
+        churnLimit: churn,
+        voluntaryExits: 0,
+        slashedExits: 0,
+      }
+      return { network, position: { validatorIndex, epoch, positionOffset, slashed } }
+    },
+
+    async getValidatorBalances(ids) {
+      const query = ids.join(',')
+      const response = await fetch(
+        `${normalizedBaseUrl}/eth/v1/beacon/states/head/validator_balances?id=${query}`,
+      )
+      if (!response.ok) throw new Error('Unable to fetch validator balances')
+      const body = (await response.json()) as {
+        data?: Array<{ index?: string | number; balance?: string | number }>
+      }
+      const out: Record<number, bigint> = {}
+      for (const entry of body.data ?? []) {
+        if (entry.index !== undefined && entry.balance !== undefined) {
+          out[Number(entry.index)] = BigInt(entry.balance)
+        }
+      }
+      return out
+    },
+  }
+}
+
+/** Beacon JSON-RPC client hook (demo when no node URL is supplied). */
+export function useBeaconRPC(beaconNodeUrl?: string): BeaconRPC {
+  return useMemo(
+    () => (beaconNodeUrl ? createHttpBeaconRPC(beaconNodeUrl) : createDemoBeaconRPC()),
+    [beaconNodeUrl],
+  )
+}

--- a/src/hooks/useExitQueuePosition.ts
+++ b/src/hooks/useExitQueuePosition.ts
@@ -1,0 +1,130 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type {
+  ExitQueueProjection,
+  NetworkQueueSnapshot,
+  ValidatorQueuePosition,
+} from '@/src/types/exitQueue'
+import { useBeaconRPC } from '@/src/hooks/useBeaconRPC'
+import { useBeaconStore } from '@/src/store/beaconSlice'
+import { EPOCH_MS, currentEpoch, epochStartMs, msUntilNextEpoch } from '@/src/utils/epochTime'
+
+const SLASHING_DELAY_EPOCHS = 4
+/** Epochs of history to backfill on mount so the EWMA/trendline have data. */
+const SEED_EPOCHS = 40
+
+interface UseExitQueuePositionOptions {
+  beaconNodeUrl?: string
+}
+
+export interface ExitQueuePositionState {
+  projection: ExitQueueProjection | null
+  position: ValidatorQueuePosition | null
+  samples: NetworkQueueSnapshot[]
+  ewmaSeries: number[]
+  ewmaChurn: number
+  isLoading: boolean
+  error: string | null
+}
+
+/**
+ * Polls the validator exit queue at epoch boundaries, feeds the shared
+ * gap-interpolated / EWMA-smoothed history in the beacon store, and projects
+ * the validator's exit epoch + ETA from its position and the EWMA churn rate.
+ */
+export function useExitQueuePosition(
+  validatorIndex: number | null,
+  options: UseExitQueuePositionOptions = {},
+): ExitQueuePositionState {
+  const rpc = useBeaconRPC(options.beaconNodeUrl)
+  const ingest = useBeaconStore((s) => s.ingest)
+  const samples = useBeaconStore((s) => s.samples)
+  const ewmaSeries = useBeaconStore((s) => s.ewmaSeries)
+  const ewmaChurn = useBeaconStore((s) => s.ewmaChurn)
+  const latest = useBeaconStore((s) => s.latest)
+
+  const [position, setPosition] = useState<ValidatorQueuePosition | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Clear stale position when the tracked validator changes (during render).
+  const [tracked, setTracked] = useState<number | null | undefined>(undefined)
+  if (tracked !== validatorIndex) {
+    setTracked(validatorIndex)
+    setPosition(null)
+  }
+
+  useEffect(() => {
+    if (validatorIndex === null) return
+
+    let cancelled = false
+    let interval: number | undefined
+
+    const poll = async (epoch: number) => {
+      try {
+        const reading = await rpc.getValidatorQueue(validatorIndex, epoch)
+        if (cancelled) return
+        ingest(reading.network)
+        setPosition(reading.position)
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to read exit queue')
+      }
+    }
+
+    const run = async () => {
+      setIsLoading(true)
+      setError(null)
+      const cur = currentEpoch(Date.now())
+      for (let epoch = Math.max(0, cur - SEED_EPOCHS + 1); epoch <= cur; epoch++) {
+        if (cancelled) return
+        await poll(epoch)
+      }
+      if (!cancelled) setIsLoading(false)
+    }
+
+    run()
+
+    // Poll exactly on each epoch boundary thereafter (≈6.4 min) to bound RPC load.
+    const timeout = window.setTimeout(() => {
+      poll(currentEpoch(Date.now()))
+      interval = window.setInterval(() => poll(currentEpoch(Date.now())), EPOCH_MS)
+    }, msUntilNextEpoch(Date.now()))
+
+    return () => {
+      cancelled = true
+      window.clearTimeout(timeout)
+      if (interval !== undefined) window.clearInterval(interval)
+    }
+  }, [validatorIndex, rpc, ingest])
+
+  const projection = useMemo<ExitQueueProjection | null>(() => {
+    if (!position) return null
+
+    let epochsRemaining: number | null = null
+    let projectedExitEpoch: number | null = null
+    let projectedExitTimestamp: number | null = null
+
+    if (ewmaChurn > 0) {
+      epochsRemaining =
+        Math.ceil(position.positionOffset / ewmaChurn) +
+        (position.slashed ? SLASHING_DELAY_EPOCHS : 0)
+      projectedExitEpoch = position.epoch + epochsRemaining
+      projectedExitTimestamp = epochStartMs(projectedExitEpoch)
+    }
+
+    return {
+      currentEpoch: position.epoch,
+      positionOffset: position.positionOffset,
+      queueDepth: latest?.queueDepth ?? 0,
+      churnLimit: latest?.churnLimit ?? 0,
+      ewmaChurn,
+      slashed: position.slashed,
+      epochsRemaining,
+      projectedExitEpoch,
+      projectedExitTimestamp,
+    }
+  }, [position, latest, ewmaChurn])
+
+  return { projection, position, samples, ewmaSeries, ewmaChurn, isLoading, error }
+}

--- a/src/hooks/useReconciliationHistory.ts
+++ b/src/hooks/useReconciliationHistory.ts
@@ -1,0 +1,114 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type {
+  ReconciliationRecord,
+  ReconciliationSummary,
+  UnlockProjection,
+  ValidatorBalanceSample,
+} from '@/src/types/validator'
+import { reconcile, reconcileSeries, summarize } from '@/src/utils/balanceReconciliation'
+import { projectUnlock } from '@/src/utils/unlockProjection'
+import { createDemoStakingService, createStakingService } from '@/src/services/stakingService'
+
+/** Per-validator reconciliation history is capped at this many records (FIFO). */
+export const MAX_HISTORY = 1000
+
+interface UseReconciliationHistoryOptions {
+  beaconNodeUrl?: string
+  historyDepth?: number
+}
+
+export interface ReconciliationHistoryState {
+  records: ReconciliationRecord[]
+  summary: ReconciliationSummary
+  projection: UnlockProjection
+  isLoading: boolean
+  error: string | null
+  /** Append a fresh sample, reconciling it and evicting the oldest at the cap. */
+  ingest: (sample: ValidatorBalanceSample) => void
+}
+
+/**
+ * Maintains a single validator's reconciliation record history with FIFO
+ * eviction at MAX_HISTORY (1,000) entries, plus a live `ingest` for streaming
+ * new epoch samples. Exposes the aggregate summary and unlock projection.
+ */
+export function useReconciliationHistory(
+  validatorIndex: number | null,
+  options: UseReconciliationHistoryOptions = {},
+): ReconciliationHistoryState {
+  const { beaconNodeUrl, historyDepth = MAX_HISTORY } = options
+  const cap = Math.min(historyDepth, MAX_HISTORY)
+
+  const provider = useMemo(
+    () => (beaconNodeUrl ? createStakingService(beaconNodeUrl) : createDemoStakingService()),
+    [beaconNodeUrl],
+  )
+
+  const [records, setRecords] = useState<ReconciliationRecord[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const lastSampleRef = useRef<ValidatorBalanceSample | null>(null)
+
+  // Clear stale records when the validator changes (adjust state during render).
+  const [trackedValidator, setTrackedValidator] = useState<number | null | undefined>(undefined)
+  if (trackedValidator !== validatorIndex) {
+    setTrackedValidator(validatorIndex)
+    setRecords([])
+  }
+
+  useEffect(() => {
+    lastSampleRef.current = null
+    if (validatorIndex === null) return
+
+    let cancelled = false
+    const run = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const samples = await provider.fetchSamples(validatorIndex, cap)
+        if (cancelled) return
+        const windowed = samples.slice(-cap)
+        const recs = reconcileSeries(windowed)
+        lastSampleRef.current = windowed.length ? windowed[windowed.length - 1] : null
+        setRecords(recs.slice(-cap))
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load reconciliation history')
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [validatorIndex, provider, cap])
+
+  const ingest = useCallback(
+    (sample: ValidatorBalanceSample) => {
+      const record = reconcile(lastSampleRef.current, sample)
+      lastSampleRef.current = sample
+      setRecords((prev) => {
+        const next = [...prev, record]
+        while (next.length > cap) next.shift()
+        return next
+      })
+    },
+    [cap],
+  )
+
+  const summary = useMemo(
+    () => summarize(validatorIndex ?? -1, records),
+    [validatorIndex, records],
+  )
+  const projection = useMemo(
+    () => projectUnlock(validatorIndex ?? -1, records),
+    [validatorIndex, records],
+  )
+
+  return { records, summary, projection, isLoading, error, ingest }
+}

--- a/src/hooks/useValidatorBalances.ts
+++ b/src/hooks/useValidatorBalances.ts
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type {
+  ReconciliationRecord,
+  ReconciliationSummary,
+  UnlockProjection,
+} from '@/src/types/validator'
+import { reconcileSeries, summarize } from '@/src/utils/balanceReconciliation'
+import { projectUnlock } from '@/src/utils/unlockProjection'
+import { createDemoStakingService, createStakingService } from '@/src/services/stakingService'
+
+/** Default history depth fetched per validator (FIFO-capped downstream). */
+const DEFAULT_DEPTH = 1000
+
+interface UseValidatorBalancesOptions {
+  beaconNodeUrl?: string
+  historyDepth?: number
+}
+
+/** Reconciled balance view for a single validator. */
+export interface ValidatorReconciliation {
+  records: ReconciliationRecord[]
+  summary: ReconciliationSummary
+  projection: UnlockProjection
+}
+
+export interface ValidatorBalancesState {
+  byValidator: Record<number, ValidatorReconciliation>
+  validators: number[]
+  isLoading: boolean
+  error: string | null
+}
+
+/**
+ * Fetches balance samples for a set of validators and reconciles each into a
+ * summary + unlock projection. This is the overview data source for the
+ * reconciliation table; per-validator live history lives in
+ * useReconciliationHistory.
+ */
+export function useValidatorBalances(
+  validatorIndices: number[],
+  options: UseValidatorBalancesOptions = {},
+): ValidatorBalancesState {
+  const { beaconNodeUrl, historyDepth = DEFAULT_DEPTH } = options
+
+  const provider = useMemo(
+    () => (beaconNodeUrl ? createStakingService(beaconNodeUrl) : createDemoStakingService()),
+    [beaconNodeUrl],
+  )
+
+  const [byValidator, setByValidator] = useState<Record<number, ValidatorReconciliation>>({})
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Stable primitive dependency so the effect re-runs only on a real change.
+  const indicesKey = validatorIndices.join(',')
+
+  // Clear stale data when the validator set changes (adjust state during render).
+  const [trackedKey, setTrackedKey] = useState<string | undefined>(undefined)
+  if (trackedKey !== indicesKey) {
+    setTrackedKey(indicesKey)
+    setByValidator({})
+  }
+
+  useEffect(() => {
+    const indices = indicesKey ? indicesKey.split(',').map(Number) : []
+    if (indices.length === 0) return
+
+    let cancelled = false
+    const run = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const entries = await Promise.all(
+          indices.map(async (vi) => {
+            const samples = (await provider.fetchSamples(vi, historyDepth)).slice(-historyDepth)
+            const records = reconcileSeries(samples)
+            const entry: ValidatorReconciliation = {
+              records,
+              summary: summarize(vi, records),
+              projection: projectUnlock(vi, records),
+            }
+            return [vi, entry] as const
+          }),
+        )
+        if (cancelled) return
+        setByValidator(Object.fromEntries(entries))
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load validator balances')
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [indicesKey, provider, historyDepth])
+
+  const validators = useMemo(
+    () => (indicesKey ? indicesKey.split(',').map(Number) : []),
+    [indicesKey],
+  )
+
+  return { byValidator, validators, isLoading, error }
+}

--- a/src/services/stakingService.ts
+++ b/src/services/stakingService.ts
@@ -1,0 +1,123 @@
+// Staking service — source of validator balance samples for reconciliation.
+//
+// Provides a deterministic demo generator (forward-simulated rewards,
+// penalties, and partial-withdrawal sweeps) and a beacon-API-backed factory.
+// Amounts are bigint gwei.
+
+import type { ValidatorBalanceSample } from '@/src/types/validator'
+import { EFFECTIVE_BALANCE_CAP_GWEI, excessOverCap } from '@/src/utils/balanceMath'
+
+const SLOTS_PER_EPOCH = 32
+const SECONDS_PER_SLOT = 12
+const GENESIS_TIME = 1_606_824_023
+const EPOCH_SECONDS = SLOTS_PER_EPOCH * SECONDS_PER_SLOT
+const SWEEP_PERIOD_EPOCHS = 225 // ~daily partial-withdrawal sweep
+
+export type StakingProvider = {
+  fetchSamples(validatorIndex: number, count: number): Promise<ValidatorBalanceSample[]>
+}
+
+function fnv01(input: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0) / 0x1_0000_0000
+}
+
+function epochTimestampMs(epoch: number): number {
+  return (GENESIS_TIME + epoch * EPOCH_SECONDS) * 1000
+}
+
+function currentEpoch(nowMs: number): number {
+  return Math.max(0, Math.floor((nowMs / 1000 - GENESIS_TIME) / EPOCH_SECONDS))
+}
+
+/**
+ * Forward-simulate `count` epoch-boundary samples for a validator. Even
+ * indices start above the cap (so they show as capped with a sweep stream);
+ * odd indices hover just below it.
+ */
+export function generateDemoSamples(
+  validatorIndex: number,
+  count: number,
+  options: { endEpoch?: number; nowMs?: number } = {},
+): ValidatorBalanceSample[] {
+  const nowMs = options.nowMs ?? Date.now()
+  const endEpoch = options.endEpoch ?? currentEpoch(nowMs)
+  const startEpoch = Math.max(0, endEpoch - count + 1)
+
+  const capped = validatorIndex % 2 === 0
+  const initialExcess = capped
+    ? BigInt(Math.round((1.5 + fnv01(`excess:${validatorIndex}`) * 2) * 1e9)) // 1.5–3.5 ETH over cap
+    : BigInt(0) - BigInt(Math.round((0.2 + fnv01(`gap:${validatorIndex}`) * 0.4) * 1e9)) // 0.2–0.6 ETH under
+
+  let actual = EFFECTIVE_BALANCE_CAP_GWEI + initialExcess
+  const sweepPhase = Math.floor(fnv01(`phase:${validatorIndex}`) * SWEEP_PERIOD_EPOCHS)
+
+  const samples: ValidatorBalanceSample[] = new Array(endEpoch - startEpoch + 1)
+  for (let i = 0, epoch = startEpoch; epoch <= endEpoch; epoch++, i++) {
+    const reward = 11_000 + Math.floor(fnv01(`r:${validatorIndex}:${epoch}`) * 9_000) // gwei
+    const missed = fnv01(`m:${validatorIndex}:${epoch}`) < 0.04
+    const penalty = missed ? 2_000 + Math.floor(fnv01(`p:${validatorIndex}:${epoch}`) * 3_000) : 0
+    actual += BigInt(reward - penalty)
+
+    // Partial-withdrawal sweep: skim the excess above the cap on the sweep epoch.
+    let withdrawal = BigInt(0)
+    const excess = excessOverCap(actual)
+    if (excess > BigInt(0) && epoch % SWEEP_PERIOD_EPOCHS === sweepPhase) {
+      // Sweep most of the excess, leaving a little so the validator stays capped.
+      withdrawal = (excess * BigInt(85)) / BigInt(100)
+      actual -= withdrawal
+    }
+
+    samples[i] = {
+      validatorIndex,
+      epoch,
+      timestamp: epochTimestampMs(epoch),
+      actualBalanceGwei: actual,
+      withdrawalGwei: withdrawal,
+    }
+  }
+  return samples
+}
+
+export function createDemoStakingService(): StakingProvider {
+  return {
+    async fetchSamples(validatorIndex, count) {
+      return generateDemoSamples(validatorIndex, count)
+    },
+  }
+}
+
+/**
+ * Beacon-API-backed provider. Reads the current validator balance; full
+ * historical decomposition requires a per-epoch state/withdrawal scan, so this
+ * returns a single current sample (callers fall back to the demo stream for
+ * history when no node is configured).
+ */
+export function createStakingService(baseUrl: string): StakingProvider {
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, '')
+  return {
+    async fetchSamples(validatorIndex) {
+      const response = await fetch(
+        `${normalizedBaseUrl}/eth/v1/beacon/states/head/validator_balances?id=${validatorIndex}`,
+      )
+      if (!response.ok) throw new Error('Unable to fetch validator balances')
+      const body = (await response.json()) as { data?: Array<{ balance?: string | number }> }
+      const balance = body.data?.[0]?.balance
+      const actualBalanceGwei = balance === undefined ? EFFECTIVE_BALANCE_CAP_GWEI : BigInt(balance)
+      const epoch = currentEpoch(Date.now())
+      return [
+        {
+          validatorIndex,
+          epoch,
+          timestamp: epochTimestampMs(epoch),
+          actualBalanceGwei,
+          withdrawalGwei: BigInt(0),
+        },
+      ]
+    },
+  }
+}

--- a/src/store/beaconSlice.ts
+++ b/src/store/beaconSlice.ts
@@ -1,0 +1,66 @@
+import { create } from 'zustand'
+import type { NetworkQueueSnapshot } from '@/src/types/exitQueue'
+import { LRUQueueCache } from '@/src/utils/lruQueueCache'
+import { interpolateQueueHistory } from '@/src/utils/queueInterpolation'
+import { DEFAULT_ALPHA, DEFAULT_WINDOW, ewmaLatest, ewmaSeries } from '@/src/utils/ewma'
+
+/**
+ * Shared beacon exit-queue state. A single LRU-bounded history (≤500 entries)
+ * is fed by the polling hook; on each ingest the history is gap-interpolated
+ * and the per-epoch drain rate (min(depth, churn)) is EWMA-smoothed. Multiple
+ * validator cards read the same derived series rather than re-deriving it.
+ */
+interface BeaconState {
+  cache: LRUQueueCache
+  /** Dense, gap-interpolated history sorted by epoch. */
+  samples: NetworkQueueSnapshot[]
+  /** Realized drain rate per epoch (min(queueDepth, churnLimit)). */
+  churnSeries: number[]
+  /** EWMA of the churn series (full length, for charting). */
+  ewmaSeries: number[]
+  /** Latest EWMA churn over the trailing 32-epoch window. */
+  ewmaChurn: number
+  latest: NetworkQueueSnapshot | null
+  ingest: (snapshot: NetworkQueueSnapshot) => void
+  reset: () => void
+}
+
+function deriveChurn(samples: NetworkQueueSnapshot[]): number[] {
+  return samples.map((s) => Math.min(s.queueDepth, s.churnLimit))
+}
+
+export const useBeaconStore = create<BeaconState>((set, get) => ({
+  cache: new LRUQueueCache(),
+  samples: [],
+  churnSeries: [],
+  ewmaSeries: [],
+  ewmaChurn: 0,
+  latest: null,
+
+  ingest: (snapshot) => {
+    const { cache } = get()
+    cache.set(snapshot.epoch, snapshot)
+
+    const samples = interpolateQueueHistory(cache.values())
+    const churnSeries = deriveChurn(samples)
+    const latest = samples.length ? samples[samples.length - 1] : null
+
+    set({
+      samples,
+      churnSeries,
+      ewmaSeries: ewmaSeries(churnSeries, DEFAULT_ALPHA),
+      ewmaChurn: ewmaLatest(churnSeries, DEFAULT_ALPHA, DEFAULT_WINDOW),
+      latest,
+    })
+  },
+
+  reset: () =>
+    set({
+      cache: new LRUQueueCache(),
+      samples: [],
+      churnSeries: [],
+      ewmaSeries: [],
+      ewmaChurn: 0,
+      latest: null,
+    }),
+}))

--- a/src/types/exitQueue.ts
+++ b/src/types/exitQueue.ts
@@ -1,0 +1,54 @@
+// Validator exit-queue types.
+//
+// When validators request to exit (voluntarily or via slashing) they join a
+// network-wide exit queue drained at the per-epoch churn limit. These types
+// model both the network-level queue snapshot and a specific validator's
+// position within it, plus the projected exit estimate.
+
+/** Network-wide exit-queue state at one epoch boundary. */
+export interface NetworkQueueSnapshot {
+  epoch: number
+  /** Unix-ms timestamp of the epoch boundary. */
+  timestamp: number
+  /** Total validators waiting in the exit queue. */
+  queueDepth: number
+  /** Validators that can leave the queue per epoch (activation/exit churn). */
+  churnLimit: number
+  /** New voluntary exits observed this epoch. */
+  voluntaryExits: number
+  /** New slashed exits this epoch (enter the queue after a 4-epoch delay). */
+  slashedExits: number
+  /** True when this snapshot was synthesized by gap interpolation. */
+  interpolated?: boolean
+}
+
+/** A specific validator's position within the exit queue at an epoch. */
+export interface ValidatorQueuePosition {
+  validatorIndex: number
+  epoch: number
+  /** Validators ahead of this one in the queue. */
+  positionOffset: number
+  /** Slashed exits incur a 4-epoch delay before entering the queue. */
+  slashed: boolean
+}
+
+/** Combined reading returned by the beacon RPC for one validator + epoch. */
+export interface ExitQueueReading {
+  network: NetworkQueueSnapshot
+  position: ValidatorQueuePosition
+}
+
+/** Projected exit estimate derived from position + EWMA churn rate. */
+export interface ExitQueueProjection {
+  currentEpoch: number | null
+  positionOffset: number
+  queueDepth: number
+  churnLimit: number
+  /** EWMA-smoothed drain rate (validators/epoch). */
+  ewmaChurn: number
+  slashed: boolean
+  /** Epochs until exit (includes the 4-epoch slashing delay when applicable). */
+  epochsRemaining: number | null
+  projectedExitEpoch: number | null
+  projectedExitTimestamp: number | null
+}

--- a/src/types/validator.ts
+++ b/src/types/validator.ts
@@ -1,0 +1,74 @@
+// Validator balance & reconciliation type definitions.
+//
+// All on-chain amounts are held as bigint gwei to avoid float drift; display
+// formatting to ETH happens at the edge (see utils/balanceMath).
+
+/**
+ * A raw balance observation for a validator at an epoch boundary. Effective
+ * balance updates only at epoch boundaries, so one sample per epoch suffices.
+ * `withdrawalGwei` is the amount swept out this epoch (0 when none).
+ */
+export interface ValidatorBalanceSample {
+  validatorIndex: number
+  epoch: number
+  /** Unix-ms timestamp of the epoch boundary. */
+  timestamp: number
+  /** Actual on-chain balance in gwei. */
+  actualBalanceGwei: bigint
+  /** Amount partial-withdrawn (swept) this epoch, in gwei. */
+  withdrawalGwei: bigint
+}
+
+/**
+ * The decomposition of one epoch's balance change relative to the previous
+ * sample. The net actual-balance delta is split into its consensus-layer
+ * reward, penalty, and withdrawal-credit components:
+ *
+ *   gross_delta   = actual_n - actual_{n-1} + withdrawal_n
+ *   rewards       = max(0, gross_delta)
+ *   penalties     = max(0, -gross_delta)
+ *   withdrawal    = withdrawal_n
+ */
+export interface ReconciliationRecord {
+  validatorIndex: number
+  epoch: number
+  timestamp: number
+  actualBalanceGwei: bigint
+  effectiveBalanceGwei: bigint
+  /** actual_n - actual_{n-1} (negative if balance fell). */
+  netDeltaGwei: bigint
+  rewardsGwei: bigint
+  penaltiesGwei: bigint
+  withdrawalCreditsGwei: bigint
+  /** True when actual balance exceeds the effective-balance cap. */
+  capped: boolean
+}
+
+/** Aggregate reconciliation summary for a validator over its tracked history. */
+export interface ReconciliationSummary {
+  validatorIndex: number
+  latest: ReconciliationRecord | null
+  totalRewardsGwei: bigint
+  totalPenaltiesGwei: bigint
+  totalWithdrawalsGwei: bigint
+  recordCount: number
+}
+
+/** Projected unlock estimate for a capped validator. */
+export interface UnlockProjection {
+  validatorIndex: number
+  /** Whether the validator is currently capped (excess above the cap). */
+  capped: boolean
+  excessGwei: bigint
+  /** Trailing-average reward rate in gwei/day used for the projection. */
+  avgDailyRewardGwei: bigint
+  /** Central ETA in days; null when not capped or no positive reward rate. */
+  etaDays: number | null
+  /** ±15% error bounds around `etaDays`. */
+  etaDaysLow: number | null
+  etaDaysHigh: number | null
+  /** Projected unlock timestamps (unix-ms); null when not projectable. */
+  unlockDate: number | null
+  unlockDateLow: number | null
+  unlockDateHigh: number | null
+}

--- a/src/utils/balanceMath.ts
+++ b/src/utils/balanceMath.ts
@@ -1,0 +1,58 @@
+// Shared validator balance math.
+//
+// Amounts are bigint gwei. The target compiles to ES2017, so bigint *literals*
+// (e.g. `32n`) are unavailable — all constants use the BigInt() constructor.
+
+export const GWEI_PER_ETH = BigInt(1_000_000_000)
+
+/**
+ * Effective-balance cap. Per the reconciliation invariants this is 32 ETH
+ * (effective_balance = min(actual_balance, 32 ETH)). Post-Electra (EIP-7251)
+ * raised the max effective balance to 2048 ETH for 0x02 validators — change
+ * this single constant to model that regime.
+ */
+export const EFFECTIVE_BALANCE_CAP_GWEI = BigInt(32) * GWEI_PER_ETH
+
+/** Epochs per day at 6.4-minute epochs (32 slots × 12 s). */
+export const EPOCHS_PER_DAY = 225
+
+export function maxBigInt(a: bigint, b: bigint): bigint {
+  return a > b ? a : b
+}
+
+export function minBigInt(a: bigint, b: bigint): bigint {
+  return a < b ? a : b
+}
+
+const ZERO = BigInt(0)
+
+/** Effective balance = min(actual, cap). */
+export function effectiveBalance(actualGwei: bigint, cap = EFFECTIVE_BALANCE_CAP_GWEI): bigint {
+  return minBigInt(actualGwei, cap)
+}
+
+/** Excess of actual balance over the cap, floored at 0. */
+export function excessOverCap(actualGwei: bigint, cap = EFFECTIVE_BALANCE_CAP_GWEI): bigint {
+  return maxBigInt(ZERO, actualGwei - cap)
+}
+
+/** Whether the validator's actual balance exceeds the cap. */
+export function isCapped(actualGwei: bigint, cap = EFFECTIVE_BALANCE_CAP_GWEI): boolean {
+  return actualGwei > cap
+}
+
+/** Convert gwei to a floating-point ETH value (display only). */
+export function gweiToEth(gwei: bigint): number {
+  return Number(gwei) / Number(GWEI_PER_ETH)
+}
+
+/** Format a gwei amount as an ETH string with `decimals` places (sign-aware). */
+export function formatEth(gwei: bigint, decimals = 4): string {
+  const negative = gwei < ZERO
+  const abs = negative ? -gwei : gwei
+  const whole = abs / GWEI_PER_ETH
+  const frac = abs % GWEI_PER_ETH
+  const fracStr = frac.toString().padStart(9, '0').slice(0, decimals)
+  const sign = negative ? '-' : ''
+  return decimals > 0 ? `${sign}${whole.toString()}.${fracStr}` : `${sign}${whole.toString()}`
+}

--- a/src/utils/balanceReconciliation.ts
+++ b/src/utils/balanceReconciliation.ts
@@ -1,0 +1,119 @@
+// Effective-balance reconciliation engine.
+//
+// The displayed effective balance drifts from the actual balance because
+// effective balance is capped (min(actual, cap)) and updates only at epoch
+// boundaries, while actual balance moves every epoch from rewards, penalties,
+// and partial-withdrawal sweeps. This engine decomposes each epoch's actual-
+// balance delta into those three components.
+//
+// Decomposition (vs the previous sample):
+//   net_delta   = actual_n - actual_{n-1}
+//   gross_delta = net_delta + withdrawal_n   (add back what was swept out)
+//   rewards     = max(0, gross_delta)        consensus-layer income
+//   penalties   = max(0, -gross_delta)       missed-duty / slashing losses
+//   withdrawal  = withdrawal_n               partial-withdrawal credit
+
+import type {
+  ReconciliationRecord,
+  ReconciliationSummary,
+  ValidatorBalanceSample,
+} from '@/src/types/validator'
+import { EFFECTIVE_BALANCE_CAP_GWEI, effectiveBalance, isCapped } from '@/src/utils/balanceMath'
+
+const ZERO = BigInt(0)
+
+/**
+ * Reconcile a single sample against the previous one. With no previous sample
+ * the record is a baseline (no decomposed delta beyond the current withdrawal).
+ */
+export function reconcile(
+  prev: ValidatorBalanceSample | null,
+  current: ValidatorBalanceSample,
+  cap = EFFECTIVE_BALANCE_CAP_GWEI,
+): ReconciliationRecord {
+  const effective = effectiveBalance(current.actualBalanceGwei, cap)
+  const capped = isCapped(current.actualBalanceGwei, cap)
+
+  if (!prev) {
+    return {
+      validatorIndex: current.validatorIndex,
+      epoch: current.epoch,
+      timestamp: current.timestamp,
+      actualBalanceGwei: current.actualBalanceGwei,
+      effectiveBalanceGwei: effective,
+      netDeltaGwei: ZERO,
+      rewardsGwei: ZERO,
+      penaltiesGwei: ZERO,
+      withdrawalCreditsGwei: current.withdrawalGwei,
+      capped,
+    }
+  }
+
+  const netDelta = current.actualBalanceGwei - prev.actualBalanceGwei
+  const grossDelta = netDelta + current.withdrawalGwei
+  const rewards = grossDelta > ZERO ? grossDelta : ZERO
+  const penalties = grossDelta < ZERO ? -grossDelta : ZERO
+
+  return {
+    validatorIndex: current.validatorIndex,
+    epoch: current.epoch,
+    timestamp: current.timestamp,
+    actualBalanceGwei: current.actualBalanceGwei,
+    effectiveBalanceGwei: effective,
+    netDeltaGwei: netDelta,
+    rewardsGwei: rewards,
+    penaltiesGwei: penalties,
+    withdrawalCreditsGwei: current.withdrawalGwei,
+    capped,
+  }
+}
+
+/**
+ * Reconcile an ordered series of samples into per-epoch records. Input is
+ * sorted ascending by epoch defensively; duplicate epochs keep the last.
+ */
+export function reconcileSeries(
+  samples: ValidatorBalanceSample[],
+  cap = EFFECTIVE_BALANCE_CAP_GWEI,
+): ReconciliationRecord[] {
+  if (samples.length === 0) return []
+
+  const sorted = [...samples].sort((a, b) => a.epoch - b.epoch)
+  const deduped: ValidatorBalanceSample[] = []
+  for (const sample of sorted) {
+    const last = deduped[deduped.length - 1]
+    if (last && last.epoch === sample.epoch) deduped[deduped.length - 1] = sample
+    else deduped.push(sample)
+  }
+
+  const records: ReconciliationRecord[] = new Array(deduped.length)
+  let prev: ValidatorBalanceSample | null = null
+  for (let i = 0; i < deduped.length; i++) {
+    records[i] = reconcile(prev, deduped[i], cap)
+    prev = deduped[i]
+  }
+  return records
+}
+
+/** Aggregate a set of records into a per-validator summary. */
+export function summarize(
+  validatorIndex: number,
+  records: ReconciliationRecord[],
+): ReconciliationSummary {
+  let totalRewards = ZERO
+  let totalPenalties = ZERO
+  let totalWithdrawals = ZERO
+  for (const r of records) {
+    totalRewards += r.rewardsGwei
+    totalPenalties += r.penaltiesGwei
+    totalWithdrawals += r.withdrawalCreditsGwei
+  }
+  return {
+    validatorIndex,
+    latest: records.length ? records[records.length - 1] : null,
+    totalRewardsGwei: totalRewards,
+    totalPenaltiesGwei: totalPenalties,
+    totalWithdrawalsGwei: totalWithdrawals,
+    recordCount: records.length,
+  }
+}

--- a/src/utils/epochTime.ts
+++ b/src/utils/epochTime.ts
@@ -1,0 +1,35 @@
+// Epoch boundary timing utilities.
+//
+// Beacon epochs are 32 slots × 12 s = 384 s (~6.4 min). Exit-queue polling is
+// aligned to epoch boundaries to avoid hammering the beacon node.
+
+export const SLOTS_PER_EPOCH = 32
+export const SECONDS_PER_SLOT = 12
+export const GENESIS_TIME = 1_606_824_023 // mainnet, unix seconds
+export const EPOCH_SECONDS = SLOTS_PER_EPOCH * SECONDS_PER_SLOT
+export const EPOCH_MS = EPOCH_SECONDS * 1000
+
+/** Epoch containing the given wall-clock time. */
+export function currentEpoch(nowMs: number): number {
+  return Math.max(0, Math.floor((nowMs / 1000 - GENESIS_TIME) / EPOCH_SECONDS))
+}
+
+/** Unix-ms timestamp of an epoch's first slot. */
+export function epochStartMs(epoch: number): number {
+  return (GENESIS_TIME + epoch * EPOCH_SECONDS) * 1000
+}
+
+/** Wall-clock time of the next epoch boundary after `nowMs`. */
+export function nextEpochBoundaryMs(nowMs: number): number {
+  return epochStartMs(currentEpoch(nowMs) + 1)
+}
+
+/** Milliseconds remaining until the next epoch boundary (>= 0). */
+export function msUntilNextEpoch(nowMs: number): number {
+  return Math.max(0, nextEpochBoundaryMs(nowMs) - nowMs)
+}
+
+/** Convert a number of epochs to milliseconds. */
+export function epochsToMs(epochs: number): number {
+  return epochs * EPOCH_MS
+}

--- a/src/utils/ewma.ts
+++ b/src/utils/ewma.ts
@@ -1,0 +1,36 @@
+// Exponentially Weighted Moving Average.
+//
+//   e[0] = x[0]
+//   e[i] = α·x[i] + (1 − α)·e[i−1]
+//
+// Exit-ETA projections use α = 0.3 over a sliding window of the last 32 epoch
+// samples, so recent churn dominates while older epochs still damp noise.
+
+export const DEFAULT_ALPHA = 0.3
+export const DEFAULT_WINDOW = 32
+
+/** Full EWMA series for `values` (same length as input). */
+export function ewmaSeries(values: number[], alpha = DEFAULT_ALPHA): number[] {
+  if (values.length === 0) return []
+  const out = new Array<number>(values.length)
+  out[0] = values[0]
+  for (let i = 1; i < values.length; i++) {
+    out[i] = alpha * values[i] + (1 - alpha) * out[i - 1]
+  }
+  return out
+}
+
+/**
+ * Latest EWMA value over the trailing `window` samples. Returns 0 for empty
+ * input.
+ */
+export function ewmaLatest(
+  values: number[],
+  alpha = DEFAULT_ALPHA,
+  window = DEFAULT_WINDOW,
+): number {
+  if (values.length === 0) return 0
+  const windowed = values.slice(-window)
+  const series = ewmaSeries(windowed, alpha)
+  return series[series.length - 1]
+}

--- a/src/utils/lruQueueCache.ts
+++ b/src/utils/lruQueueCache.ts
@@ -1,0 +1,51 @@
+// LRU cache for exit-queue history, capped at 500 entries.
+//
+// Keyed by epoch. Backed by a Map (insertion-ordered): touching an entry moves
+// it to the most-recent end, and inserts past the cap evict the least-recently
+// used key. `values()` returns entries sorted by epoch for time-series use.
+
+import type { NetworkQueueSnapshot } from '@/src/types/exitQueue'
+
+export const DEFAULT_MAX_ENTRIES = 500
+
+export class LRUQueueCache {
+  private readonly map = new Map<number, NetworkQueueSnapshot>()
+
+  constructor(private readonly maxEntries: number = DEFAULT_MAX_ENTRIES) {}
+
+  get size(): number {
+    return this.map.size
+  }
+
+  has(epoch: number): boolean {
+    return this.map.has(epoch)
+  }
+
+  get(epoch: number): NetworkQueueSnapshot | undefined {
+    const entry = this.map.get(epoch)
+    if (entry === undefined) return undefined
+    // Refresh recency.
+    this.map.delete(epoch)
+    this.map.set(epoch, entry)
+    return entry
+  }
+
+  set(epoch: number, snapshot: NetworkQueueSnapshot): void {
+    if (this.map.has(epoch)) this.map.delete(epoch)
+    this.map.set(epoch, snapshot)
+    while (this.map.size > this.maxEntries) {
+      const oldest = this.map.keys().next().value
+      if (oldest === undefined) break
+      this.map.delete(oldest)
+    }
+  }
+
+  /** Snapshots sorted ascending by epoch. */
+  values(): NetworkQueueSnapshot[] {
+    return [...this.map.values()].sort((a, b) => a.epoch - b.epoch)
+  }
+
+  clear(): void {
+    this.map.clear()
+  }
+}

--- a/src/utils/queueInterpolation.ts
+++ b/src/utils/queueInterpolation.ts
@@ -1,0 +1,55 @@
+// Gap interpolation for exit-queue history.
+//
+// Epoch polls can be missed (RPC hiccups, tab backgrounding). Rather than
+// leave holes that distort the EWMA, we linearly interpolate the queue depth
+// and churn limit across missing epochs between two observed samples. Synthetic
+// entries are flagged `interpolated` and carry zero new-exit counts.
+
+import type { NetworkQueueSnapshot } from '@/src/types/exitQueue'
+import { epochStartMs } from '@/src/utils/epochTime'
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t
+}
+
+/**
+ * Return a dense, epoch-contiguous history from possibly-sparse samples.
+ * Input need not be sorted; duplicate epochs keep the last observation.
+ */
+export function interpolateQueueHistory(samples: NetworkQueueSnapshot[]): NetworkQueueSnapshot[] {
+  if (samples.length === 0) return []
+
+  const sorted = [...samples].sort((a, b) => a.epoch - b.epoch)
+  const deduped: NetworkQueueSnapshot[] = []
+  for (const s of sorted) {
+    const last = deduped[deduped.length - 1]
+    if (last && last.epoch === s.epoch) deduped[deduped.length - 1] = s
+    else deduped.push(s)
+  }
+
+  const dense: NetworkQueueSnapshot[] = []
+  for (let i = 0; i < deduped.length; i++) {
+    const current = deduped[i]
+    dense.push(current)
+
+    const next = deduped[i + 1]
+    if (!next) break
+    const gap = next.epoch - current.epoch
+    if (gap <= 1) continue
+
+    for (let epoch = current.epoch + 1; epoch < next.epoch; epoch++) {
+      const t = (epoch - current.epoch) / gap
+      dense.push({
+        epoch,
+        timestamp: epochStartMs(epoch),
+        queueDepth: Math.round(lerp(current.queueDepth, next.queueDepth, t)),
+        churnLimit: Math.round(lerp(current.churnLimit, next.churnLimit, t)),
+        voluntaryExits: 0,
+        slashedExits: 0,
+        interpolated: true,
+      })
+    }
+  }
+
+  return dense
+}

--- a/src/utils/unlockProjection.ts
+++ b/src/utils/unlockProjection.ts
@@ -1,0 +1,99 @@
+// Projected-unlock calculator for capped validators.
+//
+// When a validator's actual balance exceeds the effective-balance cap, the
+// excess is swept out gradually by partial withdrawals. The projection
+// estimates how long the excess represents in reward-equivalent time, per the
+// invariant:
+//
+//   eta_days = (actual_balance - cap) / avg_daily_reward_rate   ± 15%
+//
+// The reward rate is a 7-day trailing average of decomposed consensus rewards.
+
+import type { ReconciliationRecord, UnlockProjection } from '@/src/types/validator'
+import { EFFECTIVE_BALANCE_CAP_GWEI, excessOverCap, isCapped } from '@/src/utils/balanceMath'
+
+const ZERO = BigInt(0)
+const DAY_MS = 24 * 60 * 60 * 1000
+const TRAILING_DAYS = 7
+const ERROR_BOUND = 0.15
+
+function emptyProjection(validatorIndex: number, excess: bigint, avgDaily: bigint): UnlockProjection {
+  return {
+    validatorIndex,
+    capped: excess > ZERO,
+    excessGwei: excess,
+    avgDailyRewardGwei: avgDaily,
+    etaDays: null,
+    etaDaysLow: null,
+    etaDaysHigh: null,
+    unlockDate: null,
+    unlockDateLow: null,
+    unlockDateHigh: null,
+  }
+}
+
+/**
+ * Average daily reward (gwei/day) over the trailing 7 days of records, scaled
+ * by the actual span covered so short histories still yield a sane rate.
+ */
+export function trailingDailyReward(
+  records: ReconciliationRecord[],
+  trailingDays = TRAILING_DAYS,
+): bigint {
+  if (records.length === 0) return ZERO
+  const dataNow = records[records.length - 1].timestamp
+  const windowStart = dataNow - trailingDays * DAY_MS
+
+  let sumRewards = ZERO
+  let earliest = dataNow
+  for (const r of records) {
+    if (r.timestamp > windowStart) {
+      sumRewards += r.rewardsGwei
+      if (r.timestamp < earliest) earliest = r.timestamp
+    }
+  }
+  if (sumRewards <= ZERO) return ZERO
+
+  const spanDays = Math.min(trailingDays, Math.max(1, (dataNow - earliest) / DAY_MS))
+  return BigInt(Math.round(Number(sumRewards) / spanDays))
+}
+
+/**
+ * Project the unlock ETA for a validator from its reconciliation records.
+ * Returns excess + reward rate always; ETA/dates are null when the validator
+ * is not capped or has no positive trailing reward rate.
+ */
+export function projectUnlock(
+  validatorIndex: number,
+  records: ReconciliationRecord[],
+  options: { now?: number; cap?: bigint } = {},
+): UnlockProjection {
+  const { now = Date.now(), cap = EFFECTIVE_BALANCE_CAP_GWEI } = options
+
+  if (records.length === 0) return emptyProjection(validatorIndex, ZERO, ZERO)
+
+  const actual = records[records.length - 1].actualBalanceGwei
+  const excess = excessOverCap(actual, cap)
+  const avgDaily = trailingDailyReward(records)
+
+  if (!isCapped(actual, cap) || avgDaily <= ZERO) {
+    return emptyProjection(validatorIndex, excess, avgDaily)
+  }
+
+  const etaDays = Number(excess) / Number(avgDaily)
+  const etaDaysLow = etaDays * (1 - ERROR_BOUND)
+  const etaDaysHigh = etaDays * (1 + ERROR_BOUND)
+
+  return {
+    validatorIndex,
+    capped: true,
+    excessGwei: excess,
+    avgDailyRewardGwei: avgDaily,
+    etaDays,
+    etaDaysLow,
+    etaDaysHigh,
+    unlockDate: now + etaDays * DAY_MS,
+    unlockDateLow: now + etaDaysLow * DAY_MS,
+    unlockDateHigh: now + etaDaysHigh * DAY_MS,
+  }
+}


### PR DESCRIPTION
Closes #43 

A real-time view of each validator's exit-queue position with an EWMA-based exit-ETA projection. It polls beacon exit-queue data at epoch boundaries, maintains a bounded local history (gap-interpolated), and projects the exit epoch + live ETA from the validator's position and the smoothed churn rate.