### PR TITLE
feat(bridge): add cross-chain bridge transaction explorer (closes #95)

### DIFF
--- a/app/bridge/[id]/page.tsx
+++ b/app/bridge/[id]/page.tsx
@@ -1,0 +1,12 @@
+import { BridgeTransactionDetail } from '@/src/components/bridge/BridgeTransactionDetail'
+
+export default async function BridgeTransactionPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
+  return (
+    <main className="mx-auto min-h-screen max-w-4xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold text-white">Bridge Transaction</h1>
+      <BridgeTransactionDetail id={id} />
+    </main>
+  )
+}

--- a/app/bridge/page.tsx
+++ b/app/bridge/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { Suspense } from 'react'
+import { BridgeTransactionList } from '@/src/components/bridge/BridgeTransactionList'
+
+export default function BridgePage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-6xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold text-white">Cross-Chain Bridge Explorer</h1>
+      <Suspense fallback={<div className="p-8 text-slate-400">Loading…</div>}>
+        <BridgeTransactionList />
+      </Suspense>
+    </main>
+  )
+}

--- a/src/components/bridge/BridgeFailureRecovery.tsx
+++ b/src/components/bridge/BridgeFailureRecovery.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useState } from 'react'
+import { claimStuckDeposit, retryBridgeTransaction } from '@/src/lib/api/bridge'
+import type { BridgeFailureReason } from '@/src/types/bridge'
+
+type ActionState = 'idle' | 'pending' | 'success' | 'error'
+
+export interface BridgeFailureRecoveryProps {
+  transactionId: string
+  failureReason: BridgeFailureReason
+  onActionComplete?: () => void
+}
+
+/**
+ * Renders the failure reason plus, only when the failure type is one we
+ * understand, a single type-appropriate recovery action: Retry for gas
+ * failures, Claim for stuck deposits. An unrecognized failure type shows the
+ * reason with no button, rather than guessing at an action that might not
+ * apply. The action button is disabled while its request is in flight (both
+ * via the `disabled` attribute and an internal state check, so a rapid
+ * double-click before React re-renders still can't fire twice), and surfaces
+ * the request's own success/failure rather than assuming it worked.
+ */
+export function BridgeFailureRecovery({ transactionId, failureReason, onActionComplete }: BridgeFailureRecoveryProps) {
+  const [state, setState] = useState<ActionState>('idle')
+  const [actionErrorMessage, setActionErrorMessage] = useState<string | null>(null)
+
+  async function runAction(action: () => Promise<void>) {
+    if (state === 'pending') return
+    setState('pending')
+    setActionErrorMessage(null)
+    try {
+      await action()
+      setState('success')
+      onActionComplete?.()
+    } catch (err) {
+      setState('error')
+      setActionErrorMessage(err instanceof Error ? err.message : 'The request failed. Please try again.')
+    }
+  }
+
+  const isPending = state === 'pending'
+
+  return (
+    <div className="rounded-xl border border-red-500/30 bg-red-950/20 p-4">
+      <p role="alert" className="text-sm text-red-300">
+        {failureReason.message}
+      </p>
+
+      <div className="mt-3 flex items-center gap-3">
+        {failureReason.type === 'gas_failure' && (
+          <button
+            type="button"
+            disabled={isPending}
+            onClick={() => runAction(() => retryBridgeTransaction(transactionId))}
+            className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-white hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isPending ? 'Retrying…' : 'Retry'}
+          </button>
+        )}
+
+        {failureReason.type === 'stuck_deposit' && (
+          <button
+            type="button"
+            disabled={isPending}
+            onClick={() => runAction(() => claimStuckDeposit(transactionId))}
+            className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-white hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isPending ? 'Claiming…' : 'Claim'}
+          </button>
+        )}
+
+        {state === 'success' && (
+          <span role="status" className="text-xs text-emerald-400">
+            Submitted - refreshing status…
+          </span>
+        )}
+      </div>
+
+      {state === 'error' && (
+        <p role="alert" className="mt-2 text-xs text-red-400">
+          {actionErrorMessage}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/bridge/BridgeNotificationToggle.tsx
+++ b/src/components/bridge/BridgeNotificationToggle.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useBridgeNotifications } from '@/src/hooks/useBridgeNotifications'
+import type { BridgeTransaction } from '@/src/types/bridge'
+
+export interface BridgeNotificationToggleProps {
+  transactions: BridgeTransaction[]
+}
+
+/**
+ * Opt-in control for status-change notifications. Notification.requestPermission()
+ * is only ever called from this button's onClick (a user gesture) - never on
+ * mount. Renders nothing when the Notification API isn't available (SSR /
+ * unsupported browser) rather than showing a control that can't work.
+ */
+export function BridgeNotificationToggle({ transactions }: BridgeNotificationToggleProps) {
+  const { supported, permission, enabled, requestEnable, disable } = useBridgeNotifications(transactions)
+
+  if (!supported) return null
+
+  if (permission === 'denied') {
+    return <span className="text-xs text-slate-500">Notifications blocked in browser settings</span>
+  }
+
+  return (
+    <button
+      type="button"
+      aria-pressed={enabled}
+      onClick={() => (enabled ? disable() : requestEnable())}
+      className="rounded-lg border border-white/10 px-3 py-1.5 text-xs font-medium text-slate-200 hover:bg-white/5"
+    >
+      {enabled ? 'Notifications on' : 'Enable notifications'}
+    </button>
+  )
+}

--- a/src/components/bridge/BridgeStatusStepper.tsx
+++ b/src/components/bridge/BridgeStatusStepper.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { BRIDGE_PIPELINE_STAGES, isBridgeFailureStatus, type BridgeFailureReason, type BridgeTxStatus } from '@/src/types/bridge'
+import { bridgeStatusLabel } from '@/src/utils/bridgeFormat'
+import { BRIDGE_STAGE_DOT_CLASSES, BRIDGE_STAGE_ICONS, BRIDGE_STAGE_STATUS_TEXT, getStageStatuses } from '@/src/utils/bridgeStages'
+
+export interface BridgeStatusStepperProps {
+  status: BridgeTxStatus
+  failureReason?: BridgeFailureReason | null
+}
+
+/**
+ * Compact per-row stage stepper for the transaction table. Each stage is a
+ * small dot carrying an icon glyph (not color alone) plus a title tooltip;
+ * the whole stepper has a single aria-label summarizing current state so
+ * screen readers get one clear announcement instead of five dot readouts.
+ */
+export function BridgeStatusStepper({ status, failureReason }: BridgeStatusStepperProps) {
+  const stageStatuses = getStageStatuses(status)
+  const summary = isBridgeFailureStatus(status)
+    ? `Failed: ${failureReason?.message ?? bridgeStatusLabel(status)}`
+    : `${bridgeStatusLabel(status)}, stage ${BRIDGE_PIPELINE_STAGES.indexOf(status) + 1} of ${BRIDGE_PIPELINE_STAGES.length}`
+
+  return (
+    <ol aria-label={`Bridge progress: ${summary}`} className="flex items-center">
+      {BRIDGE_PIPELINE_STAGES.map((stage, i) => {
+        const stageStatus = stageStatuses[i]
+        return (
+          <li key={stage} className="flex items-center">
+            <span
+              aria-current={stageStatus === 'current' || stageStatus === 'failed' ? 'step' : undefined}
+              title={`${bridgeStatusLabel(stage)} - ${BRIDGE_STAGE_STATUS_TEXT[stageStatus]}`}
+              className={`flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-bold leading-none text-white ${BRIDGE_STAGE_DOT_CLASSES[stageStatus]}`}
+            >
+              <span aria-hidden="true">{BRIDGE_STAGE_ICONS[stageStatus]}</span>
+            </span>
+            {i < BRIDGE_PIPELINE_STAGES.length - 1 && <span aria-hidden="true" className="h-px w-2 bg-slate-700" />}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/src/components/bridge/BridgeTransactionDetail.tsx
+++ b/src/components/bridge/BridgeTransactionDetail.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { format } from 'date-fns'
+import { useBridgeTransactionDetail } from '@/src/hooks/useBridgeTransactionDetail'
+import { BRIDGE_CHAIN_META, bridgeChainName } from '@/src/config/bridgeChains'
+import { BridgeStatusStepper } from '@/src/components/bridge/BridgeStatusStepper'
+import { BridgeTransactionTimeline } from '@/src/components/bridge/BridgeTransactionTimeline'
+import { BridgeFailureRecovery } from '@/src/components/bridge/BridgeFailureRecovery'
+
+export interface BridgeTransactionDetailProps {
+  id: string
+}
+
+export function BridgeTransactionDetail({ id }: BridgeTransactionDetailProps) {
+  const { transaction, isLoading, isError, error, refresh } = useBridgeTransactionDetail(id)
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3 rounded-2xl border border-white/10 bg-slate-950/40 p-6">
+        <div className="h-6 w-1/3 animate-pulse rounded bg-slate-800" />
+        <div className="h-4 w-2/3 animate-pulse rounded bg-slate-800" />
+        <div className="h-32 w-full animate-pulse rounded bg-slate-800" />
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div role="alert" className="rounded-2xl border border-red-500/30 bg-red-950/20 p-6 text-sm text-red-300">
+        {error?.message ?? 'Failed to load this bridge transaction.'}
+      </div>
+    )
+  }
+
+  if (!transaction) {
+    return (
+      <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-6 text-sm text-slate-400">
+        Transaction not found.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6 rounded-2xl border border-white/10 bg-slate-950/40 p-6 text-white">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold">
+            {bridgeChainName(transaction.sourceChain)} → {bridgeChainName(transaction.destChain)}
+          </h2>
+          <p className="text-sm text-slate-400">
+            {transaction.amount} {transaction.tokenSymbol} · Initiated {format(new Date(transaction.initiatedAt), 'MMM d, yyyy HH:mm')}
+          </p>
+        </div>
+        <BridgeStatusStepper status={transaction.status} failureReason={transaction.failureReason} />
+      </div>
+
+      <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-slate-400">
+        <a
+          href={BRIDGE_CHAIN_META[transaction.sourceChain].explorerTxUrl(transaction.sourceTxHash)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-slate-200"
+        >
+          Source tx on {bridgeChainName(transaction.sourceChain)}
+        </a>
+        {transaction.destTxHash ? (
+          <a
+            href={BRIDGE_CHAIN_META[transaction.destChain].explorerTxUrl(transaction.destTxHash)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-slate-200"
+          >
+            Destination tx on {bridgeChainName(transaction.destChain)}
+          </a>
+        ) : (
+          <span>Destination tx: pending</span>
+        )}
+      </div>
+
+      {transaction.failureReason && (
+        <BridgeFailureRecovery
+          transactionId={transaction.id}
+          failureReason={transaction.failureReason}
+          onActionComplete={refresh}
+        />
+      )}
+
+      <BridgeTransactionTimeline tx={transaction} />
+    </div>
+  )
+}

--- a/src/components/bridge/BridgeTransactionList.tsx
+++ b/src/components/bridge/BridgeTransactionList.tsx
@@ -1,0 +1,262 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { format } from 'date-fns'
+import { useBridgeTx } from '@/src/hooks/useBridgeTx'
+import { BRIDGE_CHAINS, BRIDGE_TX_STATUS, type BridgeChain, type BridgeTxStatus } from '@/src/types/bridge'
+import { bridgeChainName } from '@/src/config/bridgeChains'
+import { bridgeStatusLabel } from '@/src/utils/bridgeFormat'
+import { BridgeStatusStepper } from '@/src/components/bridge/BridgeStatusStepper'
+import { EstimatedCompletion } from '@/src/components/bridge/EstimatedCompletion'
+import { BridgeNotificationToggle } from '@/src/components/bridge/BridgeNotificationToggle'
+
+const PAGE_SIZE = 20
+
+function parseChain(value: string | null): BridgeChain | undefined {
+  return (BRIDGE_CHAINS as readonly string[]).includes(value ?? '') ? (value as BridgeChain) : undefined
+}
+
+function parseStatus(value: string | null): BridgeTxStatus | undefined {
+  return (BRIDGE_TX_STATUS as readonly string[]).includes(value ?? '') ? (value as BridgeTxStatus) : undefined
+}
+
+function parsePage(value: string | null): number {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1
+}
+
+function SkeletonRow() {
+  return (
+    <tr className="border-b border-white/5">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <td key={i} className="px-4 py-3">
+          <div className="h-4 w-full animate-pulse rounded bg-slate-800" />
+        </td>
+      ))}
+    </tr>
+  )
+}
+
+/**
+ * Cross-chain bridge transaction table: filters (chain/status/date range) and
+ * pagination are both server-side, driven entirely by URL search params so the
+ * view is shareable/bookmarkable and survives a refresh. Rows are keyed by
+ * transaction id and rendered in the order the API returns them (assumed
+ * newest-first) so a background poll patches values in place instead of
+ * remounting or reordering rows.
+ */
+export function BridgeTransactionList() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const chain = parseChain(searchParams.get('chain'))
+  const status = parseStatus(searchParams.get('status'))
+  const dateFrom = searchParams.get('dateFrom') ?? undefined
+  const dateTo = searchParams.get('dateTo') ?? undefined
+  const page = parsePage(searchParams.get('page'))
+
+  const hasActiveFilter = Boolean(chain || status || dateFrom || dateTo)
+
+  const { transactions, total, isLoading, isFetching, isError, error, hasActive } = useBridgeTx({
+    chain,
+    status,
+    dateFrom,
+    dateTo,
+    page,
+    pageSize: PAGE_SIZE,
+  })
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  // Date.now() is a read of an external system (the wall clock), which is
+  // exactly what effects are for - calling it during render is disallowed
+  // (it's impure), so `now` only advances inside this effect, and only when
+  // a poll actually brings in a new transactions array (not on every render).
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing from an external source (the clock), not deriving from props/state
+    setNow(Date.now())
+  }, [transactions])
+
+  function updateParams(updates: Record<string, string | undefined>, resetPage: boolean) {
+    const next = new URLSearchParams(searchParams.toString())
+    for (const [key, value] of Object.entries(updates)) {
+      if (value) next.set(key, value)
+      else next.delete(key)
+    }
+    if (resetPage) next.delete('page')
+    router.replace(`${pathname}?${next.toString()}`, { scroll: false })
+  }
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-950/40 text-white">
+      <div className="flex flex-wrap items-end justify-between gap-4 border-b border-white/10 p-4">
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1 text-xs text-slate-400">
+            Chain
+            <select
+              value={chain ?? ''}
+              onChange={(e) => updateParams({ chain: e.target.value || undefined }, true)}
+              className="rounded-lg border border-white/10 bg-slate-900 px-2 py-1.5 text-sm text-white"
+            >
+              <option value="">All chains</option>
+              {BRIDGE_CHAINS.map((c) => (
+                <option key={c} value={c}>
+                  {bridgeChainName(c)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-xs text-slate-400">
+            Status
+            <select
+              value={status ?? ''}
+              onChange={(e) => updateParams({ status: e.target.value || undefined }, true)}
+              className="rounded-lg border border-white/10 bg-slate-900 px-2 py-1.5 text-sm text-white"
+            >
+              <option value="">All statuses</option>
+              {BRIDGE_TX_STATUS.map((s) => (
+                <option key={s} value={s}>
+                  {bridgeStatusLabel(s)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-xs text-slate-400">
+            From
+            <input
+              type="date"
+              value={dateFrom ?? ''}
+              onChange={(e) => updateParams({ dateFrom: e.target.value || undefined }, true)}
+              className="rounded-lg border border-white/10 bg-slate-900 px-2 py-1.5 text-sm text-white"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-xs text-slate-400">
+            To
+            <input
+              type="date"
+              value={dateTo ?? ''}
+              onChange={(e) => updateParams({ dateTo: e.target.value || undefined }, true)}
+              className="rounded-lg border border-white/10 bg-slate-900 px-2 py-1.5 text-sm text-white"
+            />
+          </label>
+        </div>
+
+        <div className="flex items-center gap-3 text-xs text-slate-400">
+          <BridgeNotificationToggle transactions={transactions} />
+          {isFetching && !isLoading && (
+            <span role="status" aria-live="polite">
+              Updating…
+            </span>
+          )}
+          {hasActive && !isFetching && <span>Live</span>}
+        </div>
+      </div>
+
+      {isError && (
+        <p role="alert" className="px-4 py-3 text-sm text-red-400">
+          {error?.message ?? 'Failed to load bridge transactions.'}
+        </p>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[880px] text-left text-sm">
+          <caption className="sr-only">Cross-chain bridge transactions</caption>
+          <thead className="text-xs uppercase tracking-wide text-slate-500">
+            <tr className="border-b border-white/10">
+              <th scope="col" className="px-4 py-3 font-medium">
+                Route
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Amount
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Status
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Est. Completion
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Initiated
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                <span className="sr-only">Details</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading &&
+              transactions.length === 0 &&
+              Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)}
+
+            {!isLoading && transactions.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-10 text-center text-sm text-slate-400">
+                  {hasActiveFilter ? 'No transactions match the current filters.' : 'No bridge transactions yet.'}
+                </td>
+              </tr>
+            )}
+
+            {transactions.map((tx) => (
+              <tr key={tx.id} className="border-b border-white/5 text-slate-200">
+                <td className="px-4 py-3">
+                  {bridgeChainName(tx.sourceChain)} → {bridgeChainName(tx.destChain)}
+                </td>
+                <td className="px-4 py-3 tabular-nums">
+                  {tx.amount} {tx.tokenSymbol}
+                </td>
+                <td className="px-4 py-3">
+                  <BridgeStatusStepper status={tx.status} failureReason={tx.failureReason} />
+                </td>
+                <td className="px-4 py-3">
+                  <EstimatedCompletion tx={tx} now={now} />
+                </td>
+                <td className="px-4 py-3 text-slate-400">{format(new Date(tx.initiatedAt), 'MMM d, HH:mm')}</td>
+                <td className="px-4 py-3 text-right">
+                  <Link
+                    href={`/bridge/${tx.id}`}
+                    className="rounded-lg border border-white/10 px-3 py-1.5 text-xs font-medium text-slate-200 hover:bg-white/5"
+                  >
+                    View
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between gap-4 border-t border-white/10 px-4 py-3 text-sm text-slate-400">
+        <span>
+          Page {page} of {totalPages}
+        </span>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            aria-label="Previous page"
+            disabled={page <= 1}
+            onClick={() => updateParams({ page: String(page - 1) }, false)}
+            className="rounded-lg border border-white/10 px-3 py-1.5 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            aria-label="Next page"
+            disabled={page >= totalPages}
+            onClick={() => updateParams({ page: String(page + 1) }, false)}
+            className="rounded-lg border border-white/10 px-3 py-1.5 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/bridge/BridgeTransactionTimeline.tsx
+++ b/src/components/bridge/BridgeTransactionTimeline.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { formatDistanceStrict } from 'date-fns'
+import { BRIDGE_PIPELINE_STAGES, type BridgeTransaction } from '@/src/types/bridge'
+import { bridgeStatusLabel, formatDurationSeconds, formatUsd } from '@/src/utils/bridgeFormat'
+import { getBridgeRouteEstimateSeconds } from '@/src/config/bridgeChains'
+import {
+  BRIDGE_STAGE_DOT_CLASSES,
+  BRIDGE_STAGE_ICONS,
+  BRIDGE_STAGE_STATUS_TEXT,
+  getStageStatuses,
+} from '@/src/utils/bridgeStages'
+
+const PENDING = <span className="text-slate-500">Pending</span>
+
+function confirmationsForStage(
+  stage: (typeof BRIDGE_PIPELINE_STAGES)[number],
+  stageStatus: string,
+  tx: BridgeTransaction,
+) {
+  if (stage === 'source_confirmed') {
+    if (stageStatus === 'upcoming') return PENDING
+    return `${tx.sourceConfirmations}/${tx.requiredSourceConfirmations} confirmations`
+  }
+  if (stage === 'dest_confirmed') {
+    if (stageStatus === 'upcoming') return PENDING
+    return `${tx.destConfirmations}/${tx.requiredDestConfirmations} confirmations`
+  }
+  return null
+}
+
+/**
+ * Full five-stage timeline for the detail view: per-leg block confirmations,
+ * gas, USD cost, and estimated-vs-actual completion time. Any value that
+ * isn't knowable yet (destination gas pre-execution, USD cost the API hasn't
+ * priced, completion time before the transfer finishes) renders an explicit
+ * "Pending" label - never a bare 0, "-", or NaN standing in for unknown.
+ */
+export function BridgeTransactionTimeline({ tx }: { tx: BridgeTransaction }) {
+  const stageStatuses = getStageStatuses(tx.status)
+  const route = getBridgeRouteEstimateSeconds(tx.sourceChain, tx.destChain)
+
+  const estimatedLabel = route ? `${formatDurationSeconds(route.min)} - ${formatDurationSeconds(route.max)}` : 'Unknown'
+  const actualLabel = tx.completedAt
+    ? formatDistanceStrict(new Date(tx.completedAt), new Date(tx.initiatedAt))
+    : PENDING
+
+  return (
+    <div className="space-y-6">
+      <ol aria-label="Bridge transaction timeline" className="space-y-3">
+        {BRIDGE_PIPELINE_STAGES.map((stage, i) => {
+          const stageStatus = stageStatuses[i]
+          const confirmations = confirmationsForStage(stage, stageStatus, tx)
+          return (
+            <li key={stage} className="flex items-start gap-3">
+              <span
+                aria-hidden="true"
+                title={`${bridgeStatusLabel(stage)} - ${BRIDGE_STAGE_STATUS_TEXT[stageStatus]}`}
+                className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white ${BRIDGE_STAGE_DOT_CLASSES[stageStatus]}`}
+              >
+                {BRIDGE_STAGE_ICONS[stageStatus]}
+              </span>
+              <div>
+                <p className="text-sm font-medium text-white">
+                  {bridgeStatusLabel(stage)}
+                  <span className="ml-2 text-xs font-normal text-slate-500">({BRIDGE_STAGE_STATUS_TEXT[stageStatus]})</span>
+                </p>
+                {confirmations && <p className="text-xs text-slate-400">{confirmations}</p>}
+              </div>
+            </li>
+          )
+        })}
+      </ol>
+
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-3 border-t border-white/10 pt-4 text-sm sm:grid-cols-3">
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-slate-500">Source Gas Used</dt>
+          <dd className="text-slate-200">{tx.sourceGasUsed ?? PENDING}</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-slate-500">Est. Destination Gas</dt>
+          <dd className="text-slate-200">{tx.estimatedDestGas ?? PENDING}</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-slate-500">Actual Destination Gas</dt>
+          <dd className="text-slate-200">{tx.destGasUsed ?? PENDING}</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-slate-500">Total Cost (USD)</dt>
+          <dd className="text-slate-200">{formatUsd(tx.usdCost)}</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-slate-500">Estimated Completion</dt>
+          <dd className="text-slate-200">{estimatedLabel}</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-slate-500">Actual Completion</dt>
+          <dd className="text-slate-200">{actualLabel}</dd>
+        </div>
+      </dl>
+    </div>
+  )
+}

--- a/src/components/bridge/EstimatedCompletion.tsx
+++ b/src/components/bridge/EstimatedCompletion.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { getBridgeRouteEstimateSeconds } from '@/src/config/bridgeChains'
+import { isBridgeFailureStatus, type BridgeTransaction } from '@/src/types/bridge'
+import { formatDurationSeconds } from '@/src/utils/bridgeFormat'
+
+export interface EstimatedCompletionProps {
+  tx: BridgeTransaction
+  /** Caller-supplied clock reading (epoch ms). Reading Date.now() during render is impure, so the caller snapshots it - see BridgeTransactionList. */
+  now: number
+}
+
+/**
+ * Progress bar + remaining-time estimate derived from the historical
+ * min-max completion range for this route. Renders "Unknown" rather than
+ * NaN/0 when no historical range exists for the route, and caps the bar at
+ * 100% with a "taking longer than expected" message once elapsed time
+ * exceeds the max estimate rather than showing negative/overflowing progress.
+ */
+export function EstimatedCompletion({ tx, now }: EstimatedCompletionProps) {
+  if (isBridgeFailureStatus(tx.status)) {
+    return <span className="text-xs text-red-400">Action needed</span>
+  }
+
+  if (tx.status === 'complete') {
+    return <span className="text-xs text-emerald-400">Complete</span>
+  }
+
+  const route = getBridgeRouteEstimateSeconds(tx.sourceChain, tx.destChain)
+  if (!route) {
+    return <span className="text-xs text-slate-500">Unknown</span>
+  }
+
+  const elapsedSeconds = Math.max(0, (now - new Date(tx.initiatedAt).getTime()) / 1000)
+  const overMax = elapsedSeconds > route.max
+  const progressPct = Math.max(0, Math.min(100, (elapsedSeconds / route.max) * 100))
+  const remainingSeconds = route.max - elapsedSeconds
+
+  return (
+    <div className="w-32">
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-800">
+        <div
+          className={`h-full rounded-full transition-all duration-300 ease-out ${overMax ? 'bg-amber-500' : 'bg-sky-500'}`}
+          style={{ width: `${progressPct}%` }}
+        />
+      </div>
+      <p className="mt-1 text-[11px] text-slate-400">
+        {overMax ? 'Taking longer than expected' : `~${formatDurationSeconds(remainingSeconds)} remaining`}
+      </p>
+    </div>
+  )
+}

--- a/src/components/bridge/tests/BridgeFailureRecovery.test.tsx
+++ b/src/components/bridge/tests/BridgeFailureRecovery.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { BridgeFailureRecovery } from '@/src/components/bridge/BridgeFailureRecovery'
+import { claimStuckDeposit, retryBridgeTransaction } from '@/src/lib/api/bridge'
+
+vi.mock('@/src/lib/api/bridge', () => ({
+  retryBridgeTransaction: vi.fn(),
+  claimStuckDeposit: vi.fn(),
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.mocked(retryBridgeTransaction).mockReset()
+  vi.mocked(claimStuckDeposit).mockReset()
+})
+
+describe('BridgeFailureRecovery', () => {
+  it('shows a Retry button and calls retryBridgeTransaction for a gas failure', async () => {
+    vi.mocked(retryBridgeTransaction).mockResolvedValue(undefined)
+    render(
+      <BridgeFailureRecovery
+        transactionId="tx-1"
+        failureReason={{ type: 'gas_failure', message: 'Gas spiked' }}
+      />,
+    )
+
+    expect(screen.getByText('Gas spiked')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /claim/i })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(retryBridgeTransaction).toHaveBeenCalledWith('tx-1'))
+    expect(claimStuckDeposit).not.toHaveBeenCalled()
+  })
+
+  it('shows a Claim button and calls claimStuckDeposit for a stuck deposit', async () => {
+    vi.mocked(claimStuckDeposit).mockResolvedValue(undefined)
+    render(
+      <BridgeFailureRecovery
+        transactionId="tx-2"
+        failureReason={{ type: 'stuck_deposit', message: 'Funds stuck in bridge contract' }}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Claim' }))
+
+    await waitFor(() => expect(claimStuckDeposit).toHaveBeenCalledWith('tx-2'))
+    expect(retryBridgeTransaction).not.toHaveBeenCalled()
+  })
+
+  it('shows the reason with no action button for an unrecognized failure type', () => {
+    render(<BridgeFailureRecovery transactionId="tx-3" failureReason={{ type: 'unknown', message: 'Cause unclear' }} />)
+
+    expect(screen.getByText('Cause unclear')).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('disables the button while the request is in flight and ignores a rapid second click (no double submit)', async () => {
+    let resolveRetry!: () => void
+    vi.mocked(retryBridgeTransaction).mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRetry = resolve
+      }),
+    )
+
+    render(<BridgeFailureRecovery transactionId="tx-1" failureReason={{ type: 'gas_failure', message: 'Gas spiked' }} />)
+
+    const button = screen.getByRole('button', { name: 'Retry' })
+    fireEvent.click(button)
+    // Fire a second click before the promise resolves and before React has necessarily re-rendered `disabled`.
+    fireEvent.click(button)
+
+    expect(retryBridgeTransaction).toHaveBeenCalledTimes(1)
+    expect((screen.getByRole('button', { name: 'Retrying…' }) as HTMLButtonElement).disabled).toBe(true)
+
+    resolveRetry()
+    await waitFor(() => expect(screen.getByRole('status')).toBeTruthy())
+  })
+
+  it('surfaces the action error rather than silently no-op-ing on failure', async () => {
+    vi.mocked(retryBridgeTransaction).mockRejectedValue(new Error('Retry rejected: nonce too low'))
+
+    render(<BridgeFailureRecovery transactionId="tx-1" failureReason={{ type: 'gas_failure', message: 'Gas spiked' }} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert')
+      expect(alerts.some((el) => el.textContent?.includes('Retry rejected: nonce too low'))).toBe(true)
+    })
+    // Button re-enables so the user can try again.
+    expect((screen.getByRole('button', { name: 'Retry' }) as HTMLButtonElement).disabled).toBe(false)
+  })
+})

--- a/src/components/bridge/tests/BridgeNotificationToggle.test.tsx
+++ b/src/components/bridge/tests/BridgeNotificationToggle.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { BridgeNotificationToggle } from '@/src/components/bridge/BridgeNotificationToggle'
+import { useBridgeNotifications } from '@/src/hooks/useBridgeNotifications'
+import type { UseBridgeNotificationsResult } from '@/src/hooks/useBridgeNotifications'
+
+vi.mock('@/src/hooks/useBridgeNotifications', () => ({
+  useBridgeNotifications: vi.fn(),
+}))
+
+function mockResult(overrides: Partial<UseBridgeNotificationsResult>) {
+  vi.mocked(useBridgeNotifications).mockReturnValue({
+    supported: true,
+    permission: 'default',
+    enabled: false,
+    requestEnable: vi.fn(),
+    disable: vi.fn(),
+    ...overrides,
+  })
+}
+
+afterEach(() => cleanup())
+
+describe('BridgeNotificationToggle', () => {
+  it('renders nothing when the Notification API is unsupported', () => {
+    mockResult({ supported: false, permission: 'unsupported' })
+    const { container } = render(<BridgeNotificationToggle transactions={[]} />)
+    expect(container.textContent).toBe('')
+  })
+
+  it('shows a blocked message (not a clickable prompt) once permission is denied', () => {
+    mockResult({ permission: 'denied' })
+    render(<BridgeNotificationToggle transactions={[]} />)
+    expect(screen.getByText(/blocked/i)).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('shows an opt-in button that is not pressed by default', () => {
+    mockResult({ enabled: false })
+    render(<BridgeNotificationToggle transactions={[]} />)
+    const button = screen.getByRole('button', { name: 'Enable notifications' })
+    expect(button.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('reflects the enabled state once the user has opted in', () => {
+    mockResult({ enabled: true, permission: 'granted' })
+    render(<BridgeNotificationToggle transactions={[]} />)
+    const button = screen.getByRole('button', { name: 'Notifications on' })
+    expect(button.getAttribute('aria-pressed')).toBe('true')
+  })
+})

--- a/src/components/bridge/tests/BridgeStatusStepper.test.tsx
+++ b/src/components/bridge/tests/BridgeStatusStepper.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { BridgeStatusStepper } from '@/src/components/bridge/BridgeStatusStepper'
+
+afterEach(() => cleanup())
+
+describe('BridgeStatusStepper', () => {
+  it('exposes an accessible summary that names the current stage, not just color', () => {
+    render(<BridgeStatusStepper status="bridge_in_progress" />)
+
+    const list = screen.getByRole('list', { name: /bridge in progress/i })
+    expect(list).toBeTruthy()
+    expect(list.getAttribute('aria-label')).toMatch(/stage 3 of 5/i)
+  })
+
+  it('gives every stage dot a non-color text cue (title) and marks the current one aria-current', () => {
+    render(<BridgeStatusStepper status="source_confirmed" />)
+
+    expect(screen.getByTitle('Initiated - done')).toBeTruthy()
+    expect(screen.getByTitle('Source Confirmed - in progress')).toBeTruthy()
+    expect(screen.getByTitle('Bridge In Progress - pending')).toBeTruthy()
+
+    const current = screen.getByTitle('Source Confirmed - in progress')
+    expect(current.getAttribute('aria-current')).toBe('step')
+  })
+
+  it('surfaces the failure reason in the accessible summary and marks the failed stage, not a color swatch', () => {
+    render(
+      <BridgeStatusStepper
+        status="failed_gas"
+        failureReason={{ type: 'gas_failure', message: 'Destination gas price spiked mid-transfer' }}
+      />,
+    )
+
+    const list = screen.getByRole('list', { name: /Destination gas price spiked mid-transfer/i })
+    expect(list).toBeTruthy()
+    expect(screen.getByTitle('Bridge In Progress - failed')).toBeTruthy()
+    // Stages after the failure point are neither "done" nor "failed" - they were never reached.
+    expect(screen.getByTitle('Destination Confirmed - pending')).toBeTruthy()
+  })
+})

--- a/src/components/bridge/tests/BridgeTransactionDetail.test.tsx
+++ b/src/components/bridge/tests/BridgeTransactionDetail.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { BridgeTransactionDetail } from '@/src/components/bridge/BridgeTransactionDetail'
+import { useBridgeTransactionDetail } from '@/src/hooks/useBridgeTransactionDetail'
+import { makeBridgeTx } from '@/src/components/bridge/tests/fixtures'
+import type { UseBridgeTransactionDetailResult } from '@/src/hooks/useBridgeTransactionDetail'
+
+vi.mock('@/src/hooks/useBridgeTransactionDetail', () => ({
+  useBridgeTransactionDetail: vi.fn(),
+}))
+
+function mockDetailResult(overrides: Partial<UseBridgeTransactionDetailResult>) {
+  vi.mocked(useBridgeTransactionDetail).mockReturnValue({
+    transaction: null,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    refresh: vi.fn(),
+    ...overrides,
+  })
+}
+
+afterEach(() => cleanup())
+
+describe('BridgeTransactionDetail', () => {
+  it('shows a loading skeleton while the first fetch is in flight', () => {
+    mockDetailResult({ isLoading: true })
+    const { container } = render(<BridgeTransactionDetail id="tx-1" />)
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0)
+  })
+
+  it('surfaces a fetch error', () => {
+    mockDetailResult({ isError: true, error: new Error('not authorized') })
+    render(<BridgeTransactionDetail id="tx-1" />)
+    expect(screen.getByRole('alert').textContent).toContain('not authorized')
+  })
+
+  it('renders the route, amount, and timeline for a healthy transaction, with no recovery panel', () => {
+    mockDetailResult({ transaction: makeBridgeTx({ status: 'bridge_in_progress' }) })
+    render(<BridgeTransactionDetail id="tx-1" />)
+
+    expect(screen.getByText(/Ethereum.*Polygon/)).toBeTruthy()
+    expect(screen.getByText(/100 USDC/)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /retry|claim/i })).toBeNull()
+  })
+
+  it('shows the failure recovery panel with the type-appropriate action when the transaction has failed', () => {
+    mockDetailResult({
+      transaction: makeBridgeTx({
+        status: 'failed_gas',
+        failureReason: { type: 'gas_failure', message: 'Destination gas spiked' },
+      }),
+    })
+    render(<BridgeTransactionDetail id="tx-1" />)
+
+    expect(screen.getByText('Destination gas spiked')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy()
+  })
+
+  it('shows a pending destination-tx note rather than a broken link when destTxHash is not yet known', () => {
+    mockDetailResult({ transaction: makeBridgeTx({ status: 'initiated', destTxHash: null }) })
+    render(<BridgeTransactionDetail id="tx-1" />)
+
+    expect(screen.getByText('Destination tx: pending')).toBeTruthy()
+  })
+})

--- a/src/components/bridge/tests/BridgeTransactionList.test.tsx
+++ b/src/components/bridge/tests/BridgeTransactionList.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { useRouter, usePathname, useSearchParams } from 'next/navigation'
+import { useBridgeTx } from '@/src/hooks/useBridgeTx'
+import { BridgeTransactionList } from '@/src/components/bridge/BridgeTransactionList'
+import { makeBridgeTx } from '@/src/components/bridge/tests/fixtures'
+import type { UseBridgeTxResult } from '@/src/hooks/useBridgeTx'
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+  usePathname: vi.fn(),
+  useSearchParams: vi.fn(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@/src/hooks/useBridgeTx', () => ({
+  useBridgeTx: vi.fn(),
+}))
+
+const replaceMock = vi.fn()
+
+function mockSearchParams(query: string) {
+  vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams(query) as unknown as ReturnType<typeof useSearchParams>)
+}
+
+function mockBridgeTxResult(overrides: Partial<UseBridgeTxResult>) {
+  vi.mocked(useBridgeTx).mockReturnValue({
+    transactions: [],
+    total: 0,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+    refresh: vi.fn(),
+    hasActive: false,
+    ...overrides,
+  })
+}
+
+afterEach(() => cleanup())
+
+describe('BridgeTransactionList', () => {
+  beforeEach(() => {
+    vi.mocked(useRouter).mockReturnValue({ replace: replaceMock } as unknown as ReturnType<typeof useRouter>)
+    vi.mocked(usePathname).mockReturnValue('/bridge')
+    mockSearchParams('')
+    replaceMock.mockClear()
+  })
+
+  it('renders a row per transaction with route, amount, status, and initiated date', () => {
+    mockBridgeTxResult({
+      transactions: [makeBridgeTx({ id: 'tx-1', sourceChain: 'ethereum', destChain: 'base', amount: '42' })],
+      total: 1,
+    })
+
+    render(<BridgeTransactionList />)
+
+    expect(screen.getByText(/Ethereum.*Base/)).toBeTruthy()
+    expect(screen.getByText('42 USDC')).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'View' }).getAttribute('href')).toBe('/bridge/tx-1')
+  })
+
+  it('shows a loading skeleton only on first load, not once data has arrived', () => {
+    mockBridgeTxResult({ transactions: [], total: 0, isLoading: true })
+    const { container, rerender } = render(<BridgeTransactionList />)
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0)
+
+    mockBridgeTxResult({
+      transactions: [makeBridgeTx()],
+      total: 1,
+      isFetching: true, // background poll refresh, not first load
+    })
+    rerender(<BridgeTransactionList />)
+    expect(container.querySelectorAll('.animate-pulse').length).toBe(0)
+    expect(screen.getByText(/Updating…/)).toBeTruthy()
+  })
+
+  it('distinguishes "no transactions at all" from "no rows match the filters"', () => {
+    mockBridgeTxResult({ transactions: [], total: 0 })
+    const { rerender } = render(<BridgeTransactionList />)
+    expect(screen.getByText('No bridge transactions yet.')).toBeTruthy()
+
+    mockSearchParams('chain=ethereum')
+    rerender(<BridgeTransactionList />)
+    expect(screen.getByText('No transactions match the current filters.')).toBeTruthy()
+  })
+
+  it('changing the chain filter updates the URL and resets the page to 1', () => {
+    mockSearchParams('page=3')
+    mockBridgeTxResult({ transactions: [makeBridgeTx()], total: 1 })
+
+    render(<BridgeTransactionList />)
+    fireEvent.change(screen.getByLabelText('Chain'), { target: { value: 'polygon' } })
+
+    expect(replaceMock).toHaveBeenCalledTimes(1)
+    const [url] = replaceMock.mock.calls[0]
+    expect(url).toContain('chain=polygon')
+    expect(url).not.toContain('page=')
+  })
+
+  it('changing the status filter also resets the page to 1', () => {
+    mockSearchParams('page=2')
+    mockBridgeTxResult({ transactions: [makeBridgeTx()], total: 1 })
+
+    render(<BridgeTransactionList />)
+    fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'complete' } })
+
+    const [url] = replaceMock.mock.calls[0]
+    expect(url).toContain('status=complete')
+    expect(url).not.toContain('page=')
+  })
+
+  it('paginates forward and back without touching the active filters', () => {
+    mockSearchParams('chain=ethereum&page=2')
+    mockBridgeTxResult({ transactions: [makeBridgeTx()], total: 100 })
+
+    render(<BridgeTransactionList />)
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }))
+
+    const [url] = replaceMock.mock.calls[0]
+    expect(url).toContain('chain=ethereum')
+    expect(url).toContain('page=3')
+  })
+
+  it('disables Previous on the first page', () => {
+    mockSearchParams('')
+    mockBridgeTxResult({ transactions: [makeBridgeTx()], total: 1 })
+
+    render(<BridgeTransactionList />)
+    expect((screen.getByRole('button', { name: 'Previous page' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('surfaces the hook error state to the user', () => {
+    mockBridgeTxResult({ isError: true, error: new Error('backend unreachable') })
+    render(<BridgeTransactionList />)
+    expect(screen.getByRole('alert').textContent).toContain('backend unreachable')
+  })
+})

--- a/src/components/bridge/tests/BridgeTransactionTimeline.test.tsx
+++ b/src/components/bridge/tests/BridgeTransactionTimeline.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { BridgeTransactionTimeline } from '@/src/components/bridge/BridgeTransactionTimeline'
+import { makeBridgeTx } from '@/src/components/bridge/tests/fixtures'
+
+afterEach(() => cleanup())
+
+describe('BridgeTransactionTimeline', () => {
+  it('renders all five pipeline stages with their status text', () => {
+    render(<BridgeTransactionTimeline tx={makeBridgeTx({ status: 'bridge_in_progress' })} />)
+
+    for (const label of ['Initiated', 'Source Confirmed', 'Bridge In Progress', 'Destination Confirmed', 'Complete']) {
+      expect(screen.getByText(label)).toBeTruthy()
+    }
+  })
+
+  it('shows an explicit Pending state for destination gas and USD cost rather than 0/NaN before they are known', () => {
+    render(
+      <BridgeTransactionTimeline
+        tx={makeBridgeTx({ status: 'bridge_in_progress', destGasUsed: null, usdCost: null })}
+      />,
+    )
+
+    // "Pending" appears for the not-yet-known values; none of them render as 0, "-", or NaN.
+    expect(screen.getAllByText('Pending').length).toBeGreaterThan(0)
+    expect(screen.queryByText('NaN')).toBeNull()
+    expect(screen.queryByText('0')).toBeNull()
+  })
+
+  it('shows real gas and cost figures once they are known', () => {
+    render(
+      <BridgeTransactionTimeline
+        tx={makeBridgeTx({ status: 'complete', destGasUsed: '95000', usdCost: 12.34, completedAt: '2026-07-18T00:20:00.000Z' })}
+      />,
+    )
+
+    expect(screen.getByText('95000')).toBeTruthy()
+    expect(screen.getByText('$12.34')).toBeTruthy()
+  })
+
+  it('does not show confirmation counts for a leg that has not started yet', () => {
+    const tx = makeBridgeTx({ status: 'initiated', sourceConfirmations: 0, destConfirmations: 0 })
+    render(<BridgeTransactionTimeline tx={tx} />)
+
+    // Source confirmed and dest confirmed are both still upcoming at "initiated" - no raw "0/N" reading yet.
+    expect(screen.queryByText(/confirmations/)).toBeNull()
+  })
+
+  it('shows confirmation counts once a leg is actually in progress', () => {
+    const tx = makeBridgeTx({ status: 'source_confirmed', sourceConfirmations: 4, requiredSourceConfirmations: 12 })
+    render(<BridgeTransactionTimeline tx={tx} />)
+
+    expect(screen.getByText('4/12 confirmations')).toBeTruthy()
+  })
+
+  it('falls back to "Unknown" for the estimated completion range when the route has no historical data', () => {
+    const tx = makeBridgeTx({ sourceChain: 'polygon', destChain: 'base', status: 'bridge_in_progress' })
+    render(<BridgeTransactionTimeline tx={tx} />)
+
+    expect(screen.getByText('Unknown')).toBeTruthy()
+  })
+})

--- a/src/components/bridge/tests/EstimatedCompletion.test.tsx
+++ b/src/components/bridge/tests/EstimatedCompletion.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { EstimatedCompletion } from '@/src/components/bridge/EstimatedCompletion'
+import { makeBridgeTx } from '@/src/components/bridge/tests/fixtures'
+
+const INITIATED = new Date('2026-07-18T00:00:00.000Z').getTime()
+
+afterEach(() => cleanup())
+
+describe('EstimatedCompletion', () => {
+  it('renders a proportional progress bar and remaining time within the known route range', () => {
+    // ethereum -> polygon route: min 180s, max 900s.
+    const tx = makeBridgeTx({ sourceChain: 'ethereum', destChain: 'polygon', status: 'bridge_in_progress' })
+    const now = INITIATED + 450_000 // 450s elapsed, 50% of the 900s max
+
+    render(<EstimatedCompletion tx={tx} now={now} />)
+
+    const bar = document.querySelector('[style*="width"]') as HTMLElement
+    expect(bar.style.width).toBe('50%')
+    expect(screen.getByText(/remaining/i)).toBeTruthy()
+  })
+
+  it('caps the bar at 100% and shows a "taking longer than expected" message once elapsed exceeds the max estimate', () => {
+    const tx = makeBridgeTx({ sourceChain: 'ethereum', destChain: 'polygon', status: 'bridge_in_progress' })
+    const now = INITIATED + 2_000_000 // far beyond the 900s max
+
+    render(<EstimatedCompletion tx={tx} now={now} />)
+
+    const bar = document.querySelector('[style*="width"]') as HTMLElement
+    expect(bar.style.width).toBe('100%')
+    expect(screen.getByText(/taking longer than expected/i)).toBeTruthy()
+    expect(screen.queryByText(/remaining/i)).toBeNull()
+  })
+
+  it('shows "Unknown" rather than NaN when no historical estimate exists for the route', () => {
+    const tx = makeBridgeTx({ sourceChain: 'polygon', destChain: 'base', status: 'bridge_in_progress' })
+
+    render(<EstimatedCompletion tx={tx} now={INITIATED + 60_000} />)
+
+    expect(screen.getByText('Unknown')).toBeTruthy()
+  })
+
+  it('shows a terminal "Complete" state without a progress bar once the transfer has finished', () => {
+    const tx = makeBridgeTx({ status: 'complete' })
+    render(<EstimatedCompletion tx={tx} now={INITIATED} />)
+
+    expect(screen.getByText('Complete')).toBeTruthy()
+    expect(document.querySelector('[style*="width"]')).toBeNull()
+  })
+
+  it('shows an action-needed state for failure statuses instead of a misleading progress bar', () => {
+    const tx = makeBridgeTx({ status: 'failed_stuck_deposit' })
+    render(<EstimatedCompletion tx={tx} now={INITIATED} />)
+
+    expect(screen.getByText('Action needed')).toBeTruthy()
+    expect(document.querySelector('[style*="width"]')).toBeNull()
+  })
+})

--- a/src/components/bridge/tests/fixtures.ts
+++ b/src/components/bridge/tests/fixtures.ts
@@ -1,0 +1,26 @@
+import type { BridgeTransaction } from '@/src/types/bridge'
+
+export function makeBridgeTx(overrides: Partial<BridgeTransaction> = {}): BridgeTransaction {
+  return {
+    id: 'tx-1',
+    sourceChain: 'ethereum',
+    destChain: 'polygon',
+    status: 'bridge_in_progress',
+    tokenSymbol: 'USDC',
+    amount: '100',
+    initiatedAt: '2026-07-18T00:00:00.000Z',
+    completedAt: null,
+    sourceTxHash: '0xabc',
+    destTxHash: null,
+    sourceConfirmations: 5,
+    requiredSourceConfirmations: 12,
+    destConfirmations: 0,
+    requiredDestConfirmations: 6,
+    failureReason: null,
+    sourceGasUsed: '21000',
+    estimatedDestGas: '150000',
+    destGasUsed: null,
+    usdCost: 1.5,
+    ...overrides,
+  }
+}

--- a/src/config/bridgeChains.ts
+++ b/src/config/bridgeChains.ts
@@ -1,0 +1,63 @@
+import type { BridgeChain } from '@/src/types/bridge'
+import { BRIDGE_CHAINS } from '@/src/types/bridge'
+
+export interface BridgeChainMeta {
+  id: BridgeChain
+  name: string
+  explorerTxUrl: (txHash: string) => string
+}
+
+export const BRIDGE_CHAIN_META: Record<BridgeChain, BridgeChainMeta> = {
+  ethereum: {
+    id: 'ethereum',
+    name: 'Ethereum',
+    explorerTxUrl: (txHash) => `https://etherscan.io/tx/${txHash}`,
+  },
+  polygon: {
+    id: 'polygon',
+    name: 'Polygon',
+    explorerTxUrl: (txHash) => `https://polygonscan.com/tx/${txHash}`,
+  },
+  arbitrum: {
+    id: 'arbitrum',
+    name: 'Arbitrum',
+    explorerTxUrl: (txHash) => `https://arbiscan.io/tx/${txHash}`,
+  },
+  optimism: {
+    id: 'optimism',
+    name: 'Optimism',
+    explorerTxUrl: (txHash) => `https://optimistic.etherscan.io/tx/${txHash}`,
+  },
+  base: {
+    id: 'base',
+    name: 'Base',
+    explorerTxUrl: (txHash) => `https://basescan.org/tx/${txHash}`,
+  },
+}
+
+export function bridgeChainName(chain: BridgeChain): string {
+  return BRIDGE_CHAIN_META[chain].name
+}
+
+/** Historical per-route completion time range, in seconds, used to derive the EstimatedCompletion progress bar. Placeholder data - see assumption list in the PR description. */
+export const BRIDGE_ROUTE_ESTIMATE_SECONDS: Partial<Record<`${BridgeChain}-${BridgeChain}`, { min: number; max: number }>> = {
+  'ethereum-polygon': { min: 180, max: 900 },
+  'polygon-ethereum': { min: 600, max: 2700 },
+  'ethereum-arbitrum': { min: 60, max: 600 },
+  'arbitrum-ethereum': { min: 420, max: 2400 },
+  'ethereum-optimism': { min: 60, max: 600 },
+  'optimism-ethereum': { min: 420, max: 2400 },
+  'ethereum-base': { min: 60, max: 600 },
+  'base-ethereum': { min: 420, max: 2400 },
+  'polygon-arbitrum': { min: 240, max: 1200 },
+  'arbitrum-polygon': { min: 240, max: 1200 },
+}
+
+export function getBridgeRouteEstimateSeconds(
+  sourceChain: BridgeChain,
+  destChain: BridgeChain,
+): { min: number; max: number } | null {
+  return BRIDGE_ROUTE_ESTIMATE_SECONDS[`${sourceChain}-${destChain}`] ?? null
+}
+
+export { BRIDGE_CHAINS }

--- a/src/hooks/tests/useBridgeNotifications.test.tsx
+++ b/src/hooks/tests/useBridgeNotifications.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useBridgeNotifications, __resetBridgeNotificationState } from '@/src/hooks/useBridgeNotifications'
+import { makeBridgeTx } from '@/src/components/bridge/tests/fixtures'
+import type { BridgeTransaction } from '@/src/types/bridge'
+
+class MockNotification {
+  static permission: NotificationPermission = 'granted'
+  static requestPermission = vi.fn(async () => MockNotification.permission)
+  static instances: MockNotification[] = []
+  body?: string
+  constructor(
+    public title: string,
+    options?: NotificationOptions,
+  ) {
+    this.body = options?.body
+    MockNotification.instances.push(this)
+  }
+}
+
+async function enable(result: { current: ReturnType<typeof useBridgeNotifications> }) {
+  await act(async () => {
+    result.current.requestEnable()
+  })
+}
+
+describe('useBridgeNotifications', () => {
+  let originalNotification: unknown
+
+  beforeEach(() => {
+    __resetBridgeNotificationState()
+    originalNotification = (window as unknown as { Notification?: unknown }).Notification
+    MockNotification.permission = 'granted'
+    MockNotification.instances = []
+    MockNotification.requestPermission.mockClear()
+    ;(window as unknown as { Notification: unknown }).Notification = MockNotification
+  })
+
+  afterEach(() => {
+    ;(window as unknown as { Notification: unknown }).Notification = originalNotification
+  })
+
+  it('fires exactly once when a transaction transitions into complete', async () => {
+    const { result, rerender } = renderHook(({ txs }: { txs: BridgeTransaction[] }) => useBridgeNotifications(txs), {
+      initialProps: { txs: [makeBridgeTx({ id: 'tx-1', status: 'bridge_in_progress' })] },
+    })
+    await enable(result)
+
+    rerender({ txs: [makeBridgeTx({ id: 'tx-1', status: 'complete' })] })
+
+    expect(MockNotification.instances).toHaveLength(1)
+    expect(MockNotification.instances[0].body).toContain('Ethereum to Polygon is complete!')
+  })
+
+  it('does not fire on a poll tick where the status is unchanged', async () => {
+    const { result, rerender } = renderHook(({ txs }: { txs: BridgeTransaction[] }) => useBridgeNotifications(txs), {
+      initialProps: { txs: [makeBridgeTx({ id: 'tx-1', status: 'bridge_in_progress' })] },
+    })
+    await enable(result)
+
+    // Same status, new array/object references - exactly what a real poll refetch produces.
+    rerender({ txs: [makeBridgeTx({ id: 'tx-1', status: 'bridge_in_progress' })] })
+
+    expect(MockNotification.instances).toHaveLength(0)
+  })
+
+  it('does not fire for a transaction on its first sighting', async () => {
+    const { result, rerender } = renderHook(({ txs }: { txs: BridgeTransaction[] }) => useBridgeNotifications(txs), {
+      initialProps: { txs: [] as BridgeTransaction[] },
+    })
+    await enable(result)
+
+    rerender({ txs: [makeBridgeTx({ id: 'tx-1', status: 'complete' })] })
+
+    expect(MockNotification.instances).toHaveLength(0)
+  })
+
+  it('never calls Notification.requestPermission on mount - only requestEnable() does', () => {
+    renderHook(() => useBridgeNotifications([makeBridgeTx({ status: 'complete' })]))
+    expect(MockNotification.requestPermission).not.toHaveBeenCalled()
+  })
+
+  it('does not fire when permission is denied, and does not re-prompt the browser', async () => {
+    MockNotification.permission = 'denied'
+    const { result, rerender } = renderHook(({ txs }: { txs: BridgeTransaction[] }) => useBridgeNotifications(txs), {
+      initialProps: { txs: [makeBridgeTx({ id: 'tx-1', status: 'bridge_in_progress' })] },
+    })
+
+    act(() => result.current.requestEnable())
+    expect(MockNotification.requestPermission).not.toHaveBeenCalled()
+    expect(result.current.permission).toBe('denied')
+
+    rerender({ txs: [makeBridgeTx({ id: 'tx-1', status: 'complete' })] })
+    expect(MockNotification.instances).toHaveLength(0)
+  })
+
+  it('does not throw when the Notification API is unavailable (SSR / unsupported browser)', () => {
+    delete (window as unknown as { Notification?: unknown }).Notification
+
+    expect(() => {
+      const { result, rerender } = renderHook(({ txs }: { txs: BridgeTransaction[] }) => useBridgeNotifications(txs), {
+        initialProps: { txs: [makeBridgeTx({ id: 'tx-1', status: 'bridge_in_progress' })] },
+      })
+      act(() => result.current.requestEnable())
+      rerender({ txs: [makeBridgeTx({ id: 'tx-1', status: 'complete' })] })
+    }).not.toThrow()
+  })
+
+  it('does not re-fire a transition that was already notified before a remount', async () => {
+    const { result, rerender, unmount } = renderHook(
+      ({ txs }: { txs: BridgeTransaction[] }) => useBridgeNotifications(txs),
+      { initialProps: { txs: [makeBridgeTx({ id: 'tx-1', status: 'bridge_in_progress' })] } },
+    )
+    await enable(result)
+    rerender({ txs: [makeBridgeTx({ id: 'tx-1', status: 'complete' })] })
+    expect(MockNotification.instances).toHaveLength(1)
+
+    unmount()
+
+    // Remount races a poll that resolves with the same already-notified status.
+    const second = renderHook(({ txs }: { txs: BridgeTransaction[] }) => useBridgeNotifications(txs), {
+      initialProps: { txs: [makeBridgeTx({ id: 'tx-1', status: 'complete' })] },
+    })
+    await enable(second.result)
+
+    expect(MockNotification.instances).toHaveLength(1)
+  })
+})

--- a/src/hooks/tests/useBridgeTx.test.tsx
+++ b/src/hooks/tests/useBridgeTx.test.tsx
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider, focusManager } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useBridgeTx, computeRefetchInterval } from '@/src/hooks/useBridgeTx'
+import type { BridgeTransaction, BridgeTransactionListResponse } from '@/src/types/bridge'
+
+function makeTx(overrides: Partial<BridgeTransaction> = {}): BridgeTransaction {
+  return {
+    id: 'tx-1',
+    sourceChain: 'ethereum',
+    destChain: 'polygon',
+    status: 'bridge_in_progress',
+    tokenSymbol: 'USDC',
+    amount: '100',
+    initiatedAt: '2026-07-18T00:00:00.000Z',
+    completedAt: null,
+    sourceTxHash: '0xabc',
+    destTxHash: null,
+    sourceConfirmations: 5,
+    requiredSourceConfirmations: 12,
+    destConfirmations: 0,
+    requiredDestConfirmations: 6,
+    failureReason: null,
+    sourceGasUsed: '21000',
+    estimatedDestGas: '150000',
+    destGasUsed: null,
+    usdCost: 1.5,
+    ...overrides,
+  }
+}
+
+function makeResponse(transactions: BridgeTransaction[], page = 1): BridgeTransactionListResponse {
+  return { transactions, total: transactions.length, page, pageSize: 20 }
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+  return Wrapper
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+/** Advances fake timers and flushes the resulting promise chain inside act(), so React state updates land before the next assertion (avoids the classic waitFor-vs-fake-timers deadlock). */
+async function flush(ms = 0) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+describe('useBridgeTx', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    focusManager.setFocused(undefined)
+  })
+
+  it('polls every 10s while a tracked transaction is non-terminal', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeResponse([makeTx({ status: 'bridge_in_progress' })]),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useBridgeTx({ page: 1, pageSize: 20 }), {
+      wrapper: createWrapper(),
+    })
+
+    await flush()
+    expect(result.current.isLoading).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await flush(10_000)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    await flush(10_000)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops polling entirely once every tracked transaction is terminal', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeResponse([makeTx({ status: 'complete' })]),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useBridgeTx({ page: 1, pageSize: 20 }), {
+      wrapper: createWrapper(),
+    })
+
+    await flush()
+    expect(result.current.hasActive).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await flush(30_000)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the interval on unmount and issues no further fetches or state updates', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeResponse([makeTx({ status: 'bridge_in_progress' })]),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { result, unmount } = renderHook(() => useBridgeTx({ page: 1, pageSize: 20 }), {
+      wrapper: createWrapper(),
+    })
+
+    await flush()
+    const callsBeforeUnmount = fetchMock.mock.calls.length
+    expect(result.current.isLoading).toBe(false)
+
+    unmount()
+    await flush(30_000)
+
+    expect(fetchMock).toHaveBeenCalledTimes(callsBeforeUnmount)
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not start an overlapping request while the previous poll is still in flight', async () => {
+    let inFlight = 0
+    let maxConcurrent = 0
+    const first = deferred<BridgeTransactionListResponse>()
+    const fetchMock = vi.fn().mockImplementation(() => {
+      inFlight += 1
+      maxConcurrent = Math.max(maxConcurrent, inFlight)
+      return first.promise.then((data) => {
+        inFlight -= 1
+        return { ok: true, json: async () => data }
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderHook(() => useBridgeTx({ page: 1, pageSize: 20 }), { wrapper: createWrapper() })
+
+    await flush()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // Two poll intervals elapse while the first request is still unresolved.
+    await flush(10_000)
+    await flush(10_000)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(maxConcurrent).toBe(1)
+
+    first.resolve(makeResponse([makeTx({ status: 'bridge_in_progress' })]))
+    await flush()
+  })
+
+  it('discards a slow response for a stale filter/page once a newer one has resolved', async () => {
+    const page1 = deferred<BridgeTransactionListResponse>()
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('page=2')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => makeResponse([makeTx({ id: 'tx-page2', status: 'complete' })], 2),
+        })
+      }
+      return page1.promise.then((data) => ({ ok: true, json: async () => data }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result, rerender } = renderHook(({ page }) => useBridgeTx({ page, pageSize: 20 }), {
+      wrapper: createWrapper(),
+      initialProps: { page: 1 },
+    })
+
+    await flush()
+
+    rerender({ page: 2 })
+    await flush()
+    expect(result.current.transactions[0]?.id).toBe('tx-page2')
+
+    // The slow page-1 response arrives after page 2 has already rendered.
+    page1.resolve(makeResponse([makeTx({ id: 'tx-page1-stale', status: 'bridge_in_progress' })], 1))
+    await flush()
+
+    expect(result.current.transactions[0]?.id).toBe('tx-page2')
+  })
+
+  it('pauses polling while the document is hidden and refetches on refocus', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => makeResponse([makeTx({ status: 'bridge_in_progress' })]),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderHook(() => useBridgeTx({ page: 1, pageSize: 20 }), { wrapper: createWrapper() })
+    await flush()
+
+    focusManager.setFocused(false)
+    const callsWhileVisible = fetchMock.mock.calls.length
+    await flush(30_000)
+    // No polling at all while hidden, however many 10s ticks elapse.
+    expect(fetchMock).toHaveBeenCalledTimes(callsWhileVisible)
+
+    focusManager.setFocused(true)
+    await flush()
+    // Coming back into focus produces a fresh fetch rather than waiting out the rest of the interval.
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsWhileVisible)
+  })
+})
+
+describe('computeRefetchInterval', () => {
+  function fakeQuery(overrides: { data?: BridgeTransactionListResponse; fetchFailureCount?: number }) {
+    return {
+      state: {
+        data: overrides.data,
+        fetchFailureCount: overrides.fetchFailureCount ?? 0,
+      },
+    } as Parameters<typeof computeRefetchInterval>[0]
+  }
+
+  it('backs off exponentially and caps instead of retrying every 10s after repeated failures', () => {
+    expect(computeRefetchInterval(fakeQuery({ fetchFailureCount: 0 }))).toBe(10_000)
+    expect(computeRefetchInterval(fakeQuery({ fetchFailureCount: 1 }))).toBe(20_000)
+    expect(computeRefetchInterval(fakeQuery({ fetchFailureCount: 2 }))).toBe(40_000)
+    expect(computeRefetchInterval(fakeQuery({ fetchFailureCount: 3 }))).toBe(80_000)
+    expect(computeRefetchInterval(fakeQuery({ fetchFailureCount: 10 }))).toBe(80_000)
+  })
+
+  it('stops entirely once all transactions in the last successful response are terminal, regardless of failure count', () => {
+    const allTerminal = makeResponse([makeTx({ status: 'complete' }), makeTx({ id: 'tx-2', status: 'failed_gas' })])
+    expect(computeRefetchInterval(fakeQuery({ data: allTerminal, fetchFailureCount: 0 }))).toBe(false)
+  })
+})

--- a/src/hooks/useBridgeNotifications.ts
+++ b/src/hooks/useBridgeNotifications.ts
@@ -1,0 +1,123 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { bridgeChainName } from '@/src/config/bridgeChains'
+import { isBridgeFailureStatus, type BridgeTransaction, type BridgeTxStatus } from '@/src/types/bridge'
+
+function isNotificationSupported(): boolean {
+  return typeof window !== 'undefined' && 'Notification' in window
+}
+
+// Deliberately module-level, not component state: a transition that has
+// already produced a notification must stay notified even if this hook's
+// component remounts (e.g. navigating away from and back to the bridge page)
+// within the same page session, and the last-seen status per tx must survive
+// the same remount so a status that was already current before unmount isn't
+// mistaken for a brand-new "first sighting" that then wrongly re-fires on the
+// next real transition.
+const notifiedTransitionKeys = new Set<string>()
+const lastKnownStatusByTxId = new Map<string, BridgeTxStatus>()
+
+/** Test-only: clears the module-level transition history between test cases. Not exported from the public hook surface used by app code. */
+export function __resetBridgeNotificationState() {
+  notifiedTransitionKeys.clear()
+  lastKnownStatusByTxId.clear()
+}
+
+function notifyForTransition(tx: BridgeTransaction) {
+  const srcName = bridgeChainName(tx.sourceChain)
+  const destName = bridgeChainName(tx.destChain)
+
+  if (tx.status === 'complete') {
+    new Notification('Bridge transfer complete', {
+      body: `Your bridge transaction from ${srcName} to ${destName} is complete!`,
+      tag: `bridge-tx-${tx.id}`,
+    })
+    return
+  }
+
+  if (isBridgeFailureStatus(tx.status)) {
+    new Notification('Bridge transfer needs attention', {
+      body: `Your bridge transaction from ${srcName} to ${destName} ${tx.failureReason?.message ?? 'failed'}.`,
+      tag: `bridge-tx-${tx.id}`,
+    })
+  }
+
+  // Intermediate pipeline transitions (initiated -> source_confirmed, etc.)
+  // are deliberately silent - only the two outcomes that need the user's
+  // attention (done, or needs action) are worth interrupting them for.
+}
+
+export interface UseBridgeNotificationsResult {
+  supported: boolean
+  permission: NotificationPermission | 'unsupported'
+  enabled: boolean
+  /** Must be invoked from a user gesture (e.g. a toggle's onClick) - never called automatically. */
+  requestEnable: () => void
+  disable: () => void
+}
+
+/**
+ * Fires a browser notification when a tracked transaction's status
+ * transitions into 'complete' or a failure state - never on an unchanged
+ * poll tick, and never for a transaction's first sighting (there's no prior
+ * status to have transitioned from). Notifications only fire once the user
+ * has explicitly opted in via requestEnable() (never requested on mount) and
+ * the browser permission is granted; on unsupported browsers/SSR this is a
+ * no-op rather than a throw.
+ */
+export function useBridgeNotifications(transactions: BridgeTransaction[]): UseBridgeNotificationsResult {
+  const supported = isNotificationSupported()
+  const [enabled, setEnabled] = useState(false)
+  const [permission, setPermission] = useState<NotificationPermission | 'unsupported'>(
+    supported ? Notification.permission : 'unsupported',
+  )
+
+  const requestEnable = useCallback(() => {
+    if (!supported) return
+    if (Notification.permission === 'granted') {
+      setPermission('granted')
+      setEnabled(true)
+      return
+    }
+    if (Notification.permission === 'denied') {
+      // Browsers won't re-prompt once denied; reflect that rather than
+      // calling requestPermission() again to no effect.
+      setPermission('denied')
+      return
+    }
+    void Notification.requestPermission().then((result) => {
+      setPermission(result)
+      setEnabled(result === 'granted')
+    })
+  }, [supported])
+
+  const disable = useCallback(() => setEnabled(false), [])
+
+  useEffect(() => {
+    if (!supported) return
+
+    const isActive = enabled && permission === 'granted'
+
+    for (const tx of transactions) {
+      const previousStatus = lastKnownStatusByTxId.get(tx.id)
+      lastKnownStatusByTxId.set(tx.id, tx.status)
+
+      const isFirstSighting = previousStatus === undefined
+      const isTransition = !isFirstSighting && previousStatus !== tx.status
+      if (!isTransition) continue
+
+      // Statuses are still tracked while notifications are disabled/not yet
+      // granted, so turning them on later doesn't replay past transitions.
+      if (!isActive) continue
+
+      const transitionKey = `${tx.id}:${tx.status}`
+      if (notifiedTransitionKeys.has(transitionKey)) continue
+      notifiedTransitionKeys.add(transitionKey)
+
+      notifyForTransition(tx)
+    }
+  }, [transactions, supported, enabled, permission])
+
+  return { supported, permission, enabled, requestEnable, disable }
+}

--- a/src/hooks/useBridgeTransactionDetail.ts
+++ b/src/hooks/useBridgeTransactionDetail.ts
@@ -1,0 +1,57 @@
+'use client'
+
+import { useQuery, type Query } from '@tanstack/react-query'
+import { fetchBridgeTransaction } from '@/src/lib/api/bridge'
+import { isTerminalBridgeStatus, type BridgeTransaction } from '@/src/types/bridge'
+
+const POLL_INTERVAL_MS = 10_000
+const MAX_POLL_INTERVAL_MS = 80_000
+
+/** Single-transaction mirror of useBridgeTx's computeRefetchInterval: stop once terminal, back off on repeated failure. */
+export function computeDetailRefetchInterval(query: Query<BridgeTransaction, Error>): number | false {
+  const data = query.state.data
+  if (data && isTerminalBridgeStatus(data.status)) {
+    return false
+  }
+
+  const failures = query.state.fetchFailureCount
+  if (failures > 0) {
+    return Math.min(POLL_INTERVAL_MS * 2 ** failures, MAX_POLL_INTERVAL_MS)
+  }
+
+  return POLL_INTERVAL_MS
+}
+
+export interface UseBridgeTransactionDetailResult {
+  transaction: BridgeTransaction | null
+  isLoading: boolean
+  isFetching: boolean
+  isError: boolean
+  error: Error | null
+  refresh: () => void
+}
+
+/** Fetches /api/v1/bridge/transactions/:id and polls every 10s while the transaction is non-terminal, same lifecycle rules as useBridgeTx. */
+export function useBridgeTransactionDetail(id: string): UseBridgeTransactionDetailResult {
+  const query = useQuery<BridgeTransaction, Error>({
+    queryKey: ['bridge-transaction', id],
+    queryFn: ({ signal }) => fetchBridgeTransaction(id, signal),
+    enabled: Boolean(id),
+    refetchInterval: computeDetailRefetchInterval,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: 'always',
+    retry: 3,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 10_000),
+  })
+
+  return {
+    transaction: query.data ?? null,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isError: query.isError,
+    error: query.error,
+    refresh: () => {
+      void query.refetch()
+    },
+  }
+}

--- a/src/hooks/useBridgeTx.ts
+++ b/src/hooks/useBridgeTx.ts
@@ -1,0 +1,84 @@
+'use client'
+
+import { useQuery, type Query } from '@tanstack/react-query'
+import { fetchBridgeTransactions } from '@/src/lib/api/bridge'
+import { isTerminalBridgeStatus, type BridgeChain, type BridgeTransactionListResponse, type BridgeTxStatus } from '@/src/types/bridge'
+
+const POLL_INTERVAL_MS = 10_000
+const MAX_POLL_INTERVAL_MS = 80_000
+
+/**
+ * Backs off exponentially (10s, 20s, 40s, 80s cap) on consecutive poll
+ * failures instead of hammering every 10s, and stops polling entirely once
+ * every transaction in the current page/filter is terminal.
+ */
+export function computeRefetchInterval(query: Query<BridgeTransactionListResponse, Error>): number | false {
+  const data = query.state.data
+  if (data && !data.transactions.some((tx) => !isTerminalBridgeStatus(tx.status))) {
+    return false
+  }
+
+  const failures = query.state.fetchFailureCount
+  if (failures > 0) {
+    return Math.min(POLL_INTERVAL_MS * 2 ** failures, MAX_POLL_INTERVAL_MS)
+  }
+
+  return POLL_INTERVAL_MS
+}
+
+export interface UseBridgeTxParams {
+  chain?: BridgeChain
+  status?: BridgeTxStatus
+  dateFrom?: string
+  dateTo?: string
+  page: number
+  pageSize: number
+}
+
+export interface UseBridgeTxResult {
+  transactions: BridgeTransactionListResponse['transactions']
+  total: number
+  isLoading: boolean
+  isFetching: boolean
+  isError: boolean
+  error: Error | null
+  refresh: () => void
+  hasActive: boolean
+}
+
+/**
+ * Fetches /api/v1/bridge/transactions and polls every 10s, but only while at
+ * least one transaction on the current page/filter is non-terminal. Filter
+ * and page changes produce a distinct query key, so a slow response for a
+ * previous filter/page can never overwrite the current view (React Query
+ * keys and aborts by query key). Polling automatically pauses while the tab
+ * is hidden and does a fresh fetch on refocus (see refetchIntervalInBackground
+ * / refetchOnWindowFocus below).
+ */
+export function useBridgeTx({ chain, status, dateFrom, dateTo, page, pageSize }: UseBridgeTxParams): UseBridgeTxResult {
+  const query = useQuery<BridgeTransactionListResponse, Error>({
+    queryKey: ['bridge-transactions', chain, status, dateFrom, dateTo, page, pageSize],
+    queryFn: ({ signal }) => fetchBridgeTransactions({ chain, status, dateFrom, dateTo, page, pageSize, signal }),
+    refetchInterval: computeRefetchInterval,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: 'always',
+    retry: 3,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 10_000),
+  })
+
+  const transactions = query.data?.transactions ?? []
+  const hasActive = transactions.some((tx) => !isTerminalBridgeStatus(tx.status))
+
+  return {
+    transactions,
+    total: query.data?.total ?? 0,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isError: query.isError,
+    error: query.error,
+    refresh: () => {
+      void query.refetch()
+    },
+    hasActive,
+  }
+}

--- a/src/lib/api/bridge.ts
+++ b/src/lib/api/bridge.ts
@@ -1,0 +1,89 @@
+import type { BridgeChain, BridgeTransaction, BridgeTransactionListResponse, BridgeTxStatus } from '@/src/types/bridge'
+
+// /api/v1/bridge/transactions does not exist yet on the backend. This module
+// is the sole seam that talks to it - assumptions about the request/response
+// shape are documented on the #95 PR and are safe to change here without
+// touching callers (useBridgeTx, BridgeTransactionList).
+const BASE = '/api/v1/bridge'
+
+export interface FetchBridgeTransactionsParams {
+  chain?: BridgeChain
+  status?: BridgeTxStatus
+  /** ISO date (yyyy-mm-dd), inclusive. Filters on initiatedAt. */
+  dateFrom?: string
+  dateTo?: string
+  page: number
+  pageSize: number
+  signal?: AbortSignal
+}
+
+async function parseErrorMessage(res: Response, fallback: string): Promise<string> {
+  const body = await res.json().catch(() => ({ message: fallback }))
+  return (body as { message?: string }).message ?? fallback
+}
+
+export async function fetchBridgeTransactions({
+  chain,
+  status,
+  dateFrom,
+  dateTo,
+  page,
+  pageSize,
+  signal,
+}: FetchBridgeTransactionsParams): Promise<BridgeTransactionListResponse> {
+  const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize) })
+  if (chain) params.set('chain', chain)
+  if (status) params.set('status', status)
+  if (dateFrom) params.set('dateFrom', dateFrom)
+  if (dateTo) params.set('dateTo', dateTo)
+
+  const res = await fetch(`${BASE}/transactions?${params.toString()}`, {
+    headers: { Accept: 'application/json' },
+    credentials: 'include',
+    signal,
+  })
+
+  if (!res.ok) {
+    throw new Error(await parseErrorMessage(res, `Failed to load bridge transactions: ${res.status}`))
+  }
+
+  return res.json()
+}
+
+export async function fetchBridgeTransaction(id: string, signal?: AbortSignal): Promise<BridgeTransaction> {
+  const res = await fetch(`${BASE}/transactions/${id}`, {
+    headers: { Accept: 'application/json' },
+    credentials: 'include',
+    signal,
+  })
+
+  if (!res.ok) {
+    throw new Error(await parseErrorMessage(res, `Failed to load bridge transaction: ${res.status}`))
+  }
+
+  return res.json()
+}
+
+export async function retryBridgeTransaction(id: string): Promise<void> {
+  const res = await fetch(`${BASE}/transactions/${id}/retry`, {
+    method: 'POST',
+    headers: { Accept: 'application/json' },
+    credentials: 'include',
+  })
+
+  if (!res.ok) {
+    throw new Error(await parseErrorMessage(res, `Retry failed: ${res.status}`))
+  }
+}
+
+export async function claimStuckDeposit(id: string): Promise<void> {
+  const res = await fetch(`${BASE}/transactions/${id}/claim`, {
+    method: 'POST',
+    headers: { Accept: 'application/json' },
+    credentials: 'include',
+  })
+
+  if (!res.ok) {
+    throw new Error(await parseErrorMessage(res, `Claim failed: ${res.status}`))
+  }
+}

--- a/src/types/bridge.ts
+++ b/src/types/bridge.ts
@@ -1,0 +1,90 @@
+// Cross-chain bridge transaction tracking (#95).
+//
+// Status pipeline: initiated -> source_confirmed -> bridge_in_progress ->
+// dest_confirmed -> complete. A transaction can instead land in one of the
+// two failure states once funds have left the source chain. Failure states
+// are TERMINAL for polling purposes (nothing changes server-side without a
+// user action - retry/claim - which itself triggers a fresh fetch), but they
+// are NOT "done": the UI keeps surfacing them as needing attention rather
+// than as a finished row.
+
+export const BRIDGE_CHAINS = ['ethereum', 'polygon', 'arbitrum', 'optimism', 'base'] as const
+export type BridgeChain = (typeof BRIDGE_CHAINS)[number]
+
+export const BRIDGE_TX_STATUS = [
+  'initiated',
+  'source_confirmed',
+  'bridge_in_progress',
+  'dest_confirmed',
+  'complete',
+  'failed_gas',
+  'failed_stuck_deposit',
+] as const
+export type BridgeTxStatus = (typeof BRIDGE_TX_STATUS)[number]
+
+/** The five pipeline stages shown by the status stepper, in order. Failure states branch off but don't add a stage. */
+export const BRIDGE_PIPELINE_STAGES = [
+  'initiated',
+  'source_confirmed',
+  'bridge_in_progress',
+  'dest_confirmed',
+  'complete',
+] as const satisfies readonly BridgeTxStatus[]
+export type BridgePipelineStage = (typeof BRIDGE_PIPELINE_STAGES)[number]
+
+export const TERMINAL_BRIDGE_STATUSES = [
+  'complete',
+  'failed_gas',
+  'failed_stuck_deposit',
+] as const satisfies readonly BridgeTxStatus[]
+
+export function isTerminalBridgeStatus(status: BridgeTxStatus): boolean {
+  return (TERMINAL_BRIDGE_STATUSES as readonly BridgeTxStatus[]).includes(status)
+}
+
+export function isBridgeFailureStatus(
+  status: BridgeTxStatus,
+): status is Extract<BridgeTxStatus, 'failed_gas' | 'failed_stuck_deposit'> {
+  return status === 'failed_gas' || status === 'failed_stuck_deposit'
+}
+
+export type BridgeFailureReason =
+  | { type: 'gas_failure'; message: string; suggestedGasGwei?: number }
+  | { type: 'stuck_deposit'; message: string; claimableAt?: string }
+  | { type: 'unknown'; message: string }
+
+export interface BridgeTransaction {
+  id: string
+  sourceChain: BridgeChain
+  destChain: BridgeChain
+  status: BridgeTxStatus
+  tokenSymbol: string
+  /** Decimal string, e.g. "1.5" - avoids float drift for on-chain amounts. */
+  amount: string
+  initiatedAt: string
+  completedAt: string | null
+  sourceTxHash: string
+  destTxHash: string | null
+  sourceConfirmations: number
+  requiredSourceConfirmations: number
+  /** 0 until funds have left the source chain (bridge_in_progress or later). */
+  destConfirmations: number
+  requiredDestConfirmations: number
+  /** null unless status is a failure state. */
+  failureReason: BridgeFailureReason | null
+  /** null until the source leg is confirmed. */
+  sourceGasUsed: string | null
+  /** Pre-execution quote, available from initiation onward. Distinct from destGasUsed (the actual amount, known only after execution). */
+  estimatedDestGas: string | null
+  /** null until the destination leg has actually executed. */
+  destGasUsed: string | null
+  /** Total cost of the transfer in USD, as supplied by the API. Never recomputed client-side. */
+  usdCost: number | null
+}
+
+export interface BridgeTransactionListResponse {
+  transactions: BridgeTransaction[]
+  total: number
+  page: number
+  pageSize: number
+}

--- a/src/utils/bridgeFormat.ts
+++ b/src/utils/bridgeFormat.ts
@@ -1,0 +1,32 @@
+import type { BridgeTxStatus } from '@/src/types/bridge'
+
+const STATUS_LABELS: Record<BridgeTxStatus, string> = {
+  initiated: 'Initiated',
+  source_confirmed: 'Source Confirmed',
+  bridge_in_progress: 'Bridge In Progress',
+  dest_confirmed: 'Destination Confirmed',
+  complete: 'Complete',
+  failed_gas: 'Failed (Gas)',
+  failed_stuck_deposit: 'Failed (Stuck Deposit)',
+}
+
+export function bridgeStatusLabel(status: BridgeTxStatus): string {
+  return STATUS_LABELS[status]
+}
+
+export function formatUsd(value: number | null): string {
+  if (value === null) return 'Pending'
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value)
+}
+
+/** Formats a whole-seconds duration as e.g. "3m 20s" / "1h 05m". Negative or non-finite input renders as "0s". */
+export function formatDurationSeconds(totalSeconds: number): string {
+  const seconds = Number.isFinite(totalSeconds) ? Math.max(0, Math.round(totalSeconds)) : 0
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  const secs = seconds % 60
+
+  if (hours > 0) return `${hours}h ${String(minutes).padStart(2, '0')}m`
+  if (minutes > 0) return `${minutes}m ${String(secs).padStart(2, '0')}s`
+  return `${secs}s`
+}

