### PR TITLE
feat: pre-flight resource & gas fee estimation sub-component

### DIFF
--- a/app/wallet/preflight/page.tsx
+++ b/app/wallet/preflight/page.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import { TxModal } from '@/src/components/wallet/TxModal'
+import {
+  TRANSACTION_TYPES,
+  buildTransaction,
+  transactionLabel,
+  type SorobanTransaction,
+} from '@/src/lib/stellar/transaction'
+
+export default function PreflightDemoPage() {
+  const [transaction, setTransaction] = useState<SorobanTransaction | null>(null)
+  const [approved, setApproved] = useState<string | null>(null)
+
+  return (
+    <main className="mx-auto min-h-screen max-w-2xl bg-slate-950 px-4 py-10 text-white">
+      <h1 className="mb-2 text-2xl font-bold">Transaction Pre-Flight</h1>
+      <p className="mb-8 text-sm text-slate-400">
+        Simulate a Soroban transaction to preview its resource footprint and fee before approving.
+      </p>
+
+      <div className="flex flex-wrap gap-3">
+        {TRANSACTION_TYPES.map((type) => (
+          <button
+            key={type}
+            type="button"
+            onClick={() => setTransaction(buildTransaction(type))}
+            className="rounded-xl border border-white/10 bg-slate-900 px-4 py-2.5 text-sm font-medium hover:bg-slate-800"
+          >
+            {transactionLabel(type)}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => setTransaction(buildTransaction('stake', { operations: ['stake', 'delegate'] }))}
+          className="rounded-xl border border-sky-400/40 bg-sky-500/10 px-4 py-2.5 text-sm font-medium text-sky-200 hover:bg-sky-500/20"
+        >
+          Stake + Delegate
+        </button>
+      </div>
+
+      {approved && (
+        <p className="mt-6 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-300">
+          Approved “{approved}” — handed off to wallet for signing.
+        </p>
+      )}
+
+      <TxModal
+        transaction={transaction}
+        open={transaction !== null}
+        onClose={() => setTransaction(null)}
+        onApprove={(tx) => {
+          setApproved(transactionLabel(tx.type))
+          setTransaction(null)
+        }}
+      />
+    </main>
+  )
+}

--- a/e2e/preflight-fee-estimation.spec.ts
+++ b/e2e/preflight-fee-estimation.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test'
+
+// Known simulation values: fee = (5_000_000·100 + 5_000·1000 + 10_000·10) / 1e7
+//                              = 505_100_000 / 1e7 = 50.51 XLM
+const MOCK_COST = { instructions: 5_000_000, writeBytes: 5_000, readBytes: 10_000 }
+
+const MOCK_RESPONSE = {
+  success: true,
+  cost: MOCK_COST,
+  footprint: {
+    readWrite: ['CONTRACT_STAKE_LEDGER', 'CONTRACT_BALANCE'],
+    readOnly: ['CONTRACT_CONFIG'],
+  },
+  stateChanges: [{ key: 'CONTRACT_STAKE_LEDGER', kind: 'updated' }],
+}
+
+test.describe('Pre-flight fee estimation (#12)', () => {
+  test('shows accurate breakdown and gates Approve on simulation completion', async ({ page }) => {
+    // (a) Mock the simulation endpoint, with a small delay so we can observe the
+    // loading → ready transition.
+    await page.route('**/api/v1/simulate/transaction', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 300))
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_RESPONSE),
+      })
+    })
+
+    await page.goto('/wallet/preflight')
+
+    // (b) Open the TxModal for a stake action.
+    await page.getByRole('button', { name: 'Stake', exact: true }).click()
+    const modal = page.getByTestId('tx-modal')
+    await expect(modal).toBeVisible()
+
+    // (d) While simulating, the skeleton shows and Approve is disabled.
+    await expect(page.getByTestId('preflight-skeleton')).toBeVisible()
+    await expect(page.getByTestId('approve-wallet')).toBeDisabled()
+
+    // (c) On success, the FeeBreakdown shows the expected resource and fee values.
+    await expect(page.getByTestId('fee-instructions')).toHaveText('5,000,000')
+    await expect(page.getByTestId('fee-write-bytes')).toHaveText('5,000')
+    await expect(page.getByTestId('fee-read-bytes')).toHaveText('10,000')
+    await expect(page.getByTestId('fee-xlm')).toContainText('50.51')
+
+    // Real simulation → no "estimated" badge.
+    await expect(page.getByTestId('estimated-badge')).toHaveCount(0)
+
+    // (d) Approve becomes enabled only after simulation completes.
+    await expect(page.getByTestId('approve-wallet')).toBeEnabled()
+  })
+
+  test('falls back to a conservative estimate when simulation fails', async ({ page }) => {
+    await page.route('**/api/v1/simulate/transaction', (route) =>
+      route.fulfill({ status: 500, contentType: 'application/json', body: '{"error":"rpc down"}' }),
+    )
+
+    await page.goto('/wallet/preflight')
+    await page.getByRole('button', { name: 'Stake', exact: true }).click()
+
+    // Static estimate from feeEstimates.json (stake) is shown with a badge,
+    // and Approve is still enabled.
+    await expect(page.getByTestId('estimated-badge')).toBeVisible()
+    await expect(page.getByTestId('fee-instructions')).toHaveText('5,000,000')
+    await expect(page.getByTestId('approve-wallet')).toBeEnabled()
+  })
+})

