### PR TITLE
Feat/committee topology map

### DIFF
--- a/app/validators/dashboard/page.tsx
+++ b/app/validators/dashboard/page.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { ValidatorDashboard } from '@/src/components/validators/ValidatorDashboard'
+
+function DashboardRoute() {
+  const params = useSearchParams()
+  const rawValidators = params.get('validators')
+  const validatorIndices = rawValidators
+    ? rawValidators
+        .split(',')
+        .map((v) => Number(v.trim()))
+        .filter((n) => Number.isFinite(n) && n >= 0)
+    : undefined
+  const beaconNodeUrl = params.get('beacon') ?? undefined
+
+  return (
+    <main className="mx-auto min-h-screen max-w-5xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold text-white">Validator Dashboard</h1>
+      <ValidatorDashboard
+        validatorIndices={validatorIndices && validatorIndices.length > 0 ? validatorIndices : undefined}
+        beaconNodeUrl={beaconNodeUrl}
+      />
+    </main>
+  )
+}
+
+export default function ValidatorDashboardPage() {
+  return (
+    <div className="min-h-screen bg-slate-950">
+      <Suspense fallback={<div className="p-8 text-slate-400">Loading…</div>}>
+        <DashboardRoute />
+      </Suspense>
+    </div>
+  )
+}

--- a/src/components/canvas/CommitteeTopologyMap.tsx
+++ b/src/components/canvas/CommitteeTopologyMap.tsx
@@ -1,0 +1,394 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  SHARD_COUNT,
+  type CommitteeLayout,
+  type CommitteeLayoutResponse,
+  type EpochAssignments,
+  type NodePosition,
+} from '@/src/types/committee'
+import { shardColor, shardColorAlpha } from '@/src/utils/shardColorMapping'
+
+const DISPLAY_HEIGHT = 380
+const GRID_COLS = 8
+const GRID_ROWS = 8
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5))
+
+type View =
+  | { tier: 'cluster' }
+  | { tier: 'shard'; shard: number }
+  | { tier: 'detail'; validatorIndex: number }
+
+interface Hover {
+  node: NodePosition
+  px: number
+  py: number
+}
+
+function createWorker(): Worker | null {
+  try {
+    return new Worker(new URL('../../workers/committeeLayoutWorker.ts', import.meta.url))
+  } catch {
+    return null
+  }
+}
+
+/** Main-thread layout fallback mirroring the worker (used when no Worker). */
+function computeLayoutFallback(
+  epoch: number,
+  width: number,
+  height: number,
+  assignments: Array<{ validatorIndex: number; shard: number }>,
+): CommitteeLayout {
+  const cellW = width / GRID_COLS
+  const cellH = height / GRID_ROWS
+  const counts = new Array<number>(SHARD_COUNT).fill(0)
+  for (const a of assignments) if (a.shard >= 0 && a.shard < SHARD_COUNT) counts[a.shard]++
+
+  const centroids = Array.from({ length: SHARD_COUNT }, (_, s) => ({
+    shard: s,
+    x: (s % GRID_COLS) * cellW + cellW / 2,
+    y: Math.floor(s / GRID_COLS) * cellH + cellH / 2,
+    count: counts[s],
+  }))
+
+  const baseRadius = Math.min(cellW, cellH) * 0.12
+  const perShardIndex = new Array<number>(SHARD_COUNT).fill(0)
+  const nodes: NodePosition[] = assignments.map((a) => {
+    const centroid = centroids[a.shard] ?? { x: width / 2, y: height / 2 }
+    const i = a.shard >= 0 && a.shard < SHARD_COUNT ? perShardIndex[a.shard]++ : 0
+    const radius = baseRadius * Math.sqrt(i + 1)
+    const theta = i * GOLDEN_ANGLE
+    return {
+      validatorIndex: a.validatorIndex,
+      shard: a.shard,
+      x: centroid.x + radius * Math.cos(theta),
+      y: centroid.y + radius * Math.sin(theta),
+    }
+  })
+  return { epoch, width, height, nodes, centroids }
+}
+
+/**
+ * Interactive shard-assignment topology map with three zoom tiers:
+ *   cluster → all 64 shards   shard → one shard's validators   detail → one
+ * validator's shard timeline. Layout is computed off-thread (worker) and the
+ * cluster tier is cached to an offscreen canvas for smooth hover at scale.
+ */
+export function CommitteeTopologyMap({
+  current,
+  getValidatorTimeline,
+}: {
+  current: EpochAssignments | null
+  getValidatorTimeline: (validatorIndex: number) => Array<{ epoch: number; shard: number }>
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const offscreenRef = useRef<HTMLCanvasElement | null>(null)
+  const workerRef = useRef<Worker | null>(null)
+  const requestIdRef = useRef(0)
+  const pendingRef = useRef<string | null>(null)
+
+  const [size, setSize] = useState({ w: 0, h: DISPLAY_HEIGHT })
+  const [layout, setLayout] = useState<CommitteeLayout | null>(null)
+  const [view, setView] = useState<View>({ tier: 'cluster' })
+  const [hover, setHover] = useState<Hover | null>(null)
+
+  const assignmentKey = useMemo(
+    () => (current ? `${current.epoch}:${current.assignments.length}` : ''),
+    [current],
+  )
+
+  // Worker lifecycle.
+  useEffect(() => {
+    const worker = createWorker()
+    workerRef.current = worker
+    const handler = (e: MessageEvent<CommitteeLayoutResponse>) => {
+      const msg = e.data
+      if (msg.payload.requestId !== pendingRef.current) return
+      if (msg.type === 'LAYOUT') setLayout(msg.payload.layout)
+    }
+    worker?.addEventListener('message', handler)
+    return () => {
+      worker?.removeEventListener('message', handler)
+      worker?.terminate()
+    }
+  }, [])
+
+  // Track container width.
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const update = () => setSize({ w: el.clientWidth, h: DISPLAY_HEIGHT })
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  // Compute layout (worker, or main-thread fallback) when data/size change.
+  useEffect(() => {
+    if (!current || size.w === 0) return
+    const payload = current.assignments.map((a) => ({ validatorIndex: a.validatorIndex, shard: a.shard }))
+    const worker = workerRef.current
+    if (worker) {
+      const requestId = `layout-${++requestIdRef.current}`
+      pendingRef.current = requestId
+      worker.postMessage({
+        type: 'LAYOUT',
+        payload: { requestId, epoch: current.epoch, width: size.w, height: size.h, assignments: payload },
+      })
+      return
+    }
+
+    // No worker: compute on the main thread, deferred so the state update lands
+    // in a callback rather than synchronously in the effect body.
+    const raf = requestAnimationFrame(() =>
+      setLayout(computeLayoutFallback(current.epoch, size.w, size.h, payload)),
+    )
+    return () => cancelAnimationFrame(raf)
+  }, [assignmentKey, current, size])
+
+  // Render the cluster tier to an offscreen canvas (cached; redrawn on change).
+  useEffect(() => {
+    if (size.w === 0 || !layout || view.tier !== 'cluster') return
+    const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
+    let offscreen = offscreenRef.current
+    if (!offscreen) {
+      offscreen = document.createElement('canvas')
+      offscreenRef.current = offscreen
+    }
+    offscreen.width = Math.round(size.w * dpr)
+    offscreen.height = Math.round(size.h * dpr)
+    const ctx = offscreen.getContext('2d')
+    if (!ctx) return
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.clearRect(0, 0, size.w, size.h)
+
+    const cellW = size.w / GRID_COLS
+    const cellH = size.h / GRID_ROWS
+    // Shard cells.
+    for (const centroid of layout.centroids) {
+      const col = centroid.shard % GRID_COLS
+      const row = Math.floor(centroid.shard / GRID_COLS)
+      const x = col * cellW
+      const y = row * cellH
+      ctx.fillStyle = centroid.count > 0 ? shardColorAlpha(centroid.shard, 0.08) : 'rgba(148,163,184,0.04)'
+      ctx.fillRect(x + 1, y + 1, cellW - 2, cellH - 2)
+      ctx.fillStyle = 'rgba(148,163,184,0.5)'
+      ctx.font = '9px ui-sans-serif, system-ui, sans-serif'
+      ctx.textAlign = 'left'
+      ctx.textBaseline = 'top'
+      ctx.fillText(`S${centroid.shard}`, x + 4, y + 4)
+    }
+    // Nodes.
+    for (const node of layout.nodes) {
+      ctx.beginPath()
+      ctx.arc(node.x, node.y, 4, 0, Math.PI * 2)
+      ctx.fillStyle = shardColor(node.shard)
+      ctx.fill()
+    }
+  }, [layout, size, view])
+
+  const paint = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas || size.w === 0) return
+    const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
+    canvas.width = Math.round(size.w * dpr)
+    canvas.height = Math.round(size.h * dpr)
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.clearRect(0, 0, size.w, size.h)
+
+    if (view.tier === 'cluster') {
+      const offscreen = offscreenRef.current
+      if (offscreen) ctx.drawImage(offscreen, 0, 0, size.w, size.h)
+      if (hover) {
+        ctx.beginPath()
+        ctx.arc(hover.node.x, hover.node.y, 7, 0, Math.PI * 2)
+        ctx.strokeStyle = '#f8fafc'
+        ctx.lineWidth = 2
+        ctx.stroke()
+      }
+      return
+    }
+
+    if (view.tier === 'shard' && layout) {
+      const shardNodes = layout.nodes.filter((n) => n.shard === view.shard)
+      const cx = size.w / 2
+      const cy = size.h / 2
+      const baseR = Math.min(size.w, size.h) * 0.06
+      ctx.fillStyle = shardColorAlpha(view.shard, 0.1)
+      ctx.fillRect(0, 0, size.w, size.h)
+      shardNodes.forEach((node, i) => {
+        const r = baseR * Math.sqrt(i + 1)
+        const theta = i * GOLDEN_ANGLE
+        const x = cx + r * Math.cos(theta)
+        const y = cy + r * Math.sin(theta)
+        ctx.beginPath()
+        ctx.arc(x, y, 9, 0, Math.PI * 2)
+        ctx.fillStyle = shardColor(view.shard)
+        ctx.fill()
+        ctx.fillStyle = '#0f172a'
+        ctx.font = '8px ui-sans-serif, system-ui, sans-serif'
+        ctx.textAlign = 'center'
+        ctx.textBaseline = 'middle'
+        ctx.fillText(String(node.validatorIndex), x, y)
+      })
+      return
+    }
+
+    if (view.tier === 'detail') {
+      const timeline = getValidatorTimeline(view.validatorIndex)
+      if (timeline.length === 0) return
+      const padX = 32
+      const usableW = size.w - padX * 2
+      const trackY = size.h / 2
+      ctx.strokeStyle = 'rgba(148,163,184,0.25)'
+      ctx.beginPath()
+      ctx.moveTo(padX, trackY)
+      ctx.lineTo(size.w - padX, trackY)
+      ctx.stroke()
+      timeline.forEach((point, i) => {
+        const x = padX + (timeline.length === 1 ? usableW / 2 : (i / (timeline.length - 1)) * usableW)
+        // y position varies with shard so shard changes are visible.
+        const y = trackY + ((point.shard / SHARD_COUNT) * 2 - 1) * (size.h * 0.32)
+        ctx.beginPath()
+        ctx.arc(x, y, 5, 0, Math.PI * 2)
+        ctx.fillStyle = shardColor(point.shard)
+        ctx.fill()
+      })
+    }
+  }, [view, layout, hover, size, getValidatorTimeline])
+
+  useEffect(() => {
+    paint()
+  }, [paint])
+
+  const nodeAt = useCallback(
+    (px: number, py: number): NodePosition | null => {
+      if (!layout) return null
+      let best: NodePosition | null = null
+      let bestDist = 8 * 8
+      for (const node of layout.nodes) {
+        const dx = node.x - px
+        const dy = node.y - py
+        const d = dx * dx + dy * dy
+        if (d < bestDist) {
+          bestDist = d
+          best = node
+        }
+      }
+      return best
+    },
+    [layout],
+  )
+
+  const onMouseMove = useCallback(
+    (event: React.MouseEvent<HTMLCanvasElement>) => {
+      if (view.tier !== 'cluster') {
+        setHover(null)
+        return
+      }
+      const rect = event.currentTarget.getBoundingClientRect()
+      const px = event.clientX - rect.left
+      const py = event.clientY - rect.top
+      const node = nodeAt(px, py)
+      setHover(node ? { node, px, py } : null)
+    },
+    [view, nodeAt],
+  )
+
+  const onClick = useCallback(
+    (event: React.MouseEvent<HTMLCanvasElement>) => {
+      const rect = event.currentTarget.getBoundingClientRect()
+      const px = event.clientX - rect.left
+      const py = event.clientY - rect.top
+
+      if (view.tier === 'cluster') {
+        const node = nodeAt(px, py)
+        if (node) {
+          setView({ tier: 'detail', validatorIndex: node.validatorIndex })
+          setHover(null)
+          return
+        }
+        const col = Math.floor(px / (size.w / GRID_COLS))
+        const row = Math.floor(py / (size.h / GRID_ROWS))
+        const shard = row * GRID_COLS + col
+        if (shard >= 0 && shard < SHARD_COUNT) setView({ tier: 'shard', shard })
+        return
+      }
+      if (view.tier === 'shard' && layout) {
+        // Click a validator dot to drill into its timeline.
+        const cx = size.w / 2
+        const cy = size.h / 2
+        const baseR = Math.min(size.w, size.h) * 0.06
+        const shardNodes = layout.nodes.filter((n) => n.shard === view.shard)
+        for (let i = 0; i < shardNodes.length; i++) {
+          const r = baseR * Math.sqrt(i + 1)
+          const theta = i * GOLDEN_ANGLE
+          const x = cx + r * Math.cos(theta)
+          const y = cy + r * Math.sin(theta)
+          if ((x - px) ** 2 + (y - py) ** 2 < 11 * 11) {
+            setView({ tier: 'detail', validatorIndex: shardNodes[i].validatorIndex })
+            return
+          }
+        }
+      }
+    },
+    [view, nodeAt, layout, size],
+  )
+
+  const breadcrumb =
+    view.tier === 'cluster'
+      ? 'All shards'
+      : view.tier === 'shard'
+        ? `Shard ${view.shard}`
+        : `Validator #${view.validatorIndex}`
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-xs text-slate-400">
+        <span>
+          {breadcrumb}
+          {current ? ` · epoch ${current.epoch} · ${current.assignments.length} validators` : ''}
+        </span>
+        {view.tier !== 'cluster' && (
+          <button
+            type="button"
+            onClick={() => setView({ tier: 'cluster' })}
+            className="rounded-md border border-white/10 px-2 py-1 font-medium text-slate-200 hover:bg-white/5"
+          >
+            ← Back to all shards
+          </button>
+        )}
+      </div>
+
+      <div ref={containerRef} className="relative w-full" style={{ height: DISPLAY_HEIGHT }}>
+        <canvas
+          ref={canvasRef}
+          onMouseMove={onMouseMove}
+          onMouseLeave={() => setHover(null)}
+          onClick={onClick}
+          className="h-full w-full cursor-pointer rounded-xl bg-slate-950/60"
+          style={{ width: '100%', height: DISPLAY_HEIGHT }}
+        />
+        {hover && (
+          <div
+            className="pointer-events-none absolute z-10 rounded-md border border-white/10 bg-slate-950/95 px-2.5 py-1.5 text-xs text-slate-100 shadow-lg"
+            style={{ left: Math.min(hover.px + 12, size.w - 140), top: Math.min(hover.py + 12, size.h - 48) }}
+          >
+            <div className="font-semibold">Validator #{hover.node.validatorIndex}</div>
+            <div className="text-slate-400">Shard {hover.node.shard}</div>
+          </div>
+        )}
+      </div>
+
+      <p className="text-[11px] text-slate-500">
+        Click a shard cell to zoom in · click a validator to see its shard timeline
+      </p>
+    </div>
+  )
+}