--- a/src/utils/bridgeStages.ts
+++ b/src/utils/bridgeStages.ts
@@ -1,0 +1,42 @@
+import { BRIDGE_PIPELINE_STAGES, isBridgeFailureStatus, type BridgeTxStatus } from '@/src/types/bridge'
+
+export type BridgeStageStatus = 'done' | 'current' | 'upcoming' | 'failed'
+
+// Both failure states are modeled as having completed source confirmation and
+// then stalling during the bridge relay leg - funds have left the source
+// chain but the API does not report a more granular failure stage than
+// "gas failure" / "stuck deposit", both of which occur once funds are in
+// transit. Documented assumption (see #95 PR description).
+const FAILURE_STAGE_INDEX = BRIDGE_PIPELINE_STAGES.indexOf('bridge_in_progress')
+
+export function getStageStatuses(status: BridgeTxStatus): BridgeStageStatus[] {
+  if (isBridgeFailureStatus(status)) {
+    return BRIDGE_PIPELINE_STAGES.map((_, i) =>
+      i < FAILURE_STAGE_INDEX ? 'done' : i === FAILURE_STAGE_INDEX ? 'failed' : 'upcoming',
+    )
+  }
+  const currentIndex = BRIDGE_PIPELINE_STAGES.indexOf(status)
+  return BRIDGE_PIPELINE_STAGES.map((_, i) => (i < currentIndex ? 'done' : i === currentIndex ? 'current' : 'upcoming'))
+}
+
+export const BRIDGE_STAGE_DOT_CLASSES: Record<BridgeStageStatus, string> = {
+  done: 'bg-emerald-500',
+  current: 'bg-sky-500',
+  upcoming: 'bg-slate-700',
+  failed: 'bg-red-500',
+}
+
+/** Icon glyphs so stage state is never conveyed by color alone. */
+export const BRIDGE_STAGE_ICONS: Record<BridgeStageStatus, string> = {
+  done: '✓',
+  current: '●',
+  upcoming: '○',
+  failed: '✕',
+}
+
+export const BRIDGE_STAGE_STATUS_TEXT: Record<BridgeStageStatus, string> = {
+  done: 'done',
+  current: 'in progress',
+  upcoming: 'pending',
+  failed: 'failed',
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,36 @@
+// NOTE: this file was deleted from main in commit 49287e7 ("Remove all test
+// files") along with .github/workflows/test.yml, and recovered verbatim from
+// git history (87f72ca) while implementing #95. Without it, vitest cannot
+// resolve the `@/*` alias and every existing test fails to import. Do not
+// delete this file again without restoring an equivalent alias config.
+//
+// The '@/src' entry was added on top of the recovered version: tsconfig.json
+// maps "@/*" to both "./src/*" and "./*", so application code imports under
+// both `@/hooks/x` and `@/src/hooks/x` interchangeably (both resolve to the
+// same file under TS). The original alias map here only covered the former;
+// without '@/src' as a distinct, more specific entry, imports like
+// `@/src/hooks/useSlashingStream` resolve to the nonexistent `./src/src/...`.
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+// Scoped to colocated unit tests under src/. The Playwright e2e specs in e2e/
+// are intentionally excluded so the two runners never collide. Suites that need
+// a DOM opt in per-file via `// @vitest-environment jsdom`.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@/src': path.resolve(__dirname, './src'),
+      '@': path.resolve(__dirname, './src'),
+      '@/types': path.resolve(__dirname, './src/types'),
+      '@/utils': path.resolve(__dirname, './src/utils'),
+      '@/services': path.resolve(__dirname, './src/services'),
+      '@/hooks': path.resolve(__dirname, './src/hooks'),
+      '@/components': path.resolve(__dirname, './src/components'),
+      '@/store': path.resolve(__dirname, './src/store'),
+    },
+  },
+  test: {
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
Closes #95

Adds `/bridge` (filterable, paginated list) and `/bridge/:id` (detail with timeline, confirmations, gas, USD cost), polling every 10s while a transaction is non-terminal.

## ⚠️ The API doesn't exist yet — please review the assumed contract
`/api/v1/bridge/transactions` has no route handler, mock, or consumer anywhere in the repo. Everything below is invented to unblock frontend work and needs backend sign-off before it hardens. All of it lives behind one module (`src/lib/api/bridge.ts`), so corrections are cheap now and expensive later.

1. **Paths**: `/api/v1/bridge/transactions`, `/transactions/:id`, `/transactions/:id/retry`, `/transactions/:id/claim`
2. **List params**: `chain`, `status`, `dateFrom`, `dateTo` (optional), `page`, `pageSize` (required). Date filters assumed inclusive `yyyy-mm-dd` filtering on `initiatedAt`, not `completedAt`
3. **Envelope**: `{ transactions, total, page, pageSize }` — `total` assumed to be the *filtered* count
4. **Ordering**: newest-first and *stable across polls* — rows key by `tx.id` and rely on stable relative order so value patches don't visually reorder
5. **Status enum — the biggest bet**: exactly 7 values (`initiated`, `source_confirmed`, `bridge_in_progress`, `dest_confirmed`, `complete`, `failed_gas`, `failed_stuck_deposit`). Different or more granular backend states break every stepper consumer
6. **Failure branching**: both failure states assumed reachable only mid-`bridge_in_progress`. If gas failures can occur *before* source confirmation, the stepper shows a false "source confirmed" check
7. **`failureReason`**: discriminated union with optional `suggestedGasGwei` / `claimableAt` (defined but unused today). Unrecognized types render no action button — safe default, but it's a closed match, not exhaustive
8. **Confirmations**: plain integers; `destConfirmations` assumed `0` (not `null`) pre-departure
9. **Gas**: three nullable fields — `sourceGasUsed`, `estimatedDestGas`, `destGasUsed`. If the backend returns one `destGas` meaning different things at different stages, the 3-column breakdown collapses to 2
10. **`usdCost`**: assumed API-supplied, `null` until complete, never recomputed client-side (this frontend has no L2 gas-token price feed). If the backend won't compute it, incomplete transactions render "Pending" forever
11. **Route time estimates are fabricated placeholder data** — `BRIDGE_ROUTE_ESTIMATE_SECONDS` (`bridgeChains.ts:43-54`) is a hardcoded min/max table invented from rough L1↔L2 finality intuition. The entire `EstimatedCompletion` progress bar rests on it. `getBridgeRouteEstimateSeconds` is the single seam to replace with real historical percentiles
12. **Retry/claim**: POST, no body, 2xx on success, `{ message }` on failure; assumed idempotent enough that in-flight button disabling suffices
13. **Auth**: cookie-based (`credentials: 'include'`), no Authorization header
14. **Chains**: exactly 5 (ethereum, polygon, arbitrum, optimism, base), not driven by an API-supplied list

## Deliverables
- [x] **`BridgeTransactionList`** with per-row color-coded stepper — `BridgeTransactionList.tsx:215`, `BridgeStatusStepper.tsx:33`. Color is never the sole signal: each stage carries an icon glyph and title tooltip, asserted by `BridgeStatusStepper.test.tsx:17-26`
- [x] **`BridgeTransactionDetail`** with timeline, per-stage confirmations, 3-field gas breakdown, estimated-vs-actual time — `BridgeTransactionTimeline.tsx:16-98`
- [x] **`useBridgeTx`** polling `/api/v1/bridge/transactions` every 10s, **active-only** — `useBridgeTx.ts:7,16-26`
- [x] **`EstimatedCompletion`** column with progress bar + remaining time — `EstimatedCompletion.tsx:34-49`
- [x] **Failure recovery** with error reason + type-gated action — `BridgeFailureRecovery.tsx:47-73`
- [x] **Browser notification on status change** — `useBridgeNotifications.ts:27-49,106-108`

## The three behaviors I flagged when applying
1. **Polling stops when all tracked txs are terminal** — `computeRefetchInterval` returns `false` once every tx is terminal (TanStack Query's stop signal). Proven by `useBridgeTx.test.tsx:98-115`: advances 30s (three would-be intervals), fetch count stays at 1
2. **Notifications fire on transition only, never per poll tick** — compares against last-known status, not object identity. Positive case at `useBridgeNotifications.test.tsx:44-54`; negative case at `:56-66` re-renders with new object references at the same status (exactly what a poll refetch produces) and asserts zero notifications
3. **Recovery buttons gated on actual failure type** — two independent `type ===` guards, not if/else, so an unrecognized type falls through both. `BridgeFailureRecovery.test.tsx:19-35` (gas → Retry only), `:37-51` (stuck → Claim only), `:53-58` (unknown → neither)

## Design decisions
- **Polling via TanStack Query `refetchInterval`, diverging from the repo's 10 hand-rolled `setInterval` hooks.** Bridge polling needed stop-when-terminal, backoff on failure, and no-overlap-with-in-flight — all tested primitives in TanStack Query, which is already wired at the root (`QueryProvider`) with three hooks on it. `computeRefetchInterval` is exported as a pure function so the interval/backoff/stop logic is unit-testable without faking timers. Happy to hand-roll for consistency if you'd prefer
- **Server-side filtering/pagination via URL search params** — history is unbounded per user, so client-side filtering would force every poll to refetch everything; also makes views shareable
- **Terminal-for-polling ≠ terminal-for-UI** — failure states stop polling (nothing changes without user action) but render as "Action needed" in red, not as finished
- **Progress measured against `route.max`** — bar hits 100% exactly at the slowest historical time for that route, then clamps, turns amber, and swaps remaining-time copy for "Taking longer than expected" rather than showing negatives. `now` is caller-supplied, snapshotted once per poll tick, since reading the wall clock during render is impure
- **Notifications are two-gate opt-in** — `requestPermission()` only from an explicit toggle click, never on mount; transitions tracked in a module-level Map so remounting `/bridge` doesn't re-fire

## `vitest.config.ts` → `vitest.config.mts` (the only non-bridge file touched)
The config was deleted from `main` in commit `49287e7` ("Remove all test files"), so **no test in this repo — bridge or otherwise — could run**. Recovered verbatim from `87f72ca`, plus one added alias entry (`@/src`) because `tsconfig.json` maps `@/*` to both `./src/*` and `./*` and app code imports interchangeably.

Renamed to `.mts` for a separate reason: `vite@7.3.5` is ESM-only but this package has no `"type": "module"`, so Node loaded the config as CJS and threw `ERR_REQUIRE_ESM` before collecting a single test.

`next.config.ts` shows zero net diff (a temporary local-only edit was reverted in-session).

## Tests
54/55 passing. The one failure — `useSlashingStream > should respect dedup TTL window` — is pre-existing from commit `145ee05`, unrelated to and unmodified by this work. `tsc --noEmit` and `eslint` are clean across every bridge file; the remaining typecheck errors (missing `three` module, slashing hooks) also predate this branch.
---
Feature Implemented and Task completed
@JamesEjembi Please Review