### PR TITLE
Gwei to eth precision arithmetic

### DIFF
--- a/src/__tests__/gweiMath.test.ts
+++ b/src/__tests__/gweiMath.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { add, compound, div, formatGwei, mul, parseGwei, pct, sub } from '../utils/gweiMath'
+import { PrecisionOverflowError, UINT256_MAX } from '../utils/overflowGuard'
+
+describe('gweiMath', () => {
+  it('parses only integer gwei strings', () => {
+    expect(parseGwei('1000000000')).toBe(BigInt(1_000_000_000))
+    expect(() => parseGwei('1.5')).toThrow(TypeError)
+  })
+
+  it('performs BigInt arithmetic and fixed-point division', () => {
+    expect(add('2', BigInt(3))).toBe(BigInt(5))
+    expect(sub('5', '3')).toBe(BigInt(2))
+    expect(mul('7', 6)).toBe(BigInt(42))
+    expect(div('1', '2')).toBe(BigInt(500_000_000_000_000_000))
+  })
+
+  it('truncates ETH display to gwei precision', () => {
+    expect(formatGwei(BigInt(1_234_567_891), 'eth', 6)).toBe('1.234567 ETH')
+    expect(formatGwei(BigInt(1_234_567_891), 'eth')).toBe('1.234567891 ETH')
+  })
+
+  it('calculates percentage and compound projections without floating point ETH math', () => {
+    expect(pct(BigInt(100_000_000_000), 5)).toBe(BigInt(5_000_000_000))
+    expect(compound(BigInt(100_000_000_000), 12, 12)).toBeGreaterThan(BigInt(112_000_000_000))
+  })
+
+  it('guards uint256 overflow', () => {
+    expect(() => add(UINT256_MAX, BigInt(1))).toThrow(PrecisionOverflowError)
+  })
+})

--- a/src/components/validators/StakingCalculator.tsx
+++ b/src/components/validators/StakingCalculator.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState } from 'react'
+import { useStakingCalculator } from '@/src/hooks/useStakingCalculator'
+
+const DEFAULT_PRINCIPAL_GWEI = (BigInt(32) * BigInt(1_000_000_000)).toString()
+
+export function StakingCalculator() {
+  const [principal, setPrincipal] = useState(DEFAULT_PRINCIPAL_GWEI)
+  const [rate, setRate] = useState(3.5)
+  const [periods, setPeriods] = useState(12)
+  const [unit, setUnit] = useState<'eth' | 'gwei'>('eth')
+  const calculation = useStakingCalculator({ principalGwei: principal || '0', annualRatePct: rate, compoundingPeriods: periods })
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/80 p-6 text-white">
+      <div className="mb-5 flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold">Staking Calculator</h2>
+          <p className="text-sm text-slate-400">Precision-safe BigInt calculations in gwei.</p>
+        </div>
+        <button type="button" onClick={() => setUnit((current) => current === 'eth' ? 'gwei' : 'eth')} className="rounded-full border border-white/10 px-4 py-2 text-sm text-slate-200">
+          Show {unit === 'eth' ? 'gwei' : 'ETH'}
+        </button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <label className="text-sm text-slate-300">Principal (gwei)
+          <input className="mt-2 w-full rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-white" value={principal} onChange={(event) => setPrincipal(event.target.value)} inputMode="numeric" />
+        </label>
+        <label className="text-sm text-slate-300">Annual rate (%)
+          <input className="mt-2 w-full rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-white" value={rate} onChange={(event) => setRate(Number(event.target.value))} type="number" step="0.01" />
+        </label>
+        <label className="text-sm text-slate-300">Compounding periods
+          <input className="mt-2 w-full rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-white" value={periods} onChange={(event) => setPeriods(Number(event.target.value))} type="number" min="0" step="1" />
+        </label>
+      </div>
+
+      <dl className="mt-6 grid gap-4 md:grid-cols-3">
+        <Stat label="Annual reward" value={calculation.format(calculation.annualRewardGwei, unit)} />
+        <Stat label="Compounded reward" value={calculation.format(calculation.compoundedRewardGwei, unit)} />
+        <Stat label="Projected balance" value={calculation.format(calculation.projectedGwei, unit)} />
+      </dl>
+    </section>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return <div className="rounded-2xl bg-slate-950/80 p-4"><dt className="text-xs uppercase tracking-wide text-slate-500">{label}</dt><dd className="mt-2 font-mono text-lg text-emerald-300">{value}</dd></div>
+}