--- a/src/components/charts/EWMATrendline.tsx
+++ b/src/components/charts/EWMATrendline.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useMemo } from 'react'
+
+const VIEW_W = 300
+
+/**
+ * Lightweight SVG sparkline: the raw series (faint) with its EWMA overlay
+ * (bold). Shared min/max scaling keeps the two lines comparable. Adapted for
+ * exit-queue churn/depth trends.
+ */
+export function EWMATrendline({
+  values,
+  ewma,
+  height = 64,
+  color = '#38bdf8',
+  label,
+}: {
+  values: number[]
+  ewma?: number[]
+  height?: number
+  color?: string
+  label?: string
+}) {
+  const { rawPoints, ewmaPoints } = useMemo(() => {
+    if (values.length < 2) return { rawPoints: '', ewmaPoints: '' }
+
+    const all = ewma && ewma.length ? values.concat(ewma) : values
+    const min = Math.min(...all)
+    const max = Math.max(...all)
+    const span = max - min || 1
+
+    const toPoints = (series: number[]): string => {
+      const n = series.length
+      if (n < 2) return ''
+      return series
+        .map((v, i) => {
+          const x = (i / (n - 1)) * VIEW_W
+          const y = height - ((v - min) / span) * height
+          return `${x.toFixed(2)},${y.toFixed(2)}`
+        })
+        .join(' ')
+    }
+
+    return { rawPoints: toPoints(values), ewmaPoints: ewma ? toPoints(ewma) : '' }
+  }, [values, ewma, height])
+
+  return (
+    <div className="space-y-1">
+      {label && <p className="text-[11px] uppercase tracking-wide text-slate-500">{label}</p>}
+      <svg
+        viewBox={`0 0 ${VIEW_W} ${height}`}
+        preserveAspectRatio="none"
+        className="h-16 w-full rounded-lg bg-slate-950/60"
+        role="img"
+        aria-label={label ?? 'trend'}
+      >
+        {rawPoints ? (
+          <>
+            <polyline
+              points={rawPoints}
+              fill="none"
+              stroke={color}
+              strokeOpacity={0.3}
+              strokeWidth={1}
+              vectorEffect="non-scaling-stroke"
+            />
+            {ewmaPoints && (
+              <polyline
+                points={ewmaPoints}
+                fill="none"
+                stroke={color}
+                strokeWidth={2}
+                strokeLinejoin="round"
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
+          </>
+        ) : (
+          <line
+            x1={0}
+            y1={height / 2}
+            x2={VIEW_W}
+            y2={height / 2}
+            stroke="#334155"
+            strokeDasharray="4 4"
+            vectorEffect="non-scaling-stroke"
+          />
+        )}
+      </svg>
+    </div>
+  )
+}

--- a/src/components/validators/BalanceReconciliationTable.tsx
+++ b/src/components/validators/BalanceReconciliationTable.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useMemo } from 'react'
+import { formatEth } from '@/src/utils/balanceMath'
+import {
+  useValidatorBalances,
+  type ValidatorReconciliation,
+} from '@/src/hooks/useValidatorBalances'
+
+const ZERO = BigInt(0)
+
+/** Stacked proportion bar of rewards / penalties / withdrawals for a validator. */
+function DeltaBar({ entry }: { entry: ValidatorReconciliation }) {
+  const { totalRewardsGwei, totalPenaltiesGwei, totalWithdrawalsGwei } = entry.summary
+  const total = totalRewardsGwei + totalPenaltiesGwei + totalWithdrawalsGwei
+  const pct = (v: bigint) => (total > ZERO ? (Number(v) / Number(total)) * 100 : 0)
+
+  return (
+    <div className="flex h-2 w-28 overflow-hidden rounded-full bg-slate-800" title="rewards / penalties / withdrawals">
+      <span style={{ width: `${pct(totalRewardsGwei)}%` }} className="bg-emerald-500" />
+      <span style={{ width: `${pct(totalPenaltiesGwei)}%` }} className="bg-red-500" />
+      <span style={{ width: `${pct(totalWithdrawalsGwei)}%` }} className="bg-sky-500" />
+    </div>
+  )
+}
+
+/**
+ * Per-validator effective-vs-actual balance breakdown. Each row shows the
+ * actual and effective balance, capped status, and the decomposed
+ * reward/penalty/withdrawal totals with a proportion bar.
+ */
+export function BalanceReconciliationTable({
+  validatorIndices,
+  beaconNodeUrl,
+}: {
+  validatorIndices: number[]
+  beaconNodeUrl?: string
+}) {
+  const { byValidator, validators, isLoading, error } = useValidatorBalances(validatorIndices, {
+    beaconNodeUrl,
+  })
+
+  const rows = useMemo(
+    () => validators.map((vi) => ({ vi, entry: byValidator[vi] })).filter((r) => r.entry),
+    [validators, byValidator],
+  )
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-950/40">
+      {error && <p className="px-4 py-3 text-sm text-red-400">{error}</p>}
+      {isLoading && rows.length === 0 ? (
+        <p className="px-4 py-8 text-center text-sm text-slate-400">Reconciling balances…</p>
+      ) : rows.length === 0 ? (
+        <p className="px-4 py-8 text-center text-sm text-slate-400">No validators to reconcile.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[680px] text-left text-sm">
+            <thead className="text-xs uppercase tracking-wide text-slate-500">
+              <tr className="border-b border-white/10">
+                <th className="px-4 py-3 font-medium">Validator</th>
+                <th className="px-4 py-3 font-medium">Actual</th>
+                <th className="px-4 py-3 font-medium">Effective</th>
+                <th className="px-4 py-3 font-medium">Rewards</th>
+                <th className="px-4 py-3 font-medium">Penalties</th>
+                <th className="px-4 py-3 font-medium">Withdrawals</th>
+                <th className="px-4 py-3 font-medium">Mix</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(({ vi, entry }) => {
+                const s = entry.summary
+                const latest = s.latest
+                return (
+                  <tr key={vi} className="border-b border-white/5 text-slate-200">
+                    <td className="px-4 py-3 font-mono">
+                      #{vi}
+                      {latest?.capped && (
+                        <span className="ml-2 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold text-amber-400">
+                          CAPPED
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums">
+                      {latest ? formatEth(latest.actualBalanceGwei) : '—'}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-slate-400">
+                      {latest ? formatEth(latest.effectiveBalanceGwei) : '—'}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-emerald-400">
+                      +{formatEth(s.totalRewardsGwei)}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-red-400">
+                      -{formatEth(s.totalPenaltiesGwei)}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-sky-400">
+                      {formatEth(s.totalWithdrawalsGwei)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <DeltaBar entry={entry} />
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/validators/ExitQueuePositionCard.tsx
+++ b/src/components/validators/ExitQueuePositionCard.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { EWMATrendline } from '@/src/components/charts/EWMATrendline'
+import { useExitQueuePosition } from '@/src/hooks/useExitQueuePosition'
+
+function formatEta(ms: number | null): string {
+  if (ms === null) return '—'
+  if (ms <= 0) return 'imminent'
+  const minutes = ms / 60_000
+  if (minutes < 60) return `${Math.round(minutes)} min`
+  const hours = minutes / 60
+  if (hours < 48) return `${hours.toFixed(1)} h`
+  return `${(hours / 24).toFixed(1)} d`
+}
+
+function formatDate(ms: number | null): string {
+  if (ms === null) return '—'
+  return new Date(ms).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+/**
+ * Exit-queue position card for one validator: current position offset, total
+ * queue depth, EWMA churn rate, and the projected exit epoch / ETA, with depth
+ * and churn trendlines. Surfaces the 4-epoch slashing delay when applicable.
+ */
+export function ExitQueuePositionCard({
+  validatorIndex,
+  beaconNodeUrl,
+}: {
+  validatorIndex: number
+  beaconNodeUrl?: string
+}) {
+  const { projection, samples, ewmaSeries, isLoading, error } = useExitQueuePosition(validatorIndex, {
+    beaconNodeUrl,
+  })
+
+  // Live clock for the ETA countdown (kept out of render to stay pure).
+  const [now, setNow] = useState(0)
+  useEffect(() => {
+    const tick = () => setNow(Date.now())
+    tick()
+    const id = window.setInterval(tick, 1000)
+    return () => window.clearInterval(id)
+  }, [])
+
+  const depthSeries = useMemo(() => samples.map((s) => s.queueDepth), [samples])
+  const churnSeries = useMemo(
+    () => samples.map((s) => Math.min(s.queueDepth, s.churnLimit)),
+    [samples],
+  )
+
+  const etaMs =
+    now > 0 && projection?.projectedExitTimestamp !== null && projection?.projectedExitTimestamp !== undefined
+      ? projection.projectedExitTimestamp - now
+      : null
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-slate-900/70 p-5 text-white">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h4 className="font-mono text-sm font-semibold">Validator #{validatorIndex}</h4>
+          <p className="text-xs text-slate-500">Exit queue position</p>
+        </div>
+        {projection?.slashed && (
+          <span className="rounded-full bg-red-500/15 px-2.5 py-1 text-[10px] font-semibold text-red-400">
+            SLASHED · +4 EPOCH DELAY
+          </span>
+        )}
+      </div>
+
+      {error && <p className="mb-3 text-sm text-red-400">{error}</p>}
+
+      {isLoading && samples.length === 0 ? (
+        <p className="py-6 text-center text-sm text-slate-400">Reading exit queue…</p>
+      ) : !projection ? (
+        <p className="py-6 text-center text-sm text-slate-400">No queue data.</p>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <Stat label="Position" value={projection.positionOffset.toLocaleString()} tone="text-sky-300" />
+            <Stat label="Queue depth" value={projection.queueDepth.toLocaleString()} />
+            <Stat label="Churn (EWMA)" value={`${projection.ewmaChurn.toFixed(1)}/epoch`} />
+            <Stat
+              label="Exit epoch"
+              value={projection.projectedExitEpoch?.toLocaleString() ?? '—'}
+              tone="text-sky-300"
+            />
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-slate-400">Projected exit</span>
+              <span className="font-semibold">{formatDate(projection.projectedExitTimestamp)}</span>
+            </div>
+            <div className="mt-1 flex items-center justify-between text-xs text-slate-500">
+              <span>
+                ETA {formatEta(etaMs)}
+                {projection.epochsRemaining !== null && ` · ${projection.epochsRemaining.toLocaleString()} epochs`}
+              </span>
+            </div>
+          </div>
+
+          <EWMATrendline values={depthSeries} label="Queue depth" color="#f59e0b" />
+          <EWMATrendline values={churnSeries} ewma={ewmaSeries} label="Churn rate · EWMA α=0.3" />
+        </div>
+      )}
+    </section>
+  )
+}
+
+function Stat({ label, value, tone = 'text-slate-100' }: { label: string; value: string; tone?: string }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
+      <p className="text-[11px] uppercase tracking-wide text-slate-500">{label}</p>
+      <p className={`mt-1 font-semibold ${tone}`}>{value}</p>
+    </div>
+  )
+}

--- a/src/components/validators/ShardLegend.tsx
+++ b/src/components/validators/ShardLegend.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { CONCENTRATION_THRESHOLD, type ConcentrationResult } from '@/src/types/committee'
+import { shardColor } from '@/src/utils/shardColorMapping'
+
+/**
+ * Legend mapping shard index → color for the shards an operator currently
+ * occupies, with per-shard share and a concentration-risk highlight on any
+ * shard exceeding the threshold.
+ */
+export function ShardLegend({ concentration }: { concentration: ConcentrationResult }) {
+  if (concentration.total === 0) {
+    return <p className="text-sm text-slate-400">No shard assignments for this epoch.</p>
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-xs uppercase tracking-wide text-slate-500">
+          Shard distribution ({concentration.perShard.length} shards)
+        </p>
+        {concentration.atRisk ? (
+          <span className="rounded-full bg-red-500/15 px-2.5 py-1 text-[10px] font-semibold text-red-400">
+            ⚠ CONCENTRATION RISK · {(concentration.maxShare * 100).toFixed(0)}% on shard{' '}
+            {concentration.topShard}
+          </span>
+        ) : (
+          <span className="rounded-full bg-emerald-500/15 px-2.5 py-1 text-[10px] font-semibold text-emerald-400">
+            WELL DISTRIBUTED · max {(concentration.maxShare * 100).toFixed(0)}%
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+        {concentration.perShard.map(({ shard, count, share }) => {
+          const risky = share > CONCENTRATION_THRESHOLD
+          return (
+            <div
+              key={shard}
+              className={`flex items-center gap-2 rounded-lg border px-2.5 py-1.5 text-xs ${
+                risky ? 'border-red-500/40 bg-red-500/5' : 'border-white/10 bg-slate-950/40'
+              }`}
+            >
+              <span
+                className="inline-block h-3 w-3 shrink-0 rounded-sm"
+                style={{ backgroundColor: shardColor(shard) }}
+              />
+              <span className="font-mono text-slate-200">S{shard}</span>
+              <span className="ml-auto text-slate-400">
+                {count} · {(share * 100).toFixed(0)}%
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/validators/ValidatorDashboard.tsx
+++ b/src/components/validators/ValidatorDashboard.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { BalanceReconciliationTable } from '@/src/components/validators/BalanceReconciliationTable'
+import { ValidatorUnlockCard } from '@/src/components/validators/ValidatorUnlockCard'
+import { useValidatorBalances } from '@/src/hooks/useValidatorBalances'
+
+const DEFAULT_VALIDATORS = [100, 101, 102, 103, 104, 105]
+
+/**
+ * Validator dashboard. Hosts the "Balance Reconciliation" accordion: a
+ * per-validator effective-vs-actual breakdown table, plus projected-unlock
+ * cards for any validators currently over the effective-balance cap.
+ */
+export function ValidatorDashboard({
+  validatorIndices = DEFAULT_VALIDATORS,
+  beaconNodeUrl,
+}: {
+  validatorIndices?: number[]
+  beaconNodeUrl?: string
+}) {
+  const [open, setOpen] = useState(true)
+  const { byValidator } = useValidatorBalances(validatorIndices, { beaconNodeUrl })
+
+  const cappedValidators = useMemo(
+    () => validatorIndices.filter((vi) => byValidator[vi]?.summary.latest?.capped),
+    [validatorIndices, byValidator],
+  )
+
+  return (
+    <div className="space-y-6">
+      <section className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 text-white">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="flex w-full items-center justify-between gap-4 p-6 text-left"
+          aria-expanded={open}
+        >
+          <div>
+            <h2 className="text-xl font-semibold">Balance Reconciliation</h2>
+            <p className="text-sm text-slate-400">
+              Effective vs actual balance · {validatorIndices.length} validators
+              {cappedValidators.length > 0 && ` · ${cappedValidators.length} capped`}
+            </p>
+          </div>
+          <span className="flex h-8 w-8 items-center justify-center rounded-full border border-white/10 text-lg text-slate-300">
+            {open ? '−' : '+'}
+          </span>
+        </button>
+
+        {open && (
+          <div className="space-y-6 px-6 pb-6">
+            <BalanceReconciliationTable validatorIndices={validatorIndices} beaconNodeUrl={beaconNodeUrl} />
+
+            {cappedValidators.length > 0 && (
+              <div className="space-y-3">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                  Projected unlocks
+                </h3>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {cappedValidators.map((vi) => (
+                    <ValidatorUnlockCard key={vi} validatorIndex={vi} beaconNodeUrl={beaconNodeUrl} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/components/validators/ValidatorDashboard.tsx
+++ b/src/components/validators/ValidatorDashboard.tsx
@@ -4,7 +4,10 @@ import { useMemo, useState } from 'react'
 import { BalanceReconciliationTable } from '@/src/components/validators/BalanceReconciliationTable'
 import { ValidatorUnlockCard } from '@/src/components/validators/ValidatorUnlockCard'
 import { ExitQueuePositionCard } from '@/src/components/validators/ExitQueuePositionCard'
+import { CommitteeTopologyMap } from '@/src/components/canvas/CommitteeTopologyMap'
+import { ShardLegend } from '@/src/components/validators/ShardLegend'
 import { useValidatorBalances } from '@/src/hooks/useValidatorBalances'
+import { useCommitteeAssignments } from '@/src/hooks/useCommitteeAssignments'
 
 const DEFAULT_VALIDATORS = [100, 101, 102, 103, 104, 105]
 
@@ -22,7 +25,9 @@ export function ValidatorDashboard({
 }) {
   const [open, setOpen] = useState(true)
   const [queueOpen, setQueueOpen] = useState(true)
+  const [topoOpen, setTopoOpen] = useState(true)
   const { byValidator } = useValidatorBalances(validatorIndices, { beaconNodeUrl })
+  const committee = useCommitteeAssignments(validatorIndices, { beaconNodeUrl })
 
   const cappedValidators = useMemo(
     () => validatorIndices.filter((vi) => byValidator[vi]?.summary.latest?.capped),
@@ -93,6 +98,36 @@ export function ValidatorDashboard({
             {validatorIndices.map((vi) => (
               <ExitQueuePositionCard key={vi} validatorIndex={vi} beaconNodeUrl={beaconNodeUrl} />
             ))}
+          </div>
+        )}
+      </section>
+
+      <section className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 text-white">
+        <button
+          type="button"
+          onClick={() => setTopoOpen((o) => !o)}
+          className="flex w-full items-center justify-between gap-4 p-6 text-left"
+          aria-expanded={topoOpen}
+        >
+          <div>
+            <h2 className="text-xl font-semibold">Shard Committee Topology</h2>
+            <p className="text-sm text-slate-400">
+              Per-epoch shard assignments · {validatorIndices.length} validators
+              {committee.concentration.atRisk && ' · ⚠ concentration risk'}
+            </p>
+          </div>
+          <span className="flex h-8 w-8 items-center justify-center rounded-full border border-white/10 text-lg text-slate-300">
+            {topoOpen ? '−' : '+'}
+          </span>
+        </button>
+
+        {topoOpen && (
+          <div className="space-y-5 px-6 pb-6">
+            <CommitteeTopologyMap
+              current={committee.current}
+              getValidatorTimeline={committee.getValidatorTimeline}
+            />
+            <ShardLegend concentration={committee.concentration} />
           </div>
         )}
       </section>

--- a/src/components/validators/ValidatorDashboard.tsx
+++ b/src/components/validators/ValidatorDashboard.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react'
 import { BalanceReconciliationTable } from '@/src/components/validators/BalanceReconciliationTable'
 import { ValidatorUnlockCard } from '@/src/components/validators/ValidatorUnlockCard'
+import { ExitQueuePositionCard } from '@/src/components/validators/ExitQueuePositionCard'
 import { useValidatorBalances } from '@/src/hooks/useValidatorBalances'
 
 const DEFAULT_VALIDATORS = [100, 101, 102, 103, 104, 105]
@@ -20,6 +21,7 @@ export function ValidatorDashboard({
   beaconNodeUrl?: string
 }) {
   const [open, setOpen] = useState(true)
+  const [queueOpen, setQueueOpen] = useState(true)
   const { byValidator } = useValidatorBalances(validatorIndices, { beaconNodeUrl })
 
   const cappedValidators = useMemo(
@@ -64,6 +66,33 @@ export function ValidatorDashboard({
                 </div>
               </div>
             )}
+          </div>
+        )}
+      </section>
+
+      <section className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 text-white">
+        <button
+          type="button"
+          onClick={() => setQueueOpen((o) => !o)}
+          className="flex w-full items-center justify-between gap-4 p-6 text-left"
+          aria-expanded={queueOpen}
+        >
+          <div>
+            <h2 className="text-xl font-semibold">Exit Queue</h2>
+            <p className="text-sm text-slate-400">
+              Queue position &amp; projected exit ETA · {validatorIndices.length} validators
+            </p>
+          </div>
+          <span className="flex h-8 w-8 items-center justify-center rounded-full border border-white/10 text-lg text-slate-300">
+            {queueOpen ? '−' : '+'}
+          </span>
+        </button>
+
+        {queueOpen && (
+          <div className="grid gap-4 px-6 pb-6 sm:grid-cols-2">
+            {validatorIndices.map((vi) => (
+              <ExitQueuePositionCard key={vi} validatorIndex={vi} beaconNodeUrl={beaconNodeUrl} />
+            ))}
           </div>
         )}
       </section>

--- a/src/components/validators/ValidatorUnlockCard.tsx
+++ b/src/components/validators/ValidatorUnlockCard.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { formatEth } from '@/src/utils/balanceMath'
+import { useReconciliationHistory, MAX_HISTORY } from '@/src/hooks/useReconciliationHistory'
+
+function formatDate(ms: number | null): string {
+  if (ms === null) return '—'
+  return new Date(ms).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function formatDays(days: number | null): string {
+  if (days === null) return '—'
+  if (days >= 365) return `${(days / 365).toFixed(1)} yr`
+  return `${days.toFixed(1)} d`
+}
+
+/**
+ * Projected-unlock timeline for a single (capped) validator. Shows the excess
+ * over the cap, the trailing reward rate driving the estimate, and the ETA
+ * with its ±15% error bounds. Non-capped validators render a quiet placeholder.
+ */
+export function ValidatorUnlockCard({
+  validatorIndex,
+  beaconNodeUrl,
+}: {
+  validatorIndex: number
+  beaconNodeUrl?: string
+}) {
+  const { projection, records, isLoading } = useReconciliationHistory(validatorIndex, { beaconNodeUrl })
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-slate-900/70 p-5 text-white">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h4 className="font-mono text-sm font-semibold">Validator #{validatorIndex}</h4>
+          <p className="text-xs text-slate-500">
+            {records.length}/{MAX_HISTORY} records
+          </p>
+        </div>
+        <span
+          className={`rounded-full px-2.5 py-1 text-[10px] font-semibold ${
+            projection.capped ? 'bg-amber-500/15 text-amber-400' : 'bg-slate-700/40 text-slate-400'
+          }`}
+        >
+          {projection.capped ? 'CAPPED' : 'UNCAPPED'}
+        </span>
+      </div>
+
+      {isLoading && records.length === 0 ? (
+        <p className="py-4 text-center text-sm text-slate-400">Projecting…</p>
+      ) : !projection.capped ? (
+        <p className="py-4 text-sm text-slate-400">
+          Balance is at or below the effective-balance cap — no unlock projection.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <Stat label="Excess over cap" value={`${formatEth(projection.excessGwei)} ETH`} />
+            <Stat label="Avg reward / day" value={`${formatEth(projection.avgDailyRewardGwei, 6)} ETH`} />
+            <Stat label="Projected ETA" value={formatDays(projection.etaDays)} tone="text-sky-300" />
+            <Stat label="Unlock date" value={formatDate(projection.unlockDate)} tone="text-sky-300" />
+          </div>
+
+          <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3 text-xs text-slate-400">
+            <p className="mb-1 font-medium text-slate-300">±15% error bounds</p>
+            <div className="flex items-center justify-between">
+              <span>{formatDate(projection.unlockDateLow)}</span>
+              <span className="text-slate-600">→</span>
+              <span>{formatDate(projection.unlockDateHigh)}</span>
+            </div>
+            <div className="mt-1 flex items-center justify-between text-slate-500">
+              <span>{formatDays(projection.etaDaysLow)}</span>
+              <span>{formatDays(projection.etaDaysHigh)}</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function Stat({ label, value, tone = 'text-slate-100' }: { label: string; value: string; tone?: string }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
+      <p className="text-[11px] uppercase tracking-wide text-slate-500">{label}</p>
+      <p className={`mt-1 font-semibold ${tone}`}>{value}</p>
+    </div>
+  )
+}

--- a/src/hooks/useBeaconRPC.ts
+++ b/src/hooks/useBeaconRPC.ts
@@ -1,0 +1,137 @@
+'use client'
+
+import { useMemo } from 'react'
+import type { ExitQueueReading, NetworkQueueSnapshot } from '@/src/types/exitQueue'
+import { currentEpoch, epochStartMs } from '@/src/utils/epochTime'
+
+// Network churn parameters (validator-count exit churn).
+const ACTIVE_VALIDATORS = 900_000
+const CHURN_LIMIT_QUOTIENT = 65_536
+const MIN_PER_EPOCH_CHURN_LIMIT = 4
+const SLASHING_DELAY_EPOCHS = 4
+
+function churnLimit(): number {
+  return Math.max(MIN_PER_EPOCH_CHURN_LIMIT, Math.floor(ACTIVE_VALIDATORS / CHURN_LIMIT_QUOTIENT))
+}
+
+function fnv01(input: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0) / 0x1_0000_0000
+}
+
+export interface BeaconRPC {
+  /** Exit-queue reading for one validator at a given epoch. */
+  getValidatorQueue: (validatorIndex: number, epoch: number) => Promise<ExitQueueReading>
+  /** Raw validator balances (gwei) by index. */
+  getValidatorBalances: (ids: number[]) => Promise<Record<number, bigint>>
+}
+
+/**
+ * Deterministic demo RPC. Models a mass-slashing event ~25 epochs before the
+ * service was created, after which the queue drains at the churn limit.
+ */
+function createDemoBeaconRPC(): BeaconRPC {
+  const churn = churnLimit()
+  const anchorEpoch = currentEpoch(Date.now())
+  const slashEpoch = anchorEpoch - 25
+  const baseline = 180
+  const spike = 12_000
+
+  const depthAt = (epoch: number): number => {
+    const noise = Math.floor(fnv01(`d:${epoch}`) * 40)
+    if (epoch < slashEpoch) return baseline + noise
+    const drained = churn * (epoch - slashEpoch)
+    return Math.max(baseline, baseline + spike - drained) + noise
+  }
+
+  return {
+    async getValidatorQueue(validatorIndex, epoch) {
+      const slashed = validatorIndex % 2 === 0
+      const entryEpoch = slashEpoch + (slashed ? SLASHING_DELAY_EPOCHS : 0)
+      const initialAhead = 800 + (validatorIndex % 4000)
+      const positionOffset =
+        epoch < entryEpoch
+          ? initialAhead
+          : Math.max(0, initialAhead - churn * (epoch - entryEpoch))
+
+      const network: NetworkQueueSnapshot = {
+        epoch,
+        timestamp: epochStartMs(epoch),
+        queueDepth: depthAt(epoch),
+        churnLimit: churn,
+        voluntaryExits: Math.floor(fnv01(`v:${epoch}`) * 4),
+        slashedExits: epoch === slashEpoch ? spike : Math.floor(fnv01(`s:${epoch}`) * 2),
+      }
+
+      return { network, position: { validatorIndex, epoch, positionOffset, slashed } }
+    },
+
+    async getValidatorBalances(ids) {
+      const out: Record<number, bigint> = {}
+      for (const id of ids) out[id] = BigInt(32) * BigInt(1_000_000_000)
+      return out
+    },
+  }
+}
+
+/** Beacon-API-backed RPC. */
+function createHttpBeaconRPC(baseUrl: string): BeaconRPC {
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, '')
+  const churn = churnLimit()
+
+  return {
+    async getValidatorQueue(validatorIndex, epoch) {
+      const response = await fetch(
+        `${normalizedBaseUrl}/eth/v1/beacon/states/head/validators/${validatorIndex}`,
+      )
+      if (!response.ok) throw new Error('Unable to fetch validator state')
+      const body = (await response.json()) as {
+        data?: { validator?: { exit_epoch?: string | number; slashed?: boolean } }
+      }
+      const exitEpoch = Number(body.data?.validator?.exit_epoch ?? epoch)
+      const slashed = Boolean(body.data?.validator?.slashed)
+      // Approximate position from the assigned exit epoch and churn limit.
+      const positionOffset = Math.max(0, (exitEpoch - epoch) * churn)
+
+      const network: NetworkQueueSnapshot = {
+        epoch,
+        timestamp: epochStartMs(epoch),
+        queueDepth: positionOffset,
+        churnLimit: churn,
+        voluntaryExits: 0,
+        slashedExits: 0,
+      }
+      return { network, position: { validatorIndex, epoch, positionOffset, slashed } }
+    },
+
+    async getValidatorBalances(ids) {
+      const query = ids.join(',')
+      const response = await fetch(
+        `${normalizedBaseUrl}/eth/v1/beacon/states/head/validator_balances?id=${query}`,
+      )
+      if (!response.ok) throw new Error('Unable to fetch validator balances')
+      const body = (await response.json()) as {
+        data?: Array<{ index?: string | number; balance?: string | number }>
+      }
+      const out: Record<number, bigint> = {}
+      for (const entry of body.data ?? []) {
+        if (entry.index !== undefined && entry.balance !== undefined) {
+          out[Number(entry.index)] = BigInt(entry.balance)
+        }
+      }
+      return out
+    },
+  }
+}
+
+/** Beacon JSON-RPC client hook (demo when no node URL is supplied). */
+export function useBeaconRPC(beaconNodeUrl?: string): BeaconRPC {
+  return useMemo(
+    () => (beaconNodeUrl ? createHttpBeaconRPC(beaconNodeUrl) : createDemoBeaconRPC()),
+    [beaconNodeUrl],
+  )
+}

--- a/src/hooks/useCommitteeAssignments.ts
+++ b/src/hooks/useCommitteeAssignments.ts
@@ -1,0 +1,170 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  SHARD_COUNT,
+  type CommitteeAssignment,
+  type ConcentrationResult,
+  type EpochAssignments,
+} from '@/src/types/committee'
+import { computeConcentration } from '@/src/utils/concentrationRisk'
+import { loadEpochHistory, saveEpochAssignments } from '@/src/services/committeeHistoryStore'
+import { useCommitteeStore } from '@/src/store/committeeSlice'
+import { currentEpoch, epochStartMs } from '@/src/utils/epochTime'
+
+const DEFAULT_HISTORY_DEPTH = 32
+
+interface UseCommitteeAssignmentsOptions {
+  beaconNodeUrl?: string
+  historyDepth?: number
+}
+
+export interface CommitteeAssignmentsState {
+  /** Assignments for the currently viewed epoch. */
+  current: EpochAssignments | null
+  latestEpoch: number | null
+  viewEpoch: number | null
+  setViewEpoch: (epoch: number) => void
+  epochs: number[]
+  concentration: ConcentrationResult
+  getValidatorTimeline: (validatorIndex: number) => Array<{ epoch: number; shard: number }>
+  isLoading: boolean
+  error: string | null
+}
+
+function fnv01(input: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0) / 0x1_0000_0000
+}
+
+/** Deterministic demo shard assignment for a validator at an epoch. */
+function demoShard(validatorIndex: number, epoch: number): number {
+  return Math.floor(fnv01(`shard:${validatorIndex}:${epoch}`) * SHARD_COUNT)
+}
+
+function demoAssignments(validatorIndices: number[], epoch: number): EpochAssignments {
+  return {
+    epoch,
+    timestamp: epochStartMs(epoch),
+    assignments: validatorIndices.map((validatorIndex) => ({
+      validatorIndex,
+      epoch,
+      shard: demoShard(validatorIndex, epoch),
+    })),
+  }
+}
+
+async function fetchAssignments(
+  beaconNodeUrl: string,
+  validatorIndices: number[],
+  epoch: number,
+): Promise<EpochAssignments> {
+  const base = beaconNodeUrl.replace(/\/$/, '')
+  const response = await fetch(`${base}/eth/v1/beacon/states/head/committees?epoch=${epoch}`)
+  if (!response.ok) throw new Error('Unable to fetch committee assignments')
+  const body = (await response.json()) as {
+    data?: Array<{ index?: string | number; validators?: Array<string | number> }>
+  }
+  const wanted = new Set(validatorIndices)
+  const assignments: CommitteeAssignment[] = []
+  for (const committee of body.data ?? []) {
+    const shard = Number(committee.index ?? 0) % SHARD_COUNT
+    for (const v of committee.validators ?? []) {
+      const validatorIndex = Number(v)
+      if (wanted.has(validatorIndex)) assignments.push({ validatorIndex, epoch, shard })
+    }
+  }
+  return { epoch, timestamp: epochStartMs(epoch), assignments }
+}
+
+/**
+ * Subscribes to per-epoch sharded committee assignments for an operator's
+ * validators. Seeds recent history (persisted in IndexedDB, 256-epoch
+ * retention), exposes the viewed epoch, and computes concentration risk.
+ */
+export function useCommitteeAssignments(
+  validatorIndices: number[],
+  options: UseCommitteeAssignmentsOptions = {},
+): CommitteeAssignmentsState {
+  const { beaconNodeUrl, historyDepth = DEFAULT_HISTORY_DEPTH } = options
+
+  const byEpoch = useCommitteeStore((s) => s.byEpoch)
+  const latestEpoch = useCommitteeStore((s) => s.latestEpoch)
+  const setEpochAssignments = useCommitteeStore((s) => s.setEpochAssignments)
+  const setHistory = useCommitteeStore((s) => s.setHistory)
+  const getValidatorTimeline = useCommitteeStore((s) => s.getValidatorTimeline)
+
+  const [viewEpoch, setViewEpoch] = useState<number | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const indicesKey = validatorIndices.join(',')
+
+  useEffect(() => {
+    const indices = indicesKey ? indicesKey.split(',').map(Number) : []
+    if (indices.length === 0) return
+
+    let cancelled = false
+    const run = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const persisted = await loadEpochHistory()
+        if (cancelled) return
+        if (persisted.length) setHistory(persisted)
+
+        const cur = currentEpoch(Date.now())
+        for (let epoch = Math.max(0, cur - historyDepth + 1); epoch <= cur; epoch++) {
+          if (cancelled) return
+          const ea = beaconNodeUrl
+            ? await fetchAssignments(beaconNodeUrl, indices, epoch)
+            : demoAssignments(indices, epoch)
+          if (cancelled) return
+          setEpochAssignments(ea)
+          await saveEpochAssignments(ea)
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load assignments')
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [indicesKey, beaconNodeUrl, historyDepth, setEpochAssignments, setHistory])
+
+  const effectiveEpoch = viewEpoch ?? latestEpoch
+  const current = effectiveEpoch !== null ? (byEpoch[effectiveEpoch] ?? null) : null
+
+  const epochs = useMemo(
+    () =>
+      Object.keys(byEpoch)
+        .map(Number)
+        .sort((a, b) => a - b),
+    [byEpoch],
+  )
+
+  const concentration = useMemo(
+    () => computeConcentration(current?.assignments ?? []),
+    [current],
+  )
+
+  return {
+    current,
+    latestEpoch,
+    viewEpoch: effectiveEpoch,
+    setViewEpoch,
+    epochs,
+    concentration,
+    getValidatorTimeline,
+    isLoading,
+    error,
+  }
+}

--- a/src/hooks/useExitQueuePosition.ts
+++ b/src/hooks/useExitQueuePosition.ts
@@ -1,0 +1,130 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type {
+  ExitQueueProjection,
+  NetworkQueueSnapshot,
+  ValidatorQueuePosition,
+} from '@/src/types/exitQueue'
+import { useBeaconRPC } from '@/src/hooks/useBeaconRPC'
+import { useBeaconStore } from '@/src/store/beaconSlice'
+import { EPOCH_MS, currentEpoch, epochStartMs, msUntilNextEpoch } from '@/src/utils/epochTime'
+
+const SLASHING_DELAY_EPOCHS = 4
+/** Epochs of history to backfill on mount so the EWMA/trendline have data. */
+const SEED_EPOCHS = 40
+
+interface UseExitQueuePositionOptions {
+  beaconNodeUrl?: string
+}
+
+export interface ExitQueuePositionState {
+  projection: ExitQueueProjection | null
+  position: ValidatorQueuePosition | null
+  samples: NetworkQueueSnapshot[]
+  ewmaSeries: number[]
+  ewmaChurn: number
+  isLoading: boolean
+  error: string | null
+}
+
+/**
+ * Polls the validator exit queue at epoch boundaries, feeds the shared
+ * gap-interpolated / EWMA-smoothed history in the beacon store, and projects
+ * the validator's exit epoch + ETA from its position and the EWMA churn rate.
+ */
+export function useExitQueuePosition(
+  validatorIndex: number | null,
+  options: UseExitQueuePositionOptions = {},
+): ExitQueuePositionState {
+  const rpc = useBeaconRPC(options.beaconNodeUrl)
+  const ingest = useBeaconStore((s) => s.ingest)
+  const samples = useBeaconStore((s) => s.samples)
+  const ewmaSeries = useBeaconStore((s) => s.ewmaSeries)
+  const ewmaChurn = useBeaconStore((s) => s.ewmaChurn)
+  const latest = useBeaconStore((s) => s.latest)
+
+  const [position, setPosition] = useState<ValidatorQueuePosition | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Clear stale position when the tracked validator changes (during render).
+  const [tracked, setTracked] = useState<number | null | undefined>(undefined)
+  if (tracked !== validatorIndex) {
+    setTracked(validatorIndex)
+    setPosition(null)
+  }
+
+  useEffect(() => {
+    if (validatorIndex === null) return
+
+    let cancelled = false
+    let interval: number | undefined
+
+    const poll = async (epoch: number) => {
+      try {
+        const reading = await rpc.getValidatorQueue(validatorIndex, epoch)
+        if (cancelled) return
+        ingest(reading.network)
+        setPosition(reading.position)
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to read exit queue')
+      }
+    }
+
+    const run = async () => {
+      setIsLoading(true)
+      setError(null)
+      const cur = currentEpoch(Date.now())
+      for (let epoch = Math.max(0, cur - SEED_EPOCHS + 1); epoch <= cur; epoch++) {
+        if (cancelled) return
+        await poll(epoch)
+      }
+      if (!cancelled) setIsLoading(false)
+    }
+
+    run()
+
+    // Poll exactly on each epoch boundary thereafter (≈6.4 min) to bound RPC load.
+    const timeout = window.setTimeout(() => {
+      poll(currentEpoch(Date.now()))
+      interval = window.setInterval(() => poll(currentEpoch(Date.now())), EPOCH_MS)
+    }, msUntilNextEpoch(Date.now()))
+
+    return () => {
+      cancelled = true
+      window.clearTimeout(timeout)
+      if (interval !== undefined) window.clearInterval(interval)
+    }
+  }, [validatorIndex, rpc, ingest])
+
+  const projection = useMemo<ExitQueueProjection | null>(() => {
+    if (!position) return null
+
+    let epochsRemaining: number | null = null
+    let projectedExitEpoch: number | null = null
+    let projectedExitTimestamp: number | null = null
+
+    if (ewmaChurn > 0) {
+      epochsRemaining =
+        Math.ceil(position.positionOffset / ewmaChurn) +
+        (position.slashed ? SLASHING_DELAY_EPOCHS : 0)
+      projectedExitEpoch = position.epoch + epochsRemaining
+      projectedExitTimestamp = epochStartMs(projectedExitEpoch)
+    }
+
+    return {
+      currentEpoch: position.epoch,
+      positionOffset: position.positionOffset,
+      queueDepth: latest?.queueDepth ?? 0,
+      churnLimit: latest?.churnLimit ?? 0,
+      ewmaChurn,
+      slashed: position.slashed,
+      epochsRemaining,
+      projectedExitEpoch,
+      projectedExitTimestamp,
+    }
+  }, [position, latest, ewmaChurn])
+
+  return { projection, position, samples, ewmaSeries, ewmaChurn, isLoading, error }
+}

--- a/src/hooks/useReconciliationHistory.ts
+++ b/src/hooks/useReconciliationHistory.ts
@@ -1,0 +1,114 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type {
+  ReconciliationRecord,
+  ReconciliationSummary,
+  UnlockProjection,
+  ValidatorBalanceSample,
+} from '@/src/types/validator'
+import { reconcile, reconcileSeries, summarize } from '@/src/utils/balanceReconciliation'
+import { projectUnlock } from '@/src/utils/unlockProjection'
+import { createDemoStakingService, createStakingService } from '@/src/services/stakingService'
+
+/** Per-validator reconciliation history is capped at this many records (FIFO). */
+export const MAX_HISTORY = 1000
+
+interface UseReconciliationHistoryOptions {
+  beaconNodeUrl?: string
+  historyDepth?: number
+}
+
+export interface ReconciliationHistoryState {
+  records: ReconciliationRecord[]
+  summary: ReconciliationSummary
+  projection: UnlockProjection
+  isLoading: boolean
+  error: string | null
+  /** Append a fresh sample, reconciling it and evicting the oldest at the cap. */
+  ingest: (sample: ValidatorBalanceSample) => void
+}
+
+/**
+ * Maintains a single validator's reconciliation record history with FIFO
+ * eviction at MAX_HISTORY (1,000) entries, plus a live `ingest` for streaming
+ * new epoch samples. Exposes the aggregate summary and unlock projection.
+ */
+export function useReconciliationHistory(
+  validatorIndex: number | null,
+  options: UseReconciliationHistoryOptions = {},
+): ReconciliationHistoryState {
+  const { beaconNodeUrl, historyDepth = MAX_HISTORY } = options
+  const cap = Math.min(historyDepth, MAX_HISTORY)
+
+  const provider = useMemo(
+    () => (beaconNodeUrl ? createStakingService(beaconNodeUrl) : createDemoStakingService()),
+    [beaconNodeUrl],
+  )
+
+  const [records, setRecords] = useState<ReconciliationRecord[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const lastSampleRef = useRef<ValidatorBalanceSample | null>(null)
+
+  // Clear stale records when the validator changes (adjust state during render).
+  const [trackedValidator, setTrackedValidator] = useState<number | null | undefined>(undefined)
+  if (trackedValidator !== validatorIndex) {
+    setTrackedValidator(validatorIndex)
+    setRecords([])
+  }
+
+  useEffect(() => {
+    lastSampleRef.current = null
+    if (validatorIndex === null) return
+
+    let cancelled = false
+    const run = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const samples = await provider.fetchSamples(validatorIndex, cap)
+        if (cancelled) return
+        const windowed = samples.slice(-cap)
+        const recs = reconcileSeries(windowed)
+        lastSampleRef.current = windowed.length ? windowed[windowed.length - 1] : null
+        setRecords(recs.slice(-cap))
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load reconciliation history')
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [validatorIndex, provider, cap])
+
+  const ingest = useCallback(
+    (sample: ValidatorBalanceSample) => {
+      const record = reconcile(lastSampleRef.current, sample)
+      lastSampleRef.current = sample
+      setRecords((prev) => {
+        const next = [...prev, record]
+        while (next.length > cap) next.shift()
+        return next
+      })
+    },
+    [cap],
+  )
+
+  const summary = useMemo(
+    () => summarize(validatorIndex ?? -1, records),
+    [validatorIndex, records],
+  )
+  const projection = useMemo(
+    () => projectUnlock(validatorIndex ?? -1, records),
+    [validatorIndex, records],
+  )
+
+  return { records, summary, projection, isLoading, error, ingest }
+}

--- a/src/hooks/useValidatorBalances.ts
+++ b/src/hooks/useValidatorBalances.ts
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type {
+  ReconciliationRecord,
+  ReconciliationSummary,
+  UnlockProjection,
+} from '@/src/types/validator'
+import { reconcileSeries, summarize } from '@/src/utils/balanceReconciliation'
+import { projectUnlock } from '@/src/utils/unlockProjection'
+import { createDemoStakingService, createStakingService } from '@/src/services/stakingService'
+
+/** Default history depth fetched per validator (FIFO-capped downstream). */
+const DEFAULT_DEPTH = 1000
+
+interface UseValidatorBalancesOptions {
+  beaconNodeUrl?: string
+  historyDepth?: number
+}
+
+/** Reconciled balance view for a single validator. */
+export interface ValidatorReconciliation {
+  records: ReconciliationRecord[]
+  summary: ReconciliationSummary
+  projection: UnlockProjection
+}
+
+export interface ValidatorBalancesState {
+  byValidator: Record<number, ValidatorReconciliation>
+  validators: number[]
+  isLoading: boolean
+  error: string | null
+}
+
+/**
+ * Fetches balance samples for a set of validators and reconciles each into a
+ * summary + unlock projection. This is the overview data source for the
+ * reconciliation table; per-validator live history lives in
+ * useReconciliationHistory.
+ */
+export function useValidatorBalances(
+  validatorIndices: number[],
+  options: UseValidatorBalancesOptions = {},
+): ValidatorBalancesState {
+  const { beaconNodeUrl, historyDepth = DEFAULT_DEPTH } = options
+
+  const provider = useMemo(
+    () => (beaconNodeUrl ? createStakingService(beaconNodeUrl) : createDemoStakingService()),
+    [beaconNodeUrl],
+  )
+
+  const [byValidator, setByValidator] = useState<Record<number, ValidatorReconciliation>>({})
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Stable primitive dependency so the effect re-runs only on a real change.
+  const indicesKey = validatorIndices.join(',')
+
+  // Clear stale data when the validator set changes (adjust state during render).
+  const [trackedKey, setTrackedKey] = useState<string | undefined>(undefined)
+  if (trackedKey !== indicesKey) {
+    setTrackedKey(indicesKey)
+    setByValidator({})
+  }
+
+  useEffect(() => {
+    const indices = indicesKey ? indicesKey.split(',').map(Number) : []
+    if (indices.length === 0) return
+
+    let cancelled = false
+    const run = async () => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const entries = await Promise.all(
+          indices.map(async (vi) => {
+            const samples = (await provider.fetchSamples(vi, historyDepth)).slice(-historyDepth)
+            const records = reconcileSeries(samples)
+            const entry: ValidatorReconciliation = {
+              records,
+              summary: summarize(vi, records),
+              projection: projectUnlock(vi, records),
+            }
+            return [vi, entry] as const
+          }),
+        )
+        if (cancelled) return
+        setByValidator(Object.fromEntries(entries))
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load validator balances')
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [indicesKey, provider, historyDepth])
+
+  const validators = useMemo(
+    () => (indicesKey ? indicesKey.split(',').map(Number) : []),
+    [indicesKey],
+  )
+
+  return { byValidator, validators, isLoading, error }
+}

--- a/src/services/committeeHistoryStore.ts
+++ b/src/services/committeeHistoryStore.ts
@@ -1,0 +1,98 @@
+// IndexedDB persistence for committee assignment history.
+//
+// Stores one record per epoch keyed by epoch number, retaining the most recent
+// RETENTION_EPOCHS (256). Older epochs are pruned on write and via an explicit
+// GC pass.
+
+import { RETENTION_EPOCHS, type EpochAssignments } from '@/src/types/committee'
+
+const DB_NAME = 'verinode-committee-history'
+const STORE_NAME = 'epoch-assignments'
+const VERSION = 1
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, VERSION)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'epoch' })
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+}
+
+/** Persist one epoch's assignments, then prune beyond the retention window. */
+export async function saveEpochAssignments(
+  data: EpochAssignments,
+  retention = RETENTION_EPOCHS,
+): Promise<void> {
+  if (typeof indexedDB === 'undefined') return
+  const db = await openDb()
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite')
+      tx.objectStore(STORE_NAME).put(data)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+    await pruneCommitteeHistory(retention)
+  } finally {
+    db.close()
+  }
+}
+
+/** Load all retained epochs, ascending by epoch. */
+export async function loadEpochHistory(): Promise<EpochAssignments[]> {
+  if (typeof indexedDB === 'undefined') return []
+  const db = await openDb()
+  try {
+    const all = await new Promise<EpochAssignments[]>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly')
+      const request = tx.objectStore(STORE_NAME).getAll()
+      request.onsuccess = () => resolve((request.result as EpochAssignments[]) ?? [])
+      request.onerror = () => reject(request.error)
+    })
+    return all.sort((a, b) => a.epoch - b.epoch)
+  } finally {
+    db.close()
+  }
+}
+
+/** Delete the oldest epochs so at most `retention` remain. Returns count removed. */
+export async function pruneCommitteeHistory(retention = RETENTION_EPOCHS): Promise<number> {
+  if (typeof indexedDB === 'undefined') return 0
+  const db = await openDb()
+  let removed = 0
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite')
+      const store = tx.objectStore(STORE_NAME)
+      const countRequest = store.count()
+      countRequest.onsuccess = () => {
+        const excess = countRequest.result - retention
+        if (excess <= 0) {
+          resolve()
+          return
+        }
+        // Epochs are the keys; the keyed cursor walks ascending (oldest first).
+        const cursorRequest = store.openCursor()
+        cursorRequest.onsuccess = () => {
+          const cursor = cursorRequest.result
+          if (cursor && removed < excess) {
+            cursor.delete()
+            removed++
+            cursor.continue()
+          }
+        }
+      }
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+  } finally {
+    db.close()
+  }
+  return removed
+}

--- a/src/services/stakingService.ts
+++ b/src/services/stakingService.ts
@@ -1,0 +1,123 @@
+// Staking service — source of validator balance samples for reconciliation.
+//
+// Provides a deterministic demo generator (forward-simulated rewards,
+// penalties, and partial-withdrawal sweeps) and a beacon-API-backed factory.
+// Amounts are bigint gwei.
+
+import type { ValidatorBalanceSample } from '@/src/types/validator'
+import { EFFECTIVE_BALANCE_CAP_GWEI, excessOverCap } from '@/src/utils/balanceMath'
+
+const SLOTS_PER_EPOCH = 32
+const SECONDS_PER_SLOT = 12
+const GENESIS_TIME = 1_606_824_023
+const EPOCH_SECONDS = SLOTS_PER_EPOCH * SECONDS_PER_SLOT
+const SWEEP_PERIOD_EPOCHS = 225 // ~daily partial-withdrawal sweep
+
+export type StakingProvider = {
+  fetchSamples(validatorIndex: number, count: number): Promise<ValidatorBalanceSample[]>
+}
+
+function fnv01(input: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0) / 0x1_0000_0000
+}
+
+function epochTimestampMs(epoch: number): number {
+  return (GENESIS_TIME + epoch * EPOCH_SECONDS) * 1000
+}
+
+function currentEpoch(nowMs: number): number {
+  return Math.max(0, Math.floor((nowMs / 1000 - GENESIS_TIME) / EPOCH_SECONDS))
+}
+
+/**
+ * Forward-simulate `count` epoch-boundary samples for a validator. Even
+ * indices start above the cap (so they show as capped with a sweep stream);
+ * odd indices hover just below it.
+ */
+export function generateDemoSamples(
+  validatorIndex: number,
+  count: number,
+  options: { endEpoch?: number; nowMs?: number } = {},
+): ValidatorBalanceSample[] {
+  const nowMs = options.nowMs ?? Date.now()
+  const endEpoch = options.endEpoch ?? currentEpoch(nowMs)
+  const startEpoch = Math.max(0, endEpoch - count + 1)
+
+  const capped = validatorIndex % 2 === 0
+  const initialExcess = capped
+    ? BigInt(Math.round((1.5 + fnv01(`excess:${validatorIndex}`) * 2) * 1e9)) // 1.5–3.5 ETH over cap
+    : BigInt(0) - BigInt(Math.round((0.2 + fnv01(`gap:${validatorIndex}`) * 0.4) * 1e9)) // 0.2–0.6 ETH under
+
+  let actual = EFFECTIVE_BALANCE_CAP_GWEI + initialExcess
+  const sweepPhase = Math.floor(fnv01(`phase:${validatorIndex}`) * SWEEP_PERIOD_EPOCHS)
+
+  const samples: ValidatorBalanceSample[] = new Array(endEpoch - startEpoch + 1)
+  for (let i = 0, epoch = startEpoch; epoch <= endEpoch; epoch++, i++) {
+    const reward = 11_000 + Math.floor(fnv01(`r:${validatorIndex}:${epoch}`) * 9_000) // gwei
+    const missed = fnv01(`m:${validatorIndex}:${epoch}`) < 0.04
+    const penalty = missed ? 2_000 + Math.floor(fnv01(`p:${validatorIndex}:${epoch}`) * 3_000) : 0
+    actual += BigInt(reward - penalty)
+
+    // Partial-withdrawal sweep: skim the excess above the cap on the sweep epoch.
+    let withdrawal = BigInt(0)
+    const excess = excessOverCap(actual)
+    if (excess > BigInt(0) && epoch % SWEEP_PERIOD_EPOCHS === sweepPhase) {
+      // Sweep most of the excess, leaving a little so the validator stays capped.
+      withdrawal = (excess * BigInt(85)) / BigInt(100)
+      actual -= withdrawal
+    }
+
+    samples[i] = {
+      validatorIndex,
+      epoch,
+      timestamp: epochTimestampMs(epoch),
+      actualBalanceGwei: actual,
+      withdrawalGwei: withdrawal,
+    }
+  }
+  return samples
+}
+
+export function createDemoStakingService(): StakingProvider {
+  return {
+    async fetchSamples(validatorIndex, count) {
+      return generateDemoSamples(validatorIndex, count)
+    },
+  }
+}
+
+/**
+ * Beacon-API-backed provider. Reads the current validator balance; full
+ * historical decomposition requires a per-epoch state/withdrawal scan, so this
+ * returns a single current sample (callers fall back to the demo stream for
+ * history when no node is configured).
+ */
+export function createStakingService(baseUrl: string): StakingProvider {
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, '')
+  return {
+    async fetchSamples(validatorIndex) {
+      const response = await fetch(
+        `${normalizedBaseUrl}/eth/v1/beacon/states/head/validator_balances?id=${validatorIndex}`,
+      )
+      if (!response.ok) throw new Error('Unable to fetch validator balances')
+      const body = (await response.json()) as { data?: Array<{ balance?: string | number }> }
+      const balance = body.data?.[0]?.balance
+      const actualBalanceGwei = balance === undefined ? EFFECTIVE_BALANCE_CAP_GWEI : BigInt(balance)
+      const epoch = currentEpoch(Date.now())
+      return [
+        {
+          validatorIndex,
+          epoch,
+          timestamp: epochTimestampMs(epoch),
+          actualBalanceGwei,
+          withdrawalGwei: BigInt(0),
+        },
+      ]
+    },
+  }
+}

--- a/src/store/beaconSlice.ts
+++ b/src/store/beaconSlice.ts
@@ -1,0 +1,66 @@
+import { create } from 'zustand'
+import type { NetworkQueueSnapshot } from '@/src/types/exitQueue'
+import { LRUQueueCache } from '@/src/utils/lruQueueCache'
+import { interpolateQueueHistory } from '@/src/utils/queueInterpolation'
+import { DEFAULT_ALPHA, DEFAULT_WINDOW, ewmaLatest, ewmaSeries } from '@/src/utils/ewma'
+
+/**
+ * Shared beacon exit-queue state. A single LRU-bounded history (≤500 entries)
+ * is fed by the polling hook; on each ingest the history is gap-interpolated
+ * and the per-epoch drain rate (min(depth, churn)) is EWMA-smoothed. Multiple
+ * validator cards read the same derived series rather than re-deriving it.
+ */
+interface BeaconState {
+  cache: LRUQueueCache
+  /** Dense, gap-interpolated history sorted by epoch. */
+  samples: NetworkQueueSnapshot[]
+  /** Realized drain rate per epoch (min(queueDepth, churnLimit)). */
+  churnSeries: number[]
+  /** EWMA of the churn series (full length, for charting). */
+  ewmaSeries: number[]
+  /** Latest EWMA churn over the trailing 32-epoch window. */
+  ewmaChurn: number
+  latest: NetworkQueueSnapshot | null
+  ingest: (snapshot: NetworkQueueSnapshot) => void
+  reset: () => void
+}
+
+function deriveChurn(samples: NetworkQueueSnapshot[]): number[] {
+  return samples.map((s) => Math.min(s.queueDepth, s.churnLimit))
+}
+
+export const useBeaconStore = create<BeaconState>((set, get) => ({
+  cache: new LRUQueueCache(),
+  samples: [],
+  churnSeries: [],
+  ewmaSeries: [],
+  ewmaChurn: 0,
+  latest: null,
+
+  ingest: (snapshot) => {
+    const { cache } = get()
+    cache.set(snapshot.epoch, snapshot)
+
+    const samples = interpolateQueueHistory(cache.values())
+    const churnSeries = deriveChurn(samples)
+    const latest = samples.length ? samples[samples.length - 1] : null
+
+    set({
+      samples,
+      churnSeries,
+      ewmaSeries: ewmaSeries(churnSeries, DEFAULT_ALPHA),
+      ewmaChurn: ewmaLatest(churnSeries, DEFAULT_ALPHA, DEFAULT_WINDOW),
+      latest,
+    })
+  },
+
+  reset: () =>
+    set({
+      cache: new LRUQueueCache(),
+      samples: [],
+      churnSeries: [],
+      ewmaSeries: [],
+      ewmaChurn: 0,
+      latest: null,
+    }),
+}))

--- a/src/store/committeeSlice.ts
+++ b/src/store/committeeSlice.ts
@@ -1,0 +1,71 @@
+import { create } from 'zustand'
+import { RETENTION_EPOCHS, type EpochAssignments } from '@/src/types/committee'
+
+/**
+ * In-memory store for sharded committee assignments, mirroring the IndexedDB
+ * history and bounded to the most recent RETENTION_EPOCHS (256) epochs.
+ */
+interface CommitteeState {
+  byEpoch: Record<number, EpochAssignments>
+  latestEpoch: number | null
+  setEpochAssignments: (data: EpochAssignments) => void
+  setHistory: (epochs: EpochAssignments[]) => void
+  getEpochs: () => number[]
+  /** Shard a validator was assigned to per epoch (ascending by epoch). */
+  getValidatorTimeline: (validatorIndex: number) => Array<{ epoch: number; shard: number }>
+  reset: () => void
+}
+
+function prune(byEpoch: Record<number, EpochAssignments>): Record<number, EpochAssignments> {
+  const epochs = Object.keys(byEpoch)
+    .map(Number)
+    .sort((a, b) => a - b)
+  if (epochs.length <= RETENTION_EPOCHS) return byEpoch
+  const drop = epochs.slice(0, epochs.length - RETENTION_EPOCHS)
+  const next = { ...byEpoch }
+  for (const e of drop) delete next[e]
+  return next
+}
+
+export const useCommitteeStore = create<CommitteeState>((set, get) => ({
+  byEpoch: {},
+  latestEpoch: null,
+
+  setEpochAssignments: (data) =>
+    set((s) => {
+      const byEpoch = prune({ ...s.byEpoch, [data.epoch]: data })
+      return {
+        byEpoch,
+        latestEpoch: Math.max(s.latestEpoch ?? data.epoch, data.epoch),
+      }
+    }),
+
+  setHistory: (epochs) =>
+    set(() => {
+      const byEpoch: Record<number, EpochAssignments> = {}
+      for (const ea of epochs) byEpoch[ea.epoch] = ea
+      const pruned = prune(byEpoch)
+      const keys = Object.keys(pruned).map(Number)
+      return {
+        byEpoch: pruned,
+        latestEpoch: keys.length ? Math.max(...keys) : null,
+      }
+    }),
+
+  getEpochs: () =>
+    Object.keys(get().byEpoch)
+      .map(Number)
+      .sort((a, b) => a - b),
+
+  getValidatorTimeline: (validatorIndex) => {
+    const { byEpoch } = get()
+    const timeline: Array<{ epoch: number; shard: number }> = []
+    for (const epoch of Object.keys(byEpoch).map(Number).sort((a, b) => a - b)) {
+      const found = byEpoch[epoch].assignments.find((a) => a.validatorIndex === validatorIndex)
+      if (found) timeline.push({ epoch, shard: found.shard })
+    }
+    return timeline
+  },
+
+  reset: () => set({ byEpoch: {}, latestEpoch: null }),
+}))

--- a/src/types/committee.ts
+++ b/src/types/committee.ts
@@ -1,0 +1,86 @@
+// Sharded committee assignment types.
+//
+// Under committee-based / Danksharding assignment, each epoch partitions
+// validators into 64 shard committees; a validator serves exactly one shard
+// per epoch. These types model an operator's per-epoch assignments, the layout
+// produced for the topology map, and the concentration-risk summary.
+
+export const SHARD_COUNT = 64
+export const MAX_VALIDATORS = 1024
+export const RETENTION_EPOCHS = 256
+export const CONCENTRATION_THRESHOLD = 0.2
+
+/** One validator's shard assignment in a given epoch. */
+export interface CommitteeAssignment {
+  validatorIndex: number
+  epoch: number
+  /** Shard committee index, 0..63. */
+  shard: number
+}
+
+/** All of an operator's validator assignments for a single epoch. */
+export interface EpochAssignments {
+  epoch: number
+  /** Unix-ms timestamp of the epoch boundary. */
+  timestamp: number
+  assignments: CommitteeAssignment[]
+}
+
+/** A laid-out node position for canvas rendering. */
+export interface NodePosition {
+  validatorIndex: number
+  shard: number
+  x: number
+  y: number
+}
+
+export interface ShardCentroid {
+  shard: number
+  x: number
+  y: number
+  count: number
+}
+
+/** Layout result returned by the committee layout worker. */
+export interface CommitteeLayout {
+  epoch: number
+  width: number
+  height: number
+  nodes: NodePosition[]
+  centroids: ShardCentroid[]
+}
+
+/** Per-shard concentration share for an operator. */
+export interface ShardShare {
+  shard: number
+  count: number
+  /** Fraction of the operator's validators on this shard (0..1). */
+  share: number
+}
+
+/** Concentration-risk summary for one epoch. */
+export interface ConcentrationResult {
+  total: number
+  perShard: ShardShare[]
+  maxShare: number
+  topShard: number | null
+  /** True when any shard holds more than the concentration threshold. */
+  atRisk: boolean
+}
+
+// ---- worker message protocol --------------------------------------------
+
+export type CommitteeLayoutRequest = {
+  type: 'LAYOUT'
+  payload: {
+    requestId: string
+    epoch: number
+    width: number
+    height: number
+    assignments: Array<{ validatorIndex: number; shard: number }>
+  }
+}
+
+export type CommitteeLayoutResponse =
+  | { type: 'LAYOUT'; payload: { requestId: string; layout: CommitteeLayout } }
+  | { type: 'ERROR'; payload: { requestId: string; message: string } }

--- a/src/types/exitQueue.ts
+++ b/src/types/exitQueue.ts
@@ -1,0 +1,54 @@
+// Validator exit-queue types.
+//
+// When validators request to exit (voluntarily or via slashing) they join a
+// network-wide exit queue drained at the per-epoch churn limit. These types
+// model both the network-level queue snapshot and a specific validator's
+// position within it, plus the projected exit estimate.
+
+/** Network-wide exit-queue state at one epoch boundary. */
+export interface NetworkQueueSnapshot {
+  epoch: number
+  /** Unix-ms timestamp of the epoch boundary. */
+  timestamp: number
+  /** Total validators waiting in the exit queue. */
+  queueDepth: number
+  /** Validators that can leave the queue per epoch (activation/exit churn). */
+  churnLimit: number
+  /** New voluntary exits observed this epoch. */
+  voluntaryExits: number
+  /** New slashed exits this epoch (enter the queue after a 4-epoch delay). */
+  slashedExits: number
+  /** True when this snapshot was synthesized by gap interpolation. */
+  interpolated?: boolean
+}
+
+/** A specific validator's position within the exit queue at an epoch. */
+export interface ValidatorQueuePosition {
+  validatorIndex: number
+  epoch: number
+  /** Validators ahead of this one in the queue. */
+  positionOffset: number
+  /** Slashed exits incur a 4-epoch delay before entering the queue. */
+  slashed: boolean
+}
+
+/** Combined reading returned by the beacon RPC for one validator + epoch. */
+export interface ExitQueueReading {
+  network: NetworkQueueSnapshot
+  position: ValidatorQueuePosition
+}
+
+/** Projected exit estimate derived from position + EWMA churn rate. */
+export interface ExitQueueProjection {
+  currentEpoch: number | null
+  positionOffset: number
+  queueDepth: number
+  churnLimit: number
+  /** EWMA-smoothed drain rate (validators/epoch). */
+  ewmaChurn: number
+  slashed: boolean
+  /** Epochs until exit (includes the 4-epoch slashing delay when applicable). */
+  epochsRemaining: number | null
+  projectedExitEpoch: number | null
+  projectedExitTimestamp: number | null
+}

--- a/src/types/validator.ts
+++ b/src/types/validator.ts
@@ -1,0 +1,74 @@
+// Validator balance & reconciliation type definitions.
+//
+// All on-chain amounts are held as bigint gwei to avoid float drift; display
+// formatting to ETH happens at the edge (see utils/balanceMath).
+
+/**
+ * A raw balance observation for a validator at an epoch boundary. Effective
+ * balance updates only at epoch boundaries, so one sample per epoch suffices.
+ * `withdrawalGwei` is the amount swept out this epoch (0 when none).
+ */
+export interface ValidatorBalanceSample {
+  validatorIndex: number
+  epoch: number
+  /** Unix-ms timestamp of the epoch boundary. */
+  timestamp: number
+  /** Actual on-chain balance in gwei. */
+  actualBalanceGwei: bigint
+  /** Amount partial-withdrawn (swept) this epoch, in gwei. */
+  withdrawalGwei: bigint
+}
+
+/**
+ * The decomposition of one epoch's balance change relative to the previous
+ * sample. The net actual-balance delta is split into its consensus-layer
+ * reward, penalty, and withdrawal-credit components:
+ *
+ *   gross_delta   = actual_n - actual_{n-1} + withdrawal_n
+ *   rewards       = max(0, gross_delta)
+ *   penalties     = max(0, -gross_delta)
+ *   withdrawal    = withdrawal_n
+ */
+export interface ReconciliationRecord {
+  validatorIndex: number
+  epoch: number
+  timestamp: number
+  actualBalanceGwei: bigint
+  effectiveBalanceGwei: bigint
+  /** actual_n - actual_{n-1} (negative if balance fell). */
+  netDeltaGwei: bigint
+  rewardsGwei: bigint
+  penaltiesGwei: bigint
+  withdrawalCreditsGwei: bigint
+  /** True when actual balance exceeds the effective-balance cap. */
+  capped: boolean
+}
+
+/** Aggregate reconciliation summary for a validator over its tracked history. */
+export interface ReconciliationSummary {
+  validatorIndex: number
+  latest: ReconciliationRecord | null
+  totalRewardsGwei: bigint
+  totalPenaltiesGwei: bigint
+  totalWithdrawalsGwei: bigint
+  recordCount: number
+}
+
+/** Projected unlock estimate for a capped validator. */
+export interface UnlockProjection {
+  validatorIndex: number
+  /** Whether the validator is currently capped (excess above the cap). */
+  capped: boolean
+  excessGwei: bigint
+  /** Trailing-average reward rate in gwei/day used for the projection. */
+  avgDailyRewardGwei: bigint
+  /** Central ETA in days; null when not capped or no positive reward rate. */
+  etaDays: number | null
+  /** ±15% error bounds around `etaDays`. */
+  etaDaysLow: number | null
+  etaDaysHigh: number | null
+  /** Projected unlock timestamps (unix-ms); null when not projectable. */
+  unlockDate: number | null
+  unlockDateLow: number | null
+  unlockDateHigh: number | null
+}

--- a/src/utils/balanceMath.ts
+++ b/src/utils/balanceMath.ts
@@ -1,0 +1,58 @@
+// Shared validator balance math.
+//
+// Amounts are bigint gwei. The target compiles to ES2017, so bigint *literals*
+// (e.g. `32n`) are unavailable — all constants use the BigInt() constructor.
+
+export const GWEI_PER_ETH = BigInt(1_000_000_000)
+
+/**
+ * Effective-balance cap. Per the reconciliation invariants this is 32 ETH
+ * (effective_balance = min(actual_balance, 32 ETH)). Post-Electra (EIP-7251)
+ * raised the max effective balance to 2048 ETH for 0x02 validators — change
+ * this single constant to model that regime.
+ */
+export const EFFECTIVE_BALANCE_CAP_GWEI = BigInt(32) * GWEI_PER_ETH
+
+/** Epochs per day at 6.4-minute epochs (32 slots × 12 s). */
+export const EPOCHS_PER_DAY = 225
+
+export function maxBigInt(a: bigint, b: bigint): bigint {
+  return a > b ? a : b
+}
+
+export function minBigInt(a: bigint, b: bigint): bigint {
+  return a < b ? a : b
+}
+
+const ZERO = BigInt(0)
+
+/** Effective balance = min(actual, cap). */
+export function effectiveBalance(actualGwei: bigint, cap = EFFECTIVE_BALANCE_CAP_GWEI): bigint {
+  return minBigInt(actualGwei, cap)
+}
+
+/** Excess of actual balance over the cap, floored at 0. */
+export function excessOverCap(actualGwei: bigint, cap = EFFECTIVE_BALANCE_CAP_GWEI): bigint {
+  return maxBigInt(ZERO, actualGwei - cap)
+}
+
+/** Whether the validator's actual balance exceeds the cap. */
+export function isCapped(actualGwei: bigint, cap = EFFECTIVE_BALANCE_CAP_GWEI): boolean {
+  return actualGwei > cap
+}
+
+/** Convert gwei to a floating-point ETH value (display only). */
+export function gweiToEth(gwei: bigint): number {
+  return Number(gwei) / Number(GWEI_PER_ETH)
+}
+
+/** Format a gwei amount as an ETH string with `decimals` places (sign-aware). */
+export function formatEth(gwei: bigint, decimals = 4): string {
+  const negative = gwei < ZERO
+  const abs = negative ? -gwei : gwei
+  const whole = abs / GWEI_PER_ETH
+  const frac = abs % GWEI_PER_ETH
+  const fracStr = frac.toString().padStart(9, '0').slice(0, decimals)
+  const sign = negative ? '-' : ''
+  return decimals > 0 ? `${sign}${whole.toString()}.${fracStr}` : `${sign}${whole.toString()}`
+}

--- a/src/utils/balanceReconciliation.ts
+++ b/src/utils/balanceReconciliation.ts
@@ -1,0 +1,119 @@
+// Effective-balance reconciliation engine.
+//
+// The displayed effective balance drifts from the actual balance because
+// effective balance is capped (min(actual, cap)) and updates only at epoch
+// boundaries, while actual balance moves every epoch from rewards, penalties,
+// and partial-withdrawal sweeps. This engine decomposes each epoch's actual-
+// balance delta into those three components.
+//
+// Decomposition (vs the previous sample):
+//   net_delta   = actual_n - actual_{n-1}
+//   gross_delta = net_delta + withdrawal_n   (add back what was swept out)
+//   rewards     = max(0, gross_delta)        consensus-layer income
+//   penalties   = max(0, -gross_delta)       missed-duty / slashing losses
+//   withdrawal  = withdrawal_n               partial-withdrawal credit
+
+import type {
+  ReconciliationRecord,
+  ReconciliationSummary,
+  ValidatorBalanceSample,
+} from '@/src/types/validator'
+import { EFFECTIVE_BALANCE_CAP_GWEI, effectiveBalance, isCapped } from '@/src/utils/balanceMath'
+
+const ZERO = BigInt(0)
+
+/**
+ * Reconcile a single sample against the previous one. With no previous sample
+ * the record is a baseline (no decomposed delta beyond the current withdrawal).
+ */
+export function reconcile(
+  prev: ValidatorBalanceSample | null,
+  current: ValidatorBalanceSample,
+  cap = EFFECTIVE_BALANCE_CAP_GWEI,
+): ReconciliationRecord {
+  const effective = effectiveBalance(current.actualBalanceGwei, cap)
+  const capped = isCapped(current.actualBalanceGwei, cap)
+
+  if (!prev) {
+    return {
+      validatorIndex: current.validatorIndex,
+      epoch: current.epoch,
+      timestamp: current.timestamp,
+      actualBalanceGwei: current.actualBalanceGwei,
+      effectiveBalanceGwei: effective,
+      netDeltaGwei: ZERO,
+      rewardsGwei: ZERO,
+      penaltiesGwei: ZERO,
+      withdrawalCreditsGwei: current.withdrawalGwei,
+      capped,
+    }
+  }
+
+  const netDelta = current.actualBalanceGwei - prev.actualBalanceGwei
+  const grossDelta = netDelta + current.withdrawalGwei
+  const rewards = grossDelta > ZERO ? grossDelta : ZERO
+  const penalties = grossDelta < ZERO ? -grossDelta : ZERO
+
+  return {
+    validatorIndex: current.validatorIndex,
+    epoch: current.epoch,
+    timestamp: current.timestamp,
+    actualBalanceGwei: current.actualBalanceGwei,
+    effectiveBalanceGwei: effective,
+    netDeltaGwei: netDelta,
+    rewardsGwei: rewards,
+    penaltiesGwei: penalties,
+    withdrawalCreditsGwei: current.withdrawalGwei,
+    capped,
+  }
+}
+
+/**
+ * Reconcile an ordered series of samples into per-epoch records. Input is
+ * sorted ascending by epoch defensively; duplicate epochs keep the last.
+ */
+export function reconcileSeries(
+  samples: ValidatorBalanceSample[],
+  cap = EFFECTIVE_BALANCE_CAP_GWEI,
+): ReconciliationRecord[] {
+  if (samples.length === 0) return []
+
+  const sorted = [...samples].sort((a, b) => a.epoch - b.epoch)
+  const deduped: ValidatorBalanceSample[] = []
+  for (const sample of sorted) {
+    const last = deduped[deduped.length - 1]
+    if (last && last.epoch === sample.epoch) deduped[deduped.length - 1] = sample
+    else deduped.push(sample)
+  }
+
+  const records: ReconciliationRecord[] = new Array(deduped.length)
+  let prev: ValidatorBalanceSample | null = null
+  for (let i = 0; i < deduped.length; i++) {
+    records[i] = reconcile(prev, deduped[i], cap)
+    prev = deduped[i]
+  }
+  return records
+}
+
+/** Aggregate a set of records into a per-validator summary. */
+export function summarize(
+  validatorIndex: number,
+  records: ReconciliationRecord[],
+): ReconciliationSummary {
+  let totalRewards = ZERO
+  let totalPenalties = ZERO
+  let totalWithdrawals = ZERO
+  for (const r of records) {
+    totalRewards += r.rewardsGwei
+    totalPenalties += r.penaltiesGwei
+    totalWithdrawals += r.withdrawalCreditsGwei
+  }
+  return {
+    validatorIndex,
+    latest: records.length ? records[records.length - 1] : null,
+    totalRewardsGwei: totalRewards,
+    totalPenaltiesGwei: totalPenalties,
+    totalWithdrawalsGwei: totalWithdrawals,
+    recordCount: records.length,
+  }
+}

--- a/src/utils/concentrationRisk.ts
+++ b/src/utils/concentrationRisk.ts
@@ -1,0 +1,43 @@
+// Concentration-risk detection for shard assignments.
+//
+// Spreading an operator's validators across shards limits correlated exposure.
+// When more than CONCENTRATION_THRESHOLD (20%) of the operator's validators
+// land on a single shard in an epoch, we flag concentration risk.
+
+import {
+  CONCENTRATION_THRESHOLD,
+  type CommitteeAssignment,
+  type ConcentrationResult,
+  type ShardShare,
+} from '@/src/types/committee'
+
+/**
+ * Compute per-shard shares and flag risk when any shard exceeds the threshold.
+ */
+export function computeConcentration(
+  assignments: CommitteeAssignment[],
+  threshold = CONCENTRATION_THRESHOLD,
+): ConcentrationResult {
+  const total = assignments.length
+  if (total === 0) {
+    return { total: 0, perShard: [], maxShare: 0, topShard: null, atRisk: false }
+  }
+
+  const counts = new Map<number, number>()
+  for (const a of assignments) {
+    counts.set(a.shard, (counts.get(a.shard) ?? 0) + 1)
+  }
+
+  const perShard: ShardShare[] = [...counts.entries()]
+    .map(([shard, count]) => ({ shard, count, share: count / total }))
+    .sort((a, b) => b.share - a.share || a.shard - b.shard)
+
+  const top = perShard[0]
+  return {
+    total,
+    perShard,
+    maxShare: top.share,
+    topShard: top.shard,
+    atRisk: top.share > threshold,
+  }
+}

--- a/src/utils/epochTime.ts
+++ b/src/utils/epochTime.ts
@@ -1,0 +1,35 @@
+// Epoch boundary timing utilities.
+//
+// Beacon epochs are 32 slots × 12 s = 384 s (~6.4 min). Exit-queue polling is
+// aligned to epoch boundaries to avoid hammering the beacon node.
+
+export const SLOTS_PER_EPOCH = 32
+export const SECONDS_PER_SLOT = 12
+export const GENESIS_TIME = 1_606_824_023 // mainnet, unix seconds
+export const EPOCH_SECONDS = SLOTS_PER_EPOCH * SECONDS_PER_SLOT
+export const EPOCH_MS = EPOCH_SECONDS * 1000
+
+/** Epoch containing the given wall-clock time. */
+export function currentEpoch(nowMs: number): number {
+  return Math.max(0, Math.floor((nowMs / 1000 - GENESIS_TIME) / EPOCH_SECONDS))
+}
+
+/** Unix-ms timestamp of an epoch's first slot. */
+export function epochStartMs(epoch: number): number {
+  return (GENESIS_TIME + epoch * EPOCH_SECONDS) * 1000
+}
+
+/** Wall-clock time of the next epoch boundary after `nowMs`. */
+export function nextEpochBoundaryMs(nowMs: number): number {
+  return epochStartMs(currentEpoch(nowMs) + 1)
+}
+
+/** Milliseconds remaining until the next epoch boundary (>= 0). */
+export function msUntilNextEpoch(nowMs: number): number {
+  return Math.max(0, nextEpochBoundaryMs(nowMs) - nowMs)
+}
+
+/** Convert a number of epochs to milliseconds. */
+export function epochsToMs(epochs: number): number {
+  return epochs * EPOCH_MS
+}

--- a/src/utils/ewma.ts
+++ b/src/utils/ewma.ts
@@ -1,0 +1,36 @@
+// Exponentially Weighted Moving Average.
+//
+//   e[0] = x[0]
+//   e[i] = α·x[i] + (1 − α)·e[i−1]
+//
+// Exit-ETA projections use α = 0.3 over a sliding window of the last 32 epoch
+// samples, so recent churn dominates while older epochs still damp noise.
+
+export const DEFAULT_ALPHA = 0.3
+export const DEFAULT_WINDOW = 32
+
+/** Full EWMA series for `values` (same length as input). */
+export function ewmaSeries(values: number[], alpha = DEFAULT_ALPHA): number[] {
+  if (values.length === 0) return []
+  const out = new Array<number>(values.length)
+  out[0] = values[0]
+  for (let i = 1; i < values.length; i++) {
+    out[i] = alpha * values[i] + (1 - alpha) * out[i - 1]
+  }
+  return out
+}
+
+/**
+ * Latest EWMA value over the trailing `window` samples. Returns 0 for empty
+ * input.
+ */
+export function ewmaLatest(
+  values: number[],
+  alpha = DEFAULT_ALPHA,
+  window = DEFAULT_WINDOW,
+): number {
+  if (values.length === 0) return 0
+  const windowed = values.slice(-window)
+  const series = ewmaSeries(windowed, alpha)
+  return series[series.length - 1]
+}

--- a/src/utils/lruQueueCache.ts
+++ b/src/utils/lruQueueCache.ts
@@ -1,0 +1,51 @@
+// LRU cache for exit-queue history, capped at 500 entries.
+//
+// Keyed by epoch. Backed by a Map (insertion-ordered): touching an entry moves
+// it to the most-recent end, and inserts past the cap evict the least-recently
+// used key. `values()` returns entries sorted by epoch for time-series use.
+
+import type { NetworkQueueSnapshot } from '@/src/types/exitQueue'
+
+export const DEFAULT_MAX_ENTRIES = 500
+
+export class LRUQueueCache {
+  private readonly map = new Map<number, NetworkQueueSnapshot>()
+
+  constructor(private readonly maxEntries: number = DEFAULT_MAX_ENTRIES) {}
+
+  get size(): number {
+    return this.map.size
+  }
+
+  has(epoch: number): boolean {
+    return this.map.has(epoch)
+  }
+
+  get(epoch: number): NetworkQueueSnapshot | undefined {
+    const entry = this.map.get(epoch)
+    if (entry === undefined) return undefined
+    // Refresh recency.
+    this.map.delete(epoch)
+    this.map.set(epoch, entry)
+    return entry
+  }
+
+  set(epoch: number, snapshot: NetworkQueueSnapshot): void {
+    if (this.map.has(epoch)) this.map.delete(epoch)
+    this.map.set(epoch, snapshot)
+    while (this.map.size > this.maxEntries) {
+      const oldest = this.map.keys().next().value
+      if (oldest === undefined) break
+      this.map.delete(oldest)
+    }
+  }
+
+  /** Snapshots sorted ascending by epoch. */
+  values(): NetworkQueueSnapshot[] {
+    return [...this.map.values()].sort((a, b) => a.epoch - b.epoch)
+  }
+
+  clear(): void {
+    this.map.clear()
+  }
+}

--- a/src/utils/queueInterpolation.ts
+++ b/src/utils/queueInterpolation.ts
@@ -1,0 +1,55 @@
+// Gap interpolation for exit-queue history.
+//
+// Epoch polls can be missed (RPC hiccups, tab backgrounding). Rather than
+// leave holes that distort the EWMA, we linearly interpolate the queue depth
+// and churn limit across missing epochs between two observed samples. Synthetic
+// entries are flagged `interpolated` and carry zero new-exit counts.
+
+import type { NetworkQueueSnapshot } from '@/src/types/exitQueue'
+import { epochStartMs } from '@/src/utils/epochTime'
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t
+}
+
+/**
+ * Return a dense, epoch-contiguous history from possibly-sparse samples.
+ * Input need not be sorted; duplicate epochs keep the last observation.
+ */
+export function interpolateQueueHistory(samples: NetworkQueueSnapshot[]): NetworkQueueSnapshot[] {
+  if (samples.length === 0) return []
+
+  const sorted = [...samples].sort((a, b) => a.epoch - b.epoch)
+  const deduped: NetworkQueueSnapshot[] = []
+  for (const s of sorted) {
+    const last = deduped[deduped.length - 1]
+    if (last && last.epoch === s.epoch) deduped[deduped.length - 1] = s
+    else deduped.push(s)
+  }
+
+  const dense: NetworkQueueSnapshot[] = []
+  for (let i = 0; i < deduped.length; i++) {
+    const current = deduped[i]
+    dense.push(current)
+
+    const next = deduped[i + 1]
+    if (!next) break
+    const gap = next.epoch - current.epoch
+    if (gap <= 1) continue
+
+    for (let epoch = current.epoch + 1; epoch < next.epoch; epoch++) {
+      const t = (epoch - current.epoch) / gap
+      dense.push({
+        epoch,
+        timestamp: epochStartMs(epoch),
+        queueDepth: Math.round(lerp(current.queueDepth, next.queueDepth, t)),
+        churnLimit: Math.round(lerp(current.churnLimit, next.churnLimit, t)),
+        voluntaryExits: 0,
+        slashedExits: 0,
+        interpolated: true,
+      })
+    }
+  }
+
+  return dense
+}

--- a/src/utils/shardColorMapping.ts
+++ b/src/utils/shardColorMapping.ts
@@ -1,0 +1,25 @@
+// Shard → color mapping using golden-ratio hue spacing.
+//
+// Stepping the hue by φ × 360° (≈222.49°) per shard index spreads adjacent
+// shard colors maximally around the wheel, so neighbouring shard indices stay
+// visually distinct even across all 64 shards.
+
+const PHI = 0.618_033_988_749_895
+const HUE_STEP = PHI * 360 // ≈222.4922° per shard
+const SATURATION = 70
+const LIGHTNESS = 55
+
+/** Hue in degrees [0, 360) for a shard index. */
+export function shardHue(shard: number): number {
+  return ((shard * HUE_STEP) % 360 + 360) % 360
+}
+
+/** CSS HSL color string for a shard index. */
+export function shardColor(shard: number, saturation = SATURATION, lightness = LIGHTNESS): string {
+  return `hsl(${shardHue(shard).toFixed(1)}, ${saturation}%, ${lightness}%)`
+}
+
+/** Translucent variant for fills/backgrounds. */
+export function shardColorAlpha(shard: number, alpha: number): string {
+  return `hsla(${shardHue(shard).toFixed(1)}, ${SATURATION}%, ${LIGHTNESS}%, ${alpha})`
+}

--- a/src/utils/unlockProjection.ts
+++ b/src/utils/unlockProjection.ts
@@ -1,0 +1,99 @@
+// Projected-unlock calculator for capped validators.
+//
+// When a validator's actual balance exceeds the effective-balance cap, the
+// excess is swept out gradually by partial withdrawals. The projection
+// estimates how long the excess represents in reward-equivalent time, per the
+// invariant:
+//
+//   eta_days = (actual_balance - cap) / avg_daily_reward_rate   ± 15%
+//
+// The reward rate is a 7-day trailing average of decomposed consensus rewards.
+
+import type { ReconciliationRecord, UnlockProjection } from '@/src/types/validator'
+import { EFFECTIVE_BALANCE_CAP_GWEI, excessOverCap, isCapped } from '@/src/utils/balanceMath'
+
+const ZERO = BigInt(0)
+const DAY_MS = 24 * 60 * 60 * 1000
+const TRAILING_DAYS = 7
+const ERROR_BOUND = 0.15
+
+function emptyProjection(validatorIndex: number, excess: bigint, avgDaily: bigint): UnlockProjection {
+  return {
+    validatorIndex,
+    capped: excess > ZERO,
+    excessGwei: excess,
+    avgDailyRewardGwei: avgDaily,
+    etaDays: null,
+    etaDaysLow: null,
+    etaDaysHigh: null,
+    unlockDate: null,
+    unlockDateLow: null,
+    unlockDateHigh: null,
+  }
+}
+
+/**
+ * Average daily reward (gwei/day) over the trailing 7 days of records, scaled
+ * by the actual span covered so short histories still yield a sane rate.
+ */
+export function trailingDailyReward(
+  records: ReconciliationRecord[],
+  trailingDays = TRAILING_DAYS,
+): bigint {
+  if (records.length === 0) return ZERO
+  const dataNow = records[records.length - 1].timestamp
+  const windowStart = dataNow - trailingDays * DAY_MS
+
+  let sumRewards = ZERO
+  let earliest = dataNow
+  for (const r of records) {
+    if (r.timestamp > windowStart) {
+      sumRewards += r.rewardsGwei
+      if (r.timestamp < earliest) earliest = r.timestamp
+    }
+  }
+  if (sumRewards <= ZERO) return ZERO
+
+  const spanDays = Math.min(trailingDays, Math.max(1, (dataNow - earliest) / DAY_MS))
+  return BigInt(Math.round(Number(sumRewards) / spanDays))
+}
+
+/**
+ * Project the unlock ETA for a validator from its reconciliation records.
+ * Returns excess + reward rate always; ETA/dates are null when the validator
+ * is not capped or has no positive trailing reward rate.
+ */
+export function projectUnlock(
+  validatorIndex: number,
+  records: ReconciliationRecord[],
+  options: { now?: number; cap?: bigint } = {},
+): UnlockProjection {
+  const { now = Date.now(), cap = EFFECTIVE_BALANCE_CAP_GWEI } = options
+
+  if (records.length === 0) return emptyProjection(validatorIndex, ZERO, ZERO)
+
+  const actual = records[records.length - 1].actualBalanceGwei
+  const excess = excessOverCap(actual, cap)
+  const avgDaily = trailingDailyReward(records)
+
+  if (!isCapped(actual, cap) || avgDaily <= ZERO) {
+    return emptyProjection(validatorIndex, excess, avgDaily)
+  }
+
+  const etaDays = Number(excess) / Number(avgDaily)
+  const etaDaysLow = etaDays * (1 - ERROR_BOUND)
+  const etaDaysHigh = etaDays * (1 + ERROR_BOUND)
+
+  return {
+    validatorIndex,
+    capped: true,
+    excessGwei: excess,
+    avgDailyRewardGwei: avgDaily,
+    etaDays,
+    etaDaysLow,
+    etaDaysHigh,
+    unlockDate: now + etaDays * DAY_MS,
+    unlockDateLow: now + etaDaysLow * DAY_MS,
+    unlockDateHigh: now + etaDaysHigh * DAY_MS,
+  }
+}

--- a/src/workers/committeeLayoutWorker.ts
+++ b/src/workers/committeeLayoutWorker.ts
@@ -1,0 +1,82 @@
+// Web worker for committee topology layout.
+//
+// Computes node positions off the main thread so rendering up to 1,024
+// validators stays smooth. Shards are laid out on an 8×8 grid of centroids;
+// each shard's validators are packed around their centroid via a golden-angle
+// (phyllotaxis) spiral, which gives an even, force-directed-like clustering
+// without an iterative simulation.
+
+import {
+  SHARD_COUNT,
+  type CommitteeLayout,
+  type CommitteeLayoutRequest,
+  type CommitteeLayoutResponse,
+  type NodePosition,
+  type ShardCentroid,
+} from '@/src/types/committee'
+
+const GRID_COLS = 8
+const GRID_ROWS = 8 // 8 × 8 = 64 shards
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5)) // ≈2.39996 rad
+
+function post(message: CommitteeLayoutResponse): void {
+  ;(self as unknown as Worker).postMessage(message)
+}
+
+function computeLayout(
+  epoch: number,
+  width: number,
+  height: number,
+  assignments: Array<{ validatorIndex: number; shard: number }>,
+): CommitteeLayout {
+  const cellW = width / GRID_COLS
+  const cellH = height / GRID_ROWS
+
+  const counts = new Array<number>(SHARD_COUNT).fill(0)
+  for (const a of assignments) {
+    if (a.shard >= 0 && a.shard < SHARD_COUNT) counts[a.shard]++
+  }
+
+  const centroids: ShardCentroid[] = new Array(SHARD_COUNT)
+  for (let s = 0; s < SHARD_COUNT; s++) {
+    const col = s % GRID_COLS
+    const row = Math.floor(s / GRID_COLS)
+    centroids[s] = {
+      shard: s,
+      x: col * cellW + cellW / 2,
+      y: row * cellH + cellH / 2,
+      count: counts[s],
+    }
+  }
+
+  const baseRadius = Math.min(cellW, cellH) * 0.12
+  const perShardIndex = new Array<number>(SHARD_COUNT).fill(0)
+  const nodes: NodePosition[] = assignments.map((a) => {
+    const centroid = centroids[a.shard] ?? { x: width / 2, y: height / 2 }
+    const i = a.shard >= 0 && a.shard < SHARD_COUNT ? perShardIndex[a.shard]++ : 0
+    const radius = baseRadius * Math.sqrt(i + 1)
+    const theta = i * GOLDEN_ANGLE
+    return {
+      validatorIndex: a.validatorIndex,
+      shard: a.shard,
+      x: centroid.x + radius * Math.cos(theta),
+      y: centroid.y + radius * Math.sin(theta),
+    }
+  })
+
+  return { epoch, width, height, nodes, centroids }
+}
+
+self.onmessage = (e: MessageEvent<CommitteeLayoutRequest>) => {
+  const msg = e.data
+  if (msg.type !== 'LAYOUT') return
+  const { requestId, epoch, width, height, assignments } = msg.payload
+  try {
+    post({ type: 'LAYOUT', payload: { requestId, layout: computeLayout(epoch, width, height, assignments) } })
+  } catch (err) {
+    post({
+      type: 'ERROR',
+      payload: { requestId, message: err instanceof Error ? err.message : 'Unknown worker error' },
+    })
+  }
+}


### PR DESCRIPTION
# feat: Sharded Validator Committee Assignment Interactive Topology Map

Closes #45

## Changes

| File | Role |
|------|------|
| `src/types/committee.ts` | Assignment / layout / concentration types + constants (64 shards, 1024 validators, 256-epoch retention, 20% threshold) |
| `src/utils/shardColorMapping.ts` | HSL hue stepped by **φ × 360°** per shard index |
| `src/utils/concentrationRisk.ts` | Per-shard share + **>20%** risk flag |
| `src/services/committeeHistoryStore.ts` | IndexedDB history with **256-epoch** retention + GC |
| `src/store/committeeSlice.ts` | In-memory assignment store bounded to 256 epochs |
| `src/workers/committeeLayoutWorker.ts` | Off-thread phyllotaxis cluster layout |
| `src/hooks/useCommitteeAssignments.ts` | Per-epoch assignment subscription, history, concentration |
| `src/components/canvas/CommitteeTopologyMap.tsx` | Offscreen-cached canvas, cluster/shard/detail zoom tiers, hover + click-to-drill |
| `src/components/validators/ShardLegend.tsx` | Shard ↔ color legend + concentration-risk badge |
| `src/components/validators/ValidatorDashboard.tsx` | "Shard Committee Topology" collapsible panel beneath the validator table |