--- a/src/components/wallet/FeeBreakdown.tsx
+++ b/src/components/wallet/FeeBreakdown.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import { useMemo } from 'react'
+import { FormattedBalance } from '@/src/components/shared/FormattedBalance'
+import {
+  INSTRUCTION_LIMIT,
+  READ_BYTES_LIMIT,
+  WRITE_BYTES_LIMIT,
+  computeFee,
+} from '@/src/lib/stellar/transaction'
+import type { OperationCost, SimulationResult } from '@/src/lib/api/simulate'
+
+const FOOTPRINT_PREVIEW = 5
+
+function ResourceBar({
+  label,
+  value,
+  limit,
+  unit,
+  testid,
+}: {
+  label: string
+  value: number
+  limit: number
+  unit: string
+  testid: string
+}) {
+  const pct = Math.min(100, limit > 0 ? (value / limit) * 100 : 0)
+  const tone = pct >= 90 ? 'bg-red-500' : pct >= 70 ? 'bg-amber-500' : 'bg-emerald-500'
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between text-sm">
+        <span className="text-slate-300">{label}</span>
+        <span className="tabular-nums text-slate-400">
+          <span data-testid={testid} className="font-medium text-slate-100">
+            {value.toLocaleString()}
+          </span>{' '}
+          / {limit.toLocaleString()} {unit}
+        </span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-800">
+        <div className={`h-full rounded-full ${tone}`} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  )
+}
+
+function OperationRow({ op }: { op: OperationCost }) {
+  const fee = computeFee(op.instructions, op.writeBytes, op.readBytes)
+  return (
+    <details className="rounded-lg border border-white/10 bg-slate-950/40 px-3 py-2">
+      <summary className="flex cursor-pointer items-center justify-between text-sm text-slate-200">
+        <span>{op.label}</span>
+        <span className="tabular-nums text-xs text-slate-400">
+          <FormattedBalance value={fee} aria-label={`${op.label} fee`} /> XLM
+        </span>
+      </summary>
+      <dl className="mt-2 grid grid-cols-3 gap-2 text-xs text-slate-400">
+        <div>
+          <dt className="text-slate-500">Instructions</dt>
+          <dd className="tabular-nums text-slate-200">{op.instructions.toLocaleString()}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-500">Write bytes</dt>
+          <dd className="tabular-nums text-slate-200">{op.writeBytes.toLocaleString()}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-500">Read bytes</dt>
+          <dd className="tabular-nums text-slate-200">{op.readBytes.toLocaleString()}</dd>
+        </div>
+      </dl>
+    </details>
+  )
+}
+
+/**
+ * Renders the pre-flight resource breakdown: instruction/byte usage against
+ * limits, the estimated XLM fee, the storage footprint, and a per-operation
+ * accordion for multi-step transactions.
+ */
+export function FeeBreakdown({ result }: { result: SimulationResult }) {
+  const fee = useMemo(
+    () => computeFee(result.instructions, result.writeBytes, result.readBytes),
+    [result.instructions, result.writeBytes, result.readBytes],
+  )
+
+  const footprint = useMemo(() => {
+    return [
+      ...result.footprint.readWrite.map((key) => ({ key, access: 'write' as const })),
+      ...result.footprint.readOnly.map((key) => ({ key, access: 'read' as const })),
+    ]
+  }, [result.footprint])
+
+  const previewKeys = footprint.slice(0, FOOTPRINT_PREVIEW)
+  const remaining = footprint.slice(FOOTPRINT_PREVIEW)
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-3">
+        <ResourceBar
+          label="Instructions consumed"
+          value={result.instructions}
+          limit={INSTRUCTION_LIMIT}
+          unit=""
+          testid="fee-instructions"
+        />
+        <ResourceBar
+          label="Write bytes"
+          value={result.writeBytes}
+          limit={WRITE_BYTES_LIMIT}
+          unit="B"
+          testid="fee-write-bytes"
+        />
+        <ResourceBar
+          label="Read bytes"
+          value={result.readBytes}
+          limit={READ_BYTES_LIMIT}
+          unit="B"
+          testid="fee-read-bytes"
+        />
+      </div>
+
+      <div className="flex items-center justify-between rounded-xl border border-white/10 bg-slate-950/60 px-4 py-3">
+        <span className="text-sm text-slate-300">Estimated fee</span>
+        <span data-testid="fee-xlm" className="text-base font-semibold text-white">
+          <FormattedBalance value={fee} aria-label="Estimated fee" /> XLM
+        </span>
+      </div>
+
+      {result.operations.length > 1 && (
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-wide text-slate-500">Per-operation breakdown</p>
+          <div className="space-y-2">
+            {result.operations.map((op, i) => (
+              <OperationRow key={`${op.type}-${i}`} op={op} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <p className="text-xs uppercase tracking-wide text-slate-500">
+          Storage footprint{footprint.length > 0 ? ` (${footprint.length})` : ''}
+        </p>
+        {footprint.length === 0 ? (
+          <p className="text-sm text-slate-500">No storage footprint reported.</p>
+        ) : (
+          <ul className="space-y-1" data-testid="footprint-list">
+            {previewKeys.map((entry) => (
+              <li key={entry.key} className="flex items-center gap-2 text-xs">
+                <span
+                  className={`rounded px-1.5 py-0.5 font-medium ${
+                    entry.access === 'write'
+                      ? 'bg-sky-500/15 text-sky-300'
+                      : 'bg-slate-700/40 text-slate-300'
+                  }`}
+                >
+                  {entry.access === 'write' ? 'RW' : 'RO'}
+                </span>
+                <span className="truncate font-mono text-slate-300">{entry.key}</span>
+              </li>
+            ))}
+            {remaining.length > 0 && (
+              <li>
+                <details>
+                  <summary className="cursor-pointer text-xs text-sky-400">
+                    and {remaining.length} more
+                  </summary>
+                  <ul className="mt-1 space-y-1">
+                    {remaining.map((entry) => (
+                      <li key={entry.key} className="flex items-center gap-2 text-xs">
+                        <span
+                          className={`rounded px-1.5 py-0.5 font-medium ${
+                            entry.access === 'write'
+                              ? 'bg-sky-500/15 text-sky-300'
+                              : 'bg-slate-700/40 text-slate-300'
+                          }`}
+                        >
+                          {entry.access === 'write' ? 'RW' : 'RO'}
+                        </span>
+                        <span className="truncate font-mono text-slate-300">{entry.key}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              </li>
+            )}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/wallet/TxModal.tsx
+++ b/src/components/wallet/TxModal.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useCallback } from 'react'
+import { FeeBreakdown } from '@/src/components/wallet/FeeBreakdown'
+import { usePreflightSimulation } from '@/src/hooks/usePreflightSimulation'
+import { transactionLabel, type SorobanTransaction } from '@/src/lib/stellar/transaction'
+
+function SkeletonBar() {
+  return (
+    <div className="space-y-1">
+      <div className="h-3 w-40 animate-pulse rounded bg-slate-700/60" />
+      <div className="h-1.5 w-full animate-pulse rounded-full bg-slate-800" />
+    </div>
+  )
+}
+
+function PreflightSkeleton() {
+  return (
+    <div className="space-y-4" data-testid="preflight-skeleton" aria-busy="true">
+      <SkeletonBar />
+      <SkeletonBar />
+      <SkeletonBar />
+      <div className="h-12 w-full animate-pulse rounded-xl bg-slate-800/60" />
+    </div>
+  )
+}
+
+/**
+ * Pre-flight transaction modal. On open it simulates the transaction and shows
+ * an accurate fee/resource breakdown before the user approves in their wallet.
+ * The "Approve in Wallet" action is enabled only once a result is available.
+ */
+export function TxModal({
+  transaction,
+  open,
+  onClose,
+  onApprove,
+}: {
+  transaction: SorobanTransaction | null
+  open: boolean
+  onClose: () => void
+  onApprove?: (transaction: SorobanTransaction) => void
+}) {
+  const state = usePreflightSimulation(transaction, { enabled: open })
+
+  const handleApprove = useCallback(() => {
+    if (transaction && state.result) onApprove?.(transaction)
+  }, [transaction, state.result, onApprove])
+
+  if (!open || !transaction) return null
+
+  const isLoading = state.status === 'loading'
+  const isEstimated = state.status === 'timeout' || state.status === 'fallback'
+  const canApprove = !isLoading && state.result !== null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Transaction pre-flight"
+      data-testid="tx-modal"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-3xl border border-white/10 bg-slate-900 p-6 text-white shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold">Confirm {transactionLabel(transaction.type)}</h2>
+            <p className="text-sm text-slate-400">Pre-flight resource &amp; fee estimate</p>
+          </div>
+          {isEstimated && (
+            <span
+              data-testid="estimated-badge"
+              className="rounded-full bg-amber-500/15 px-2.5 py-1 text-[10px] font-semibold text-amber-400"
+            >
+              {state.status === 'timeout' ? 'CONSERVATIVE ESTIMATE' : 'ESTIMATED (SIMULATION UNAVAILABLE)'}
+            </span>
+          )}
+          {state.status === 'success' && state.fromCache && (
+            <span className="rounded-full bg-slate-700/40 px-2.5 py-1 text-[10px] font-semibold text-slate-300">
+              CACHED
+            </span>
+          )}
+        </div>
+
+        {state.timedOut && (
+          <p
+            data-testid="timeout-warning"
+            className="mb-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300"
+          >
+            Simulation timing out — using conservative estimate.
+          </p>
+        )}
+
+        <div className="mb-5">
+          {isLoading || !state.result ? (
+            <PreflightSkeleton />
+          ) : (
+            <FeeBreakdown result={state.result} />
+          )}
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 rounded-xl border border-white/10 px-4 py-2.5 text-sm font-medium text-slate-300 hover:bg-white/5"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleApprove}
+            disabled={!canApprove}
+            data-testid="approve-wallet"
+            className="flex-1 rounded-xl bg-sky-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
+          >
+            {isLoading ? 'Simulating…' : 'Approve in Wallet'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/config/feeEstimates.json
+++ b/src/config/feeEstimates.json
@@ -1,0 +1,7 @@
+{
+  "stake": { "instructions": 5000000, "writeBytes": 5000, "readBytes": 10000 },
+  "unstake": { "instructions": 4500000, "writeBytes": 4000, "readBytes": 9000 },
+  "delegate": { "instructions": 3000000, "writeBytes": 3000, "readBytes": 7000 },
+  "registerNode": { "instructions": 8000000, "writeBytes": 12000, "readBytes": 15000 },
+  "submitAttestation": { "instructions": 2000000, "writeBytes": 1500, "readBytes": 5000 }
+}

--- a/src/hooks/usePreflightCache.ts
+++ b/src/hooks/usePreflightCache.ts
@@ -1,0 +1,69 @@
+'use client'
+
+import { useMemo } from 'react'
+import type { SimulationResult } from '@/src/lib/api/simulate'
+
+/** Cached simulation results live for 60 seconds. */
+export const PREFLIGHT_TTL_MS = 60_000
+
+interface CacheEntry {
+  result: SimulationResult
+  expiresAt: number
+}
+
+// Module-level so the cache survives modal close/reopen within the session.
+const cache = new Map<string, CacheEntry>()
+
+/**
+ * SHA-256 hex of the transaction XDR — the cache key. Uses Web Crypto when
+ * available (browser / Node ≥ 20) and falls back to a non-crypto FNV-1a hash
+ * only when SubtleCrypto is absent (so keys are always derivable).
+ */
+export async function preflightCacheKey(xdr: string): Promise<string> {
+  const subtle = globalThis.crypto?.subtle
+  if (subtle) {
+    const digest = await subtle.digest('SHA-256', new TextEncoder().encode(xdr))
+    return Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('')
+  }
+  let hash = 0x811c9dc5
+  for (let i = 0; i < xdr.length; i++) {
+    hash ^= xdr.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return `fnv-${(hash >>> 0).toString(16)}`
+}
+
+export interface PreflightCache {
+  get: (key: string, now?: number) => SimulationResult | null
+  set: (key: string, result: SimulationResult, now?: number) => void
+  clear: () => void
+}
+
+/**
+ * Access the shared pre-flight result cache (keyed by SHA-256 of the tx XDR,
+ * 60s TTL). Returns a stable handle so it can be used as an effect dependency.
+ */
+export function usePreflightCache(): PreflightCache {
+  return useMemo<PreflightCache>(
+    () => ({
+      get(key, now = Date.now()) {
+        const entry = cache.get(key)
+        if (!entry) return null
+        if (entry.expiresAt <= now) {
+          cache.delete(key)
+          return null
+        }
+        return entry.result
+      },
+      set(key, result, now = Date.now()) {
+        cache.set(key, { result, expiresAt: now + PREFLIGHT_TTL_MS })
+      },
+      clear() {
+        cache.clear()
+      },
+    }),
+    [],
+  )
+}

--- a/src/hooks/usePreflightSimulation.ts
+++ b/src/hooks/usePreflightSimulation.ts
@@ -1,0 +1,103 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { SorobanTransaction } from '@/src/lib/stellar/transaction'
+import { getFallbackEstimate, simulateTransaction, type SimulationResult } from '@/src/lib/api/simulate'
+import { preflightCacheKey, usePreflightCache } from '@/src/hooks/usePreflightCache'
+
+/** Maximum simulation time before showing a conservative estimate. */
+export const PREFLIGHT_TIMEOUT_MS = 2000
+
+export type PreflightStatus = 'idle' | 'loading' | 'success' | 'timeout' | 'fallback'
+
+export interface PreflightState {
+  result: SimulationResult | null
+  status: PreflightStatus
+  fromCache: boolean
+  /** True when the 2s budget elapsed and a conservative estimate is shown. */
+  timedOut: boolean
+}
+
+interface UsePreflightOptions {
+  enabled?: boolean
+  timeoutMs?: number
+}
+
+const IDLE: PreflightState = { result: null, status: 'idle', fromCache: false, timedOut: false }
+
+/**
+ * Orchestrates the pre-flight simulation lifecycle:
+ *   cache hit → success · in-flight → loading · >2s → timeout (+fallback) ·
+ *   RPC error → fallback. Successful results are cached for 60s.
+ */
+export function usePreflightSimulation(
+  transaction: SorobanTransaction | null,
+  options: UsePreflightOptions = {},
+): PreflightState {
+  const { enabled = true, timeoutMs = PREFLIGHT_TIMEOUT_MS } = options
+  const cache = usePreflightCache()
+
+  const [state, setState] = useState<PreflightState>(IDLE)
+
+  // Reset to loading the moment the tracked transaction changes (during render).
+  const xdr = transaction?.xdr
+  const [trackedXdr, setTrackedXdr] = useState<string | undefined>(undefined)
+  if (trackedXdr !== xdr) {
+    setTrackedXdr(xdr)
+    setState(xdr && enabled ? { ...IDLE, status: 'loading' } : IDLE)
+  }
+
+  useEffect(() => {
+    if (!transaction || !enabled) return
+
+    let cancelled = false
+    let settled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    const run = async () => {
+      const key = await preflightCacheKey(transaction.xdr)
+      if (cancelled) return
+
+      const cached = cache.get(key)
+      if (cached) {
+        setState({ result: cached, status: 'success', fromCache: true, timedOut: false })
+        return
+      }
+
+      setState({ result: null, status: 'loading', fromCache: false, timedOut: false })
+
+      timer = setTimeout(() => {
+        if (cancelled || settled) return
+        setState((prev) =>
+          prev.status === 'loading'
+            ? { result: getFallbackEstimate(transaction), status: 'timeout', fromCache: false, timedOut: true }
+            : prev,
+        )
+      }, timeoutMs)
+
+      try {
+        const result = await simulateTransaction(transaction)
+        if (cancelled) return
+        settled = true
+        if (result.success) {
+          cache.set(key, result)
+          setState({ result, status: 'success', fromCache: false, timedOut: false })
+        } else {
+          setState({ result: getFallbackEstimate(transaction), status: 'fallback', fromCache: false, timedOut: false })
+        }
+      } catch {
+        if (cancelled) return
+        settled = true
+        setState({ result: getFallbackEstimate(transaction), status: 'fallback', fromCache: false, timedOut: false })
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [transaction, enabled, timeoutMs, cache])
+
+  return state
+}

--- a/src/lib/api/simulate.ts
+++ b/src/lib/api/simulate.ts
@@ -1,0 +1,152 @@
+// Pre-flight Soroban simulation API.
+//
+// Calls POST /api/v1/simulate/transaction (a thin proxy over the Soroban RPC
+// `simulateTransaction` method) and normalizes the response. On failure the
+// caller falls back to the static, per-type estimates in feeEstimates.json.
+
+import type { SorobanTransaction, TransactionType } from '@/src/lib/stellar/transaction'
+import { transactionLabel } from '@/src/lib/stellar/transaction'
+import feeEstimates from '@/src/config/feeEstimates.json'
+
+const SIMULATE_ENDPOINT = '/api/v1/simulate/transaction'
+
+export interface StorageFootprint {
+  readOnly: string[]
+  readWrite: string[]
+}
+
+export interface StateChange {
+  key: string
+  kind: 'created' | 'updated' | 'removed'
+}
+
+export interface OperationCost {
+  type: TransactionType
+  label: string
+  instructions: number
+  writeBytes: number
+  readBytes: number
+}
+
+export interface SimulationResult {
+  success: boolean
+  instructions: number
+  writeBytes: number
+  readBytes: number
+  footprint: StorageFootprint
+  stateChanges: StateChange[]
+  operations: OperationCost[]
+  /** True when the result is a static estimate (simulation unavailable). */
+  estimated: boolean
+  error?: string
+}
+
+/** Wire shape returned by the simulation endpoint (mirrors RPC `cost`). */
+interface SimulateWireResponse {
+  success: boolean
+  cost: { instructions: number; writeBytes: number; readBytes: number }
+  footprint?: Partial<StorageFootprint>
+  stateChanges?: StateChange[]
+  operations?: Array<{
+    type: TransactionType
+    label?: string
+    cost: { instructions: number; writeBytes: number; readBytes: number }
+  }>
+  error?: string
+}
+
+type FeeEstimate = { instructions: number; writeBytes: number; readBytes: number }
+const ESTIMATES = feeEstimates as Record<TransactionType, FeeEstimate>
+
+function normalize(wire: SimulateWireResponse, tx: SorobanTransaction): SimulationResult {
+  const operations: OperationCost[] = (wire.operations ?? []).map((op) => ({
+    type: op.type,
+    label: op.label ?? transactionLabel(op.type),
+    instructions: op.cost.instructions,
+    writeBytes: op.cost.writeBytes,
+    readBytes: op.cost.readBytes,
+  }))
+
+  return {
+    success: wire.success,
+    instructions: wire.cost.instructions,
+    writeBytes: wire.cost.writeBytes,
+    readBytes: wire.cost.readBytes,
+    footprint: {
+      readOnly: wire.footprint?.readOnly ?? [],
+      readWrite: wire.footprint?.readWrite ?? [],
+    },
+    stateChanges: wire.stateChanges ?? [],
+    operations:
+      operations.length > 0
+        ? operations
+        : tx.operations.map((op) => ({
+            type: op.type,
+            label: op.label,
+            instructions: wire.cost.instructions,
+            writeBytes: wire.cost.writeBytes,
+            readBytes: wire.cost.readBytes,
+          })),
+    estimated: false,
+    error: wire.error,
+  }
+}
+
+/**
+ * Run a pre-flight simulation. Throws on network/HTTP/parse failure so the
+ * orchestrator can apply the conservative fallback estimate.
+ */
+export async function simulateTransaction(tx: SorobanTransaction): Promise<SimulationResult> {
+  const response = await fetch(SIMULATE_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ xdr: tx.xdr, type: tx.type }),
+  })
+  if (!response.ok) {
+    throw new Error(`Simulation failed: HTTP ${response.status}`)
+  }
+  const wire = (await response.json()) as SimulateWireResponse
+  return normalize(wire, tx)
+}
+
+/**
+ * Conservative static estimate from feeEstimates.json, distributed evenly
+ * across the transaction's operations. Flagged `estimated` so the UI can show
+ * an "Estimated (simulation unavailable)" badge.
+ */
+export function getFallbackEstimate(tx: SorobanTransaction): SimulationResult {
+  const totalOps = Math.max(1, tx.operations.length)
+  const operations: OperationCost[] = tx.operations.map((op) => {
+    const est = ESTIMATES[op.type]
+    return {
+      type: op.type,
+      label: op.label,
+      instructions: est.instructions,
+      writeBytes: est.writeBytes,
+      readBytes: est.readBytes,
+    }
+  })
+
+  const sum = operations.reduce(
+    (acc, op) => ({
+      instructions: acc.instructions + op.instructions,
+      writeBytes: acc.writeBytes + op.writeBytes,
+      readBytes: acc.readBytes + op.readBytes,
+    }),
+    { instructions: 0, writeBytes: 0, readBytes: 0 },
+  )
+
+  // Single-op transactions read straight from the table.
+  const base = totalOps === 1 ? operations[0] : sum
+
+  return {
+    success: true,
+    instructions: base.instructions,
+    writeBytes: base.writeBytes,
+    readBytes: base.readBytes,
+    footprint: { readOnly: [], readWrite: [] },
+    stateChanges: [],
+    operations,
+    estimated: true,
+  }
+}

--- a/src/lib/stellar/transaction.ts
+++ b/src/lib/stellar/transaction.ts
@@ -1,0 +1,98 @@
+// Soroban transaction model + resource→fee math for pre-flight estimation.
+
+import { SorobanBalance } from '@/src/utils/sorobanMath'
+
+export type TransactionType =
+  | 'stake'
+  | 'unstake'
+  | 'delegate'
+  | 'registerNode'
+  | 'submitAttestation'
+
+export const TRANSACTION_TYPES: TransactionType[] = [
+  'stake',
+  'unstake',
+  'delegate',
+  'registerNode',
+  'submitAttestation',
+]
+
+export interface SorobanOperation {
+  type: TransactionType
+  label: string
+}
+
+export interface SorobanTransaction {
+  type: TransactionType
+  /** Base64 transaction XDR — the cache key source for pre-flight results. */
+  xdr: string
+  /** Operations for multi-step transactions (e.g. stake + delegate). */
+  operations: SorobanOperation[]
+}
+
+// Soroban per-transaction resource ceilings (illustrative mainnet bounds).
+export const INSTRUCTION_LIMIT = 100_000_000
+export const WRITE_BYTES_LIMIT = 129_024
+export const READ_BYTES_LIMIT = 204_800
+
+const FEE_INSTRUCTION_WEIGHT = BigInt(100)
+const FEE_WRITE_WEIGHT = BigInt(1000)
+const FEE_READ_WEIGHT = BigInt(10)
+
+const TYPE_LABELS: Record<TransactionType, string> = {
+  stake: 'Stake',
+  unstake: 'Unstake',
+  delegate: 'Delegate',
+  registerNode: 'Register Node',
+  submitAttestation: 'Submit Attestation',
+}
+
+export function transactionLabel(type: TransactionType): string {
+  return TYPE_LABELS[type]
+}
+
+/**
+ * Fee in stroops (XLM atomic units, 1e-7 XLM):
+ *   fee_XLM = (instructions·100 + writeBytes·1000 + readBytes·10) / 10^7
+ * so the numerator is exactly the fee expressed in stroops.
+ */
+export function computeFeeStroops(
+  instructions: number,
+  writeBytes: number,
+  readBytes: number,
+): bigint {
+  return (
+    BigInt(Math.max(0, Math.trunc(instructions))) * FEE_INSTRUCTION_WEIGHT +
+    BigInt(Math.max(0, Math.trunc(writeBytes))) * FEE_WRITE_WEIGHT +
+    BigInt(Math.max(0, Math.trunc(readBytes))) * FEE_READ_WEIGHT
+  )
+}
+
+/** Estimated fee as a SorobanBalance (XLM), ready for <FormattedBalance>. */
+export function computeFee(
+  instructions: number,
+  writeBytes: number,
+  readBytes: number,
+): SorobanBalance {
+  return SorobanBalance.fromAtomicUnits(computeFeeStroops(instructions, writeBytes, readBytes))
+}
+
+function toBase64(input: string): string {
+  if (typeof btoa === 'function') return btoa(unescape(encodeURIComponent(input)))
+  // Node / SSR fallback.
+  return Buffer.from(input, 'utf-8').toString('base64')
+}
+
+/**
+ * Build a (demo) Soroban transaction. The XDR is deterministic for a given
+ * (type, operations, params) so identical invocations hit the pre-flight cache.
+ */
+export function buildTransaction(
+  type: TransactionType,
+  options: { operations?: TransactionType[]; params?: Record<string, unknown> } = {},
+): SorobanTransaction {
+  const opTypes = options.operations && options.operations.length > 0 ? options.operations : [type]
+  const operations: SorobanOperation[] = opTypes.map((t) => ({ type: t, label: transactionLabel(t) }))
+  const xdr = toBase64(`${type}|${opTypes.join(',')}|${JSON.stringify(options.params ?? {})}`)
+  return { type, xdr, operations }
+}


### PR DESCRIPTION
Closes #12.

- lib/stellar/transaction.ts: SorobanTransaction model + builder, resource limits, and the fee formula ((instructions*100 + writeBytes*1000 + readBytes*10) / 10^7 XLM) as a SorobanBalance
- lib/api/simulate.ts: simulateTransaction() over /api/v1/simulate/transaction
  + getFallbackEstimate() from config/feeEstimates.json
- config/feeEstimates.json: per-type conservative estimates
- hooks/usePreflightCache.ts: SHA-256(xdr)-keyed result cache, 60s TTL Map
- hooks/usePreflightSimulation.ts: lifecycle orchestrator — cache hit, 2s timeout -> conservative estimate, RPC error -> fallback
- components/wallet/FeeBreakdown.tsx: instruction/byte bars vs limits, fee via FormattedBalance, storage footprint (truncated 5 + 'and N more'), per-op accordion for multi-step txs
- components/wallet/TxModal.tsx: skeleton loader, timeout warning, estimated badge, Approve enabled only after simulation completes
- app/wallet/preflight: demo/mount page
- e2e/preflight-fee-estimation.spec.ts: Playwright test (mock endpoint, assert breakdown values + fee + Approve gating + fallback)