--- a/src/components/validators/ValidatorDashboard.tsx
+++ b/src/components/validators/ValidatorDashboard.tsx
@@ -8,6 +8,7 @@ import { CommitteeTopologyMap } from '@/src/components/canvas/CommitteeTopologyM
 import { ShardLegend } from '@/src/components/validators/ShardLegend'
 import { useValidatorBalances } from '@/src/hooks/useValidatorBalances'
 import { useCommitteeAssignments } from '@/src/hooks/useCommitteeAssignments'
+import { StakingCalculator } from '@/src/components/validators/StakingCalculator'
 
 const DEFAULT_VALIDATORS = [100, 101, 102, 103, 104, 105]
 
@@ -36,6 +37,7 @@ export function ValidatorDashboard({
 
   return (
     <div className="space-y-6">
+      <StakingCalculator />
       <section className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 text-white">
         <button
           type="button"

--- a/src/hooks/useStakingCalculator.ts
+++ b/src/hooks/useStakingCalculator.ts
@@ -1,0 +1,27 @@
+'use client'
+
+import { useMemo } from 'react'
+import { compound, formatGwei, pct, parseGwei } from '../utils/gweiMath'
+
+export interface StakingCalculatorInput {
+  principalGwei: bigint | string
+  annualRatePct: number
+  compoundingPeriods: number
+}
+
+export function useStakingCalculator({ principalGwei, annualRatePct, compoundingPeriods }: StakingCalculatorInput) {
+  return useMemo(() => {
+    const principal = parseGwei(principalGwei)
+    const annualReward = pct(principal, annualRatePct)
+    const projected = compound(principal, annualRatePct, compoundingPeriods)
+    const compoundedReward = projected - principal
+
+    return {
+      principalGwei: principal,
+      annualRewardGwei: annualReward,
+      projectedGwei: projected,
+      compoundedRewardGwei: compoundedReward,
+      format: formatGwei,
+    }
+  }, [annualRatePct, compoundingPeriods, principalGwei])
+}

--- a/src/services/coingeckoService.ts
+++ b/src/services/coingeckoService.ts
@@ -1,0 +1,14 @@
+export interface CoinGeckoSimplePriceResponse {
+  ethereum?: Record<string, number>
+}
+
+export async function fetchEthPrice(currency = 'usd'): Promise<number> {
+  const response = await fetch(
+    `https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=${encodeURIComponent(currency.toLowerCase())}`,
+  )
+  if (!response.ok) throw new Error(`CoinGecko price request failed: ${response.status}`)
+  const payload = (await response.json()) as CoinGeckoSimplePriceResponse
+  const price = payload.ethereum?.[currency.toLowerCase()]
+  if (typeof price !== 'number' || !Number.isFinite(price)) throw new Error('CoinGecko response did not include a finite ETH price')
+  return price
+}

--- a/src/types/currency.ts
+++ b/src/types/currency.ts
@@ -1,0 +1,22 @@
+export type GweiAmount = bigint
+
+export type CurrencyCode = 'ETH' | 'GWEI' | 'USD' | (string & {})
+
+export interface CurrencyAmount {
+  amount: bigint
+  currency: CurrencyCode
+  decimals: number
+}
+
+export interface DisplayAmount {
+  value: string
+  unit: 'eth' | 'gwei' | 'fiat'
+  currency?: CurrencyCode
+}
+
+export interface FiatRate {
+  rate: bigint
+  decimals: number
+  currency: CurrencyCode
+  fetchedAt: number
+}

--- a/src/utils/fiatConversion.ts
+++ b/src/utils/fiatConversion.ts
@@ -1,0 +1,36 @@
+import { fetchEthPrice } from '../services/coingeckoService'
+import type { CurrencyAmount, FiatRate, GweiAmount } from '../types/currency'
+import { GWEI_PER_ETH } from './gweiMath'
+import { assertUint256, guarded } from './overflowGuard'
+
+const RATE_DECIMALS = 18
+const RATE_SCALE = BigInt(1_000_000_000_000_000_000)
+const CACHE_TTL_MS = 5 * 60 * 1000
+let cachedRate: FiatRate | null = null
+
+function numberToFixed(value: number, decimals: number): bigint {
+  const [whole, fraction = ''] = value.toFixed(decimals).split('.')
+  return BigInt(`${whole}${fraction.padEnd(decimals, '0')}`)
+}
+
+export async function getEthFiatRate(currency = 'USD'): Promise<FiatRate> {
+  const now = Date.now()
+  if (cachedRate && cachedRate.currency === currency && now - cachedRate.fetchedAt < CACHE_TTL_MS) return cachedRate
+  const rate = numberToFixed(await fetchEthPrice(currency), RATE_DECIMALS)
+  cachedRate = { rate, decimals: RATE_DECIMALS, currency, fetchedAt: now }
+  return cachedRate
+}
+
+export function convertGweiToFiat(gwei: GweiAmount, rate: FiatRate): CurrencyAmount {
+  const amount = guarded(() => (assertUint256(gwei) * rate.rate) / GWEI_PER_ETH / RATE_SCALE)
+  return { amount, currency: rate.currency, decimals: 0 }
+}
+
+export function convertGweiToFiatCents(gwei: GweiAmount, rate: FiatRate): CurrencyAmount {
+  const amount = guarded(() => (assertUint256(gwei) * rate.rate * BigInt(100)) / GWEI_PER_ETH / RATE_SCALE)
+  return { amount, currency: rate.currency, decimals: 2 }
+}
+
+export function clearFiatRateCache(): void {
+  cachedRate = null
+}

--- a/src/utils/gweiMath.ts
+++ b/src/utils/gweiMath.ts
@@ -1,0 +1,80 @@
+import { assertUint256, guarded } from './overflowGuard'
+
+export const ZERO = BigInt(0)
+export const GWEI_PER_ETH = BigInt(1_000_000_000)
+export const FIXED_POINT_DECIMALS = 18
+export const FIXED_POINT_SCALE = BigInt(1_000_000_000_000_000_000)
+const INTEGER_PATTERN = /^-?\d+$/
+
+export function parseGwei(value: bigint | string): bigint {
+  if (typeof value === 'bigint') return assertUint256(value)
+  if (!INTEGER_PATTERN.test(value)) {
+    throw new TypeError('Gwei string inputs must match /^-?\\d+$/')
+  }
+  return assertUint256(BigInt(value))
+}
+
+export function add(a: bigint | string, b: bigint | string): bigint {
+  return guarded(() => parseGwei(a) + parseGwei(b))
+}
+
+export function sub(a: bigint | string, b: bigint | string): bigint {
+  return guarded(() => parseGwei(a) - parseGwei(b))
+}
+
+export function mul(a: bigint | string, scalar: number): bigint {
+  if (!Number.isSafeInteger(scalar)) throw new TypeError('Scalar must be a safe integer')
+  return guarded(() => parseGwei(a) * BigInt(scalar))
+}
+
+export function div(a: bigint | string, b: bigint | string, precision = FIXED_POINT_DECIMALS): bigint {
+  const divisor = parseGwei(b)
+  if (divisor === ZERO) throw new RangeError('Cannot divide by zero')
+  if (!Number.isSafeInteger(precision) || precision < 0 || precision > 36) {
+    throw new RangeError('Precision must be a safe integer between 0 and 36')
+  }
+  const scale = BigInt(10) ** BigInt(precision)
+  return guarded(() => (parseGwei(a) * scale) / divisor)
+}
+
+function decimalToFixed(value: number, decimals = FIXED_POINT_DECIMALS): bigint {
+  if (!Number.isFinite(value)) throw new TypeError('Decimal value must be finite')
+  const sign = value < 0 ? '-' : ''
+  const [whole, fraction = ''] = Math.abs(value).toFixed(decimals).split('.')
+  return BigInt(`${sign}${whole}${fraction.padEnd(decimals, '0')}`)
+}
+
+export function pct(value: bigint | string, percentage: number): bigint {
+  const rate = decimalToFixed(percentage / 100)
+  return guarded(() => (parseGwei(value) * rate) / FIXED_POINT_SCALE)
+}
+
+export function compound(principal: bigint | string, annualRatePct: number, periods: number): bigint {
+  if (!Number.isSafeInteger(periods) || periods < 0) throw new RangeError('Periods must be a non-negative safe integer')
+  const periodRate = decimalToFixed(annualRatePct / 100 / Math.max(periods, 1))
+  let amount = parseGwei(principal)
+  for (let period = 0; period < periods; period += 1) {
+    amount = guarded(() => (amount * (FIXED_POINT_SCALE + periodRate)) / FIXED_POINT_SCALE)
+  }
+  return amount
+}
+
+export function formatGwei(value: bigint | string, unit: 'eth' | 'gwei' | 'fiat', decimals = unit === 'eth' ? 9 : 2): string {
+  const parsed = parseGwei(value)
+  const negative = parsed < ZERO
+  const abs = negative ? -parsed : parsed
+  const sign = negative ? '-' : ''
+
+  if (unit === 'gwei') return `${sign}${abs.toString()} gwei`
+
+  if (unit === 'eth') {
+    const whole = abs / GWEI_PER_ETH
+    const fraction = (abs % GWEI_PER_ETH).toString().padStart(9, '0').slice(0, Math.min(decimals, 9))
+    return decimals > 0 ? `${sign}${whole.toString()}.${fraction} ETH` : `${sign}${whole.toString()} ETH`
+  }
+
+  const scale = BigInt(10) ** BigInt(Math.max(0, decimals))
+  const whole = abs / scale
+  const fraction = (abs % scale).toString().padStart(decimals, '0')
+  return decimals > 0 ? `${sign}$${whole.toString()}.${fraction}` : `${sign}$${whole.toString()}`
+}

--- a/src/utils/overflowGuard.ts
+++ b/src/utils/overflowGuard.ts
@@ -1,0 +1,19 @@
+export const UINT256_MAX = (BigInt(1) << BigInt(256)) - BigInt(1)
+
+export class PrecisionOverflowError extends Error {
+  constructor(message = 'Precision arithmetic result exceeds uint256 bounds') {
+    super(message)
+    this.name = 'PrecisionOverflowError'
+  }
+}
+
+export function assertUint256(value: bigint): bigint {
+  if (value > UINT256_MAX || value < -UINT256_MAX) {
+    throw new PrecisionOverflowError()
+  }
+  return value
+}
+
+export function guarded(operation: () => bigint): bigint {
+  return assertUint256(operation())
+}


### PR DESCRIPTION
### Motivation
- Staking calculations must be precision-safe across gwei→ETH scales to avoid IEEE-754 float drift and preserve gwei precision for display and arithmetic. 
- Fiat conversions require deterministic fixed-point storage and short-term caching to avoid frequent network calls.
- All arithmetic must guard against huge results exceeding the target `uint256` bound.

### Description
- Add typed currency primitives in `src/types/currency.ts` and accept gwei inputs as `bigint | string` with integer-string validation (`/^-?\d+$/`).
- Implement a BigInt-first precision arithmetic layer in `src/utils/gweiMath.ts` with `add`, `sub`, `mul`, `div` (fixed-point, default 18 decimals), `pct`, `compound`, `parseGwei`, and `formatGwei` that truncates ETH display to gwei precision (up to 9 decimals).
- Add overflow protection in `src/utils/overflowGuard.ts` which throws `PrecisionOverflowError` when results exceed `2^256 - 1`.
- Provide CoinGecko ETH price fetching and fiat helpers in `src/services/coingeckoService.ts` and `src/utils/fiatConversion.ts` that store rates as `BigInt` with 18-decimal fixed precision and a 5-minute cache TTL.
- Expose a convenience hook `useStakingCalculator` in `src/hooks/useStakingCalculator.ts` that performs BigInt gwei projections (annual pct and compounding) and a `StakingCalculator` UI in `src/components/validators/StakingCalculator.tsx` that toggles ETH/gwei views and formats outputs via `formatGwei`.
- Mount the staking calculator in the validator dashboard at `src/components/validators/ValidatorDashboard.tsx` and add unit tests covering parsing, arithmetic, fixed-point division, formatting, pct/compound projections, and overflow in `src/__tests__/gweiMath.test.ts`.

### Testing
- Ran unit tests with `npm run test:unit -- src/__tests__/gweiMath.test.ts`, which passed (`5 passed`).
- Ran lint with `npm run lint`, which completed successfully but reported an existing warning in `src/hooks/useNodeList.ts`.
- Ran type-checking with `npx tsc --noEmit`, which completed successfully.

------

Closes #55 