### PR TITLE
feat: Webhook Delivery Service with Retry and Signature Verification (#108)

### DIFF
--- a/src/services/tests/webhookService.test.ts
+++ b/src/services/tests/webhookService.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Unit tests for webhook delivery service (#108)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  createWebhookService,
+  signPayload,
+  verifySignature,
+  computeNextDelay,
+  SIGNATURE_HEADER,
+  type WebhookEvent,
+  type WebhookService,
+  type DeliveryRecord,
+} from '../webhookService'
+
+// Mock fetch for controlled testing
+const mockFetch = vi.fn()
+global.fetch = mockFetch as unknown as typeof fetch
+
+describe('webhookService', () => {
+  const SECRET = 'test-secret-key-for-hmac'
+  const TARGET_URL = 'https://webhook.example.com/events'
+
+  beforeEach(() => {
+    mockFetch.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('signPayload — HMAC-SHA256 signing', () => {
+    it('generates deterministic sha256=<hex> signature', async () => {
+      const payload = '{"test":"data"}'
+      const sig1 = await signPayload(payload, SECRET)
+      const sig2 = await signPayload(payload, SECRET)
+
+      expect(sig1).toMatch(/^sha256=[0-9a-f]{64}$/)
+      expect(sig1).toBe(sig2) // deterministic
+    })
+
+    it('produces different signatures for different secrets', async () => {
+      const payload = '{"test":"data"}'
+      const sig1 = await signPayload(payload, 'secret-a')
+      const sig2 = await signPayload(payload, 'secret-b')
+
+      expect(sig1).not.toBe(sig2)
+    })
+
+    it('produces different signatures for different payloads', async () => {
+      const sig1 = await signPayload('{"test":"data"}', SECRET)
+      const sig2 = await signPayload('{"test":"modified"}', SECRET)
+
+      expect(sig1).not.toBe(sig2)
+    })
+  })
+
+  describe('verifySignature — constant-time HMAC verification', () => {
+    it('accepts valid signatures', async () => {
+      const payload = '{"test":"data"}'
+      const signature = await signPayload(payload, SECRET)
+      const valid = await verifySignature(payload, signature, SECRET)
+
+      expect(valid).toBe(true)
+    })
+
+    it('rejects signatures generated with a different secret', async () => {
+      const payload = '{"test":"data"}'
+      const signature = await signPayload(payload, 'wrong-secret')
+      const valid = await verifySignature(payload, signature, SECRET)
+
+      expect(valid).toBe(false)
+    })
+
+    it('rejects tampered payloads', async () => {
+      const original = '{"test":"data"}'
+      const signature = await signPayload(original, SECRET)
+      const tampered = '{"test":"tampered"}'
+      const valid = await verifySignature(tampered, signature, SECRET)
+
+      expect(valid).toBe(false)
+    })
+
+    it('rejects malformed signatures', async () => {
+      const payload = '{"test":"data"}'
+
+      expect(await verifySignature(payload, 'not-a-signature', SECRET)).toBe(false)
+      expect(await verifySignature(payload, 'sha256=', SECRET)).toBe(false)
+      expect(await verifySignature(payload, 'sha256=short', SECRET)).toBe(false)
+      expect(await verifySignature(payload, 'sha256=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz', SECRET)).toBe(false)
+    })
+  })
+
+  describe('computeNextDelay — exponential backoff with jitter', () => {
+    it('grows exponentially (bounded by maxDelayMs)', () => {
+      const baseMs = 1000
+      const maxMs = 30_000
+
+      // attempt 0 (first retry): 0..1000
+      const d0 = computeNextDelay(0, baseMs, maxMs)
+      expect(d0).toBeGreaterThanOrEqual(0)
+      expect(d0).toBeLessThanOrEqual(1000)
+
+      // attempt 1: 0..2000
+      const d1 = computeNextDelay(1, baseMs, maxMs)
+      expect(d1).toBeGreaterThanOrEqual(0)
+      expect(d1).toBeLessThanOrEqual(2000)
+
+      // attempt 2: 0..4000
+      const d2 = computeNextDelay(2, baseMs, maxMs)
+      expect(d2).toBeGreaterThanOrEqual(0)
+      expect(d2).toBeLessThanOrEqual(4000)
+
+      // attempt 10: should be capped at maxMs
+      const d10 = computeNextDelay(10, baseMs, maxMs)
+      expect(d10).toBeGreaterThanOrEqual(0)
+      expect(d10).toBeLessThanOrEqual(maxMs)
+    })
+
+    it('applies jitter (non-deterministic)', () => {
+      const samples = Array.from({ length: 10 }, () =>
+        computeNextDelay(0, 1000, 30_000),
+      )
+      const unique = new Set(samples)
+      // With 10 samples and full jitter, we expect at least 2 distinct values
+      // (can occasionally fail with extremely low probability).
+      expect(unique.size).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('createWebhookService — delivery lifecycle', () => {
+    let service: WebhookService
+
+    beforeEach(() => {
+      service = createWebhookService({
+        secret: SECRET,
+        maxAttempts: 5,
+        baseDelayMs: 100, // short delays for fast tests
+        maxDelayMs: 500,
+      })
+    })
+
+    it('delivers successfully on first attempt (HTTP 200)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      } as Response)
+
+      const event: WebhookEvent = {
+        id: 'evt-1',
+        type: 'validator.attested',
+        createdAt: Date.now(),
+        payload: { validatorIndex: 42 },
+      }
+
+      const record = await service.deliver(event, TARGET_URL)
+
+      expect(record.status).toBe('delivered')
+      expect(record.attempts).toBe(1)
+      expect(record.lastHttpStatus).toBe(200)
+      expect(record.lastError).toBeNull()
+
+      // Verify fetch was called once with correct headers
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      const [url, init] = mockFetch.mock.calls[0]
+      expect(url).toBe(TARGET_URL)
+      expect(init.method).toBe('POST')
+      expect(init.headers['Content-Type']).toBe('application/json')
+      expect(init.headers[SIGNATURE_HEADER]).toMatch(/^sha256=[0-9a-f]{64}$/)
+      expect(init.headers['X-VeriNode-Event']).toBe('validator.attested')
+      expect(init.headers['X-VeriNode-Delivery']).toBe(record.deliveryId)
+    })
+
+    it('retries on HTTP 500 and eventually succeeds', async () => {
+      // First two attempts fail, third succeeds
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+        .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+        .mockResolvedValueOnce({ ok: true, status: 200 } as Response)
+
+      const event: WebhookEvent = {
+        id: 'evt-2',
+        type: 'staking.confirmed',
+        createdAt: Date.now(),
+        payload: { amount: 100 },
+      }
+
+      const record = await service.deliver(event, TARGET_URL)
+
+      expect(record.status).toBe('delivered')
+      expect(record.attempts).toBe(3)
+      expect(record.lastHttpStatus).toBe(200)
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+    })
+
+    it('marks delivery as failed after max attempts exhausted', async () => {
+      // All 5 attempts fail
+      mockFetch.mockResolvedValue({ ok: false, status: 503 } as Response)
+
+      const event: WebhookEvent = {
+        id: 'evt-3',
+        type: 'node.offline',
+        createdAt: Date.now(),
+        payload: { nodeId: 'n-123' },
+      }
+
+      const record = await service.deliver(event, TARGET_URL)
+
+      expect(record.status).toBe('failed')
+      expect(record.attempts).toBe(5)
+      expect(record.lastHttpStatus).toBe(503)
+      expect(mockFetch).toHaveBeenCalledTimes(5)
+    })
+
+    it('handles network errors (fetch throws)', async () => {
+      mockFetch.mockRejectedValue(new Error('ECONNREFUSED'))
+
+      const event: WebhookEvent = {
+        id: 'evt-4',
+        type: 'governance.proposalCreated',
+        createdAt: Date.now(),
+        payload: { proposalId: 'p-42' },
+      }
+
+      const record = await service.deliver(event, TARGET_URL)
+
+      expect(record.status).toBe('failed')
+      expect(record.attempts).toBe(5)
+      expect(record.lastHttpStatus).toBeNull()
+      expect(record.lastError).toMatch(/ECONNREFUSED/)
+    })
+
+    it('records all deliveries in getDeliveryRecords()', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 } as Response)
+
+      const event1: WebhookEvent = {
+        id: 'evt-a',
+        type: 'validator.attested',
+        createdAt: Date.now(),
+        payload: {},
+      }
+      const event2: WebhookEvent = {
+        id: 'evt-b',
+        type: 'validator.slashed',
+        createdAt: Date.now(),
+        payload: {},
+      }
+
+      await service.deliver(event1, TARGET_URL)
+      await service.deliver(event2, TARGET_URL)
+
+      const records = service.getDeliveryRecords()
+      expect(records).toHaveLength(2)
+      expect(records.map((r) => r.event.id)).toEqual(['evt-a', 'evt-b'])
+    })
+
+    it('incremental status updates reflected in getDeliveryRecords()', async () => {
+      // Let the first attempt fail so we can observe pending status briefly.
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+        .mockResolvedValueOnce({ ok: true, status: 200 } as Response)
+
+      const event: WebhookEvent = {
+        id: 'evt-5',
+        type: 'staking.failed',
+        createdAt: Date.now(),
+        payload: {},
+      }
+
+      const promise = service.deliver(event, TARGET_URL)
+
+      // The record should exist immediately (status: pending, attempts: 0).
+      let records = service.getDeliveryRecords()
+      expect(records).toHaveLength(1)
+      expect(records[0].status).toBe('pending')
+
+      await promise
+
+      // After completion: status delivered, attempts 2.
+      records = service.getDeliveryRecords()
+      expect(records[0].status).toBe('delivered')
+      expect(records[0].attempts).toBe(2)
+    })
+  })
+
+  describe('createWebhookService — signature verification API', () => {
+    let service: WebhookService
+
+    beforeEach(() => {
+      service = createWebhookService({ secret: SECRET })
+    })
+
+    it('service.sign() wraps signPayload with the configured secret', async () => {
+      const payload = '{"test":"data"}'
+      const sig1 = await service.sign(payload)
+      const sig2 = await signPayload(payload, SECRET)
+
+      expect(sig1).toBe(sig2)
+    })
+
+    it('service.verify() wraps verifySignature with the configured secret', async () => {
+      const payload = '{"test":"data"}'
+      const signature = await service.sign(payload)
+
+      const valid = await service.verify(payload, signature)
+      const invalid = await service.verify(payload, 'sha256=0000000000000000000000000000000000000000000000000000000000000000')
+
+      expect(valid).toBe(true)
+      expect(invalid).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles empty payloads', async () => {
+      const sig = await signPayload('', SECRET)
+      const valid = await verifySignature('', sig, SECRET)
+      expect(valid).toBe(true)
+    })
+
+    it('handles large payloads (>10 KB)', async () => {
+      const largePayload = JSON.stringify({ data: 'x'.repeat(20_000) })
+      const sig = await signPayload(largePayload, SECRET)
+      const valid = await verifySignature(largePayload, sig, SECRET)
+      expect(valid).toBe(true)
+    })
+
+    it('handles unicode payloads', async () => {
+      const payload = JSON.stringify({ message: 'こんにちは 🌍' })
+      const sig = await signPayload(payload, SECRET)
+      const valid = await verifySignature(payload, sig, SECRET)
+      expect(valid).toBe(true)
+    })
+
+    it('generates unique delivery IDs for concurrent deliveries', async () => {
+      mockFetch.mockResolvedValue({ ok: true, status: 200 } as Response)
+
+      const service = createWebhookService({ secret: SECRET })
+      const event: WebhookEvent = {
+        id: 'evt-concurrent',
+        type: 'validator.attested',
+        createdAt: Date.now(),
+        payload: {},
+      }
+
+      const [r1, r2, r3] = await Promise.all([
+        service.deliver(event, TARGET_URL),
+        service.deliver(event, TARGET_URL),
+        service.deliver(event, TARGET_URL),
+      ])
+
+      const ids = [r1.deliveryId, r2.deliveryId, r3.deliveryId]
+      const unique = new Set(ids)
+      expect(unique.size).toBe(3)
+    })
+  })
+
+  describe('real-world scenario: webhook receiver validation', () => {
+    it('end-to-end: sign on sender, verify on receiver', async () => {
+      const senderService = createWebhookService({ secret: SECRET })
+      const receiverService = createWebhookService({ secret: SECRET })
+
+      const event: WebhookEvent = {
+        id: 'evt-e2e',
+        type: 'governance.proposalResolved',
+        createdAt: Date.now(),
+        payload: { proposalId: 'p-999', result: 'approved' },
+      }
+
+      const body = JSON.stringify(event)
+      const signature = await senderService.sign(body)
+
+      // Receiver validates the signature before processing
+      const valid = await receiverService.verify(body, signature)
+      expect(valid).toBe(true)
+
+      // Tampered body should fail verification
+      const tamperedBody = JSON.stringify({ ...event, payload: { ...event.payload, result: 'rejected' } })
+      const tamperedValid = await receiverService.verify(tamperedBody, signature)
+      expect(tamperedValid).toBe(false)
+    })
+
+    it('different secrets between sender and receiver fail verification', async () => {
+      const senderService = createWebhookService({ secret: 'sender-secret' })
+      const receiverService = createWebhookService({ secret: 'receiver-secret' })
+
+      const body = '{"test":"data"}'
+      const signature = await senderService.sign(body)
+      const valid = await receiverService.verify(body, signature)
+
+      expect(valid).toBe(false)
+    })
+  })
+
+  describe('performance: P99 < 100ms for signature operations', () => {
+    it('signPayload completes in <100ms for typical payloads', async () => {
+      const payload = JSON.stringify({
+        id: 'evt-perf',
+        type: 'validator.attested',
+        createdAt: Date.now(),
+        payload: { validatorIndex: 42, blockNumber: 1_000_000 },
+      })
+
+      const samples: number[] = []
+      for (let i = 0; i < 100; i++) {
+        const start = performance.now()
+        await signPayload(payload, SECRET)
+        samples.push(performance.now() - start)
+      }
+
+      samples.sort((a, b) => a - b)
+      const p99 = samples[98] // 99th percentile
+      expect(p99).toBeLessThan(100)
+    })
+
+    it('verifySignature completes in <100ms for typical payloads', async () => {
+      const payload = JSON.stringify({
+        id: 'evt-perf',
+        type: 'validator.attested',
+        createdAt: Date.now(),
+        payload: { validatorIndex: 42, blockNumber: 1_000_000 },
+      })
+      const signature = await signPayload(payload, SECRET)
+
+      const samples: number[] = []
+      for (let i = 0; i < 100; i++) {
+        const start = performance.now()
+        await verifySignature(payload, signature, SECRET)
+        samples.push(performance.now() - start)
+      }
+
+      samples.sort((a, b) => a - b)
+      const p99 = samples[98] // 99th percentile
+      expect(p99).toBeLessThan(100)
+    })
+  })
+})

--- a/src/services/webhookService.ts
+++ b/src/services/webhookService.ts
@@ -1,0 +1,310 @@
+/**
+ * Webhook Delivery Service with Retry and Signature Verification (#108)
+ *
+ * Provides:
+ *   - HMAC-SHA256 payload signing so receivers can verify authenticity.
+ *   - Exponential-backoff retry queue with jitter (max 5 attempts by default).
+ *   - Per-delivery status tracking: pending → delivered / failed.
+ *   - Delivery history accessible via `getDeliveryRecords()`.
+ *
+ * Design notes:
+ *   - All crypto uses the Web Crypto API (SubtleCrypto) — no extra dependencies.
+ *   - The service is environment-agnostic (works in both Node test environments
+ *     and the browser) because it only depends on the global `crypto` object.
+ *   - Factory functions mirror the pattern used throughout the codebase:
+ *     `createWebhookService(config)` for live use, plus pure utility exports
+ *     (`signPayload`, `verifySignature`, `computeNextDelay`) for isolated tests.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Well-known webhook event types produced by VeriNode services. */
+export type WebhookEventType =
+  | 'validator.attested'
+  | 'validator.slashed'
+  | 'validator.statusChanged'
+  | 'staking.confirmed'
+  | 'staking.failed'
+  | 'node.online'
+  | 'node.offline'
+  | 'governance.proposalCreated'
+  | 'governance.proposalResolved'
+
+/** A single webhook event envelope ready to be delivered. */
+export interface WebhookEvent {
+  /** Unique identifier for this event (UUID v4 or caller-supplied). */
+  id: string
+  /** Discriminator for the event type. */
+  type: WebhookEventType
+  /** Unix-millisecond timestamp of when the event was created. */
+  createdAt: number
+  /** Arbitrary domain-specific payload. Must be JSON-serialisable. */
+  payload: Record<string, unknown>
+}
+
+/** Delivery status lifecycle: pending → delivered | failed. */
+export type DeliveryStatus = 'pending' | 'delivered' | 'failed'
+
+/** Immutable record of a single delivery attempt / final outcome. */
+export interface DeliveryRecord {
+  deliveryId: string
+  event: WebhookEvent
+  targetUrl: string
+  status: DeliveryStatus
+  attempts: number
+  /** HTTP status from the last attempt, or null if it never reached the network. */
+  lastHttpStatus: number | null
+  /** Error message from the last attempt, or null on success. */
+  lastError: string | null
+  createdAt: number
+  updatedAt: number
+}
+
+/** Configuration supplied to `createWebhookService`. */
+export interface WebhookServiceConfig {
+  /**
+   * Secret used to generate the HMAC-SHA256 signature sent in the
+   * `X-VeriNode-Signature-256` header. Receivers must hold the same secret to
+   * verify deliveries.
+   */
+  secret: string
+  /**
+   * Maximum delivery attempts per event before the delivery is marked failed.
+   * @default 5
+   */
+  maxAttempts?: number
+  /**
+   * Base delay in milliseconds for the first retry (doubled each attempt).
+   * @default 1000
+   */
+  baseDelayMs?: number
+  /**
+   * Upper cap on the computed backoff delay in milliseconds.
+   * @default 30_000
+   */
+  maxDelayMs?: number
+}
+
+/** Public interface exposed by `createWebhookService`. */
+export interface WebhookService {
+  /**
+   * Deliver `event` to `targetUrl`. Retries automatically on transient failures.
+   * Resolves once the event is delivered or all retry attempts are exhausted.
+   */
+  deliver(event: WebhookEvent, targetUrl: string): Promise<DeliveryRecord>
+  /**
+   * Sign an arbitrary payload string with the configured secret. Returns the
+   * hex-encoded HMAC-SHA256 digest in the format `sha256=<hex>`.
+   */
+  sign(payload: string): Promise<string>
+  /**
+   * Verify that `signature` (in the format `sha256=<hex>`) matches the
+   * expected HMAC-SHA256 of `payload` under the configured secret.
+   */
+  verify(payload: string, signature: string): Promise<boolean>
+  /** Snapshot of all delivery records tracked since service creation. */
+  getDeliveryRecords(): ReadonlyArray<DeliveryRecord>
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const SIGNATURE_HEADER = 'X-VeriNode-Signature-256'
+const SIGNATURE_PREFIX = 'sha256='
+const DEFAULT_MAX_ATTEMPTS = 5
+const DEFAULT_BASE_DELAY_MS = 1_000
+const DEFAULT_MAX_DELAY_MS = 30_000
+
+// ─── Pure crypto utilities ────────────────────────────────────────────────────
+
+/**
+ * Imports a raw HMAC-SHA256 key from a UTF-8 secret string.
+ * Kept internal — callers use `signPayload` / `verifySignature`.
+ */
+async function importHmacKey(secret: string): Promise<CryptoKey> {
+  const enc = new TextEncoder()
+  return crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify'],
+  )
+}
+
+/**
+ * Converts an ArrayBuffer to a lowercase hex string.
+ */
+function bufferToHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Compute the HMAC-SHA256 signature of `payload` under `secret`.
+ * Returns the full header value, e.g. `sha256=abcd1234…`.
+ *
+ * Exported for isolated unit testing.
+ */
+export async function signPayload(payload: string, secret: string): Promise<string> {
+  const key = await importHmacKey(secret)
+  const enc = new TextEncoder()
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(payload))
+  return `${SIGNATURE_PREFIX}${bufferToHex(sig)}`
+}
+
+/**
+ * Verify that `signature` (format `sha256=<hex>`) is the correct HMAC-SHA256
+ * of `payload` under `secret`. Uses constant-time comparison via SubtleCrypto
+ * to prevent timing attacks.
+ *
+ * Returns `false` for malformed signatures rather than throwing.
+ *
+ * Exported for isolated unit testing.
+ */
+export async function verifySignature(
+  payload: string,
+  signature: string,
+  secret: string,
+): Promise<boolean> {
+  if (!signature.startsWith(SIGNATURE_PREFIX)) return false
+  const hexDigest = signature.slice(SIGNATURE_PREFIX.length)
+  // Validate hex string before proceeding
+  if (!/^[0-9a-f]{64}$/i.test(hexDigest)) return false
+
+  const key = await importHmacKey(secret)
+  const enc = new TextEncoder()
+
+  // Convert the provided hex digest back to bytes for SubtleCrypto.verify,
+  // which performs constant-time comparison internally.
+  const providedBytes = new Uint8Array(
+    hexDigest.match(/.{2}/g)!.map((byte) => parseInt(byte, 16)),
+  )
+  return crypto.subtle.verify('HMAC', key, providedBytes.buffer as ArrayBuffer, enc.encode(payload))
+}
+
+// ─── Retry backoff ────────────────────────────────────────────────────────────
+
+/**
+ * Compute the next retry delay using full-jitter exponential backoff.
+ *
+ *   delay = random(0, min(maxDelayMs, baseDelayMs * 2 ** attempt))
+ *
+ * `attempt` is 0-indexed (0 = first retry, after the initial attempt fails).
+ *
+ * Exported for isolated unit testing.
+ */
+export function computeNextDelay(
+  attempt: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+): number {
+  const cap = Math.min(maxDelayMs, baseDelayMs * Math.pow(2, attempt))
+  return Math.floor(Math.random() * cap)
+}
+
+// ─── Service factory ──────────────────────────────────────────────────────────
+
+/**
+ * Creates a webhook delivery service bound to a specific secret and retry
+ * configuration. Multiple instances can co-exist with different secrets.
+ */
+export function createWebhookService(config: WebhookServiceConfig): WebhookService {
+  const {
+    secret,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    maxDelayMs = DEFAULT_MAX_DELAY_MS,
+  } = config
+
+  const records = new Map<string, DeliveryRecord>()
+
+  function upsertRecord(partial: DeliveryRecord): DeliveryRecord {
+    records.set(partial.deliveryId, partial)
+    return partial
+  }
+
+  async function attemptDelivery(
+    record: DeliveryRecord,
+    body: string,
+    signature: string,
+  ): Promise<{ ok: boolean; httpStatus: number | null; error: string | null }> {
+    try {
+      const response = await fetch(record.targetUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          [SIGNATURE_HEADER]: signature,
+          'X-VeriNode-Event': record.event.type,
+          'X-VeriNode-Delivery': record.deliveryId,
+        },
+        body,
+      })
+      return { ok: response.ok, httpStatus: response.status, error: null }
+    } catch (err: unknown) {
+      const error = err instanceof Error ? err.message : 'Network error'
+      return { ok: false, httpStatus: null, error }
+    }
+  }
+
+  async function deliver(event: WebhookEvent, targetUrl: string): Promise<DeliveryRecord> {
+    const deliveryId =
+      typeof crypto !== 'undefined' && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `delivery-${Date.now()}-${Math.round(Math.random() * 1e9)}`
+
+    const now = Date.now()
+    let record: DeliveryRecord = upsertRecord({
+      deliveryId,
+      event,
+      targetUrl,
+      status: 'pending',
+      attempts: 0,
+      lastHttpStatus: null,
+      lastError: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const body = JSON.stringify(event)
+    const signature = await signPayload(body, secret)
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      // Apply backoff before every retry (not before the first attempt).
+      if (attempt > 0) {
+        const delay = computeNextDelay(attempt - 1, baseDelayMs, maxDelayMs)
+        await new Promise<void>((resolve) => setTimeout(resolve, delay))
+      }
+
+      const result = await attemptDelivery(record, body, signature)
+      record = upsertRecord({
+        ...record,
+        attempts: attempt + 1,
+        lastHttpStatus: result.httpStatus,
+        lastError: result.error,
+        status: result.ok ? 'delivered' : attempt + 1 < maxAttempts ? 'pending' : 'failed',
+        updatedAt: Date.now(),
+      })
+
+      if (result.ok) break
+    }
+
+    return record
+  }
+
+  return {
+    deliver,
+
+    sign(payload: string) {
+      return signPayload(payload, secret)
+    },
+
+    verify(payload: string, signature: string) {
+      return verifySignature(payload, signature, secret)
+    },
+
+    getDeliveryRecords() {
+      return [...records.values()]
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Implements the Webhook Delivery Service as described in issue #108.

Closes #108

---

## Changes

### src/services/webhookService.ts (new)
- Factory function createWebhookService(config) — bind a secret + retry policy once; call .deliver() for each event
- **HMAC-SHA256 signing** via Web Crypto SubtleCrypto — no new runtime dependencies
- Signature format: sha256=<64-hex-chars> sent in X-VeriNode-Signature-256 header (matches GitHub-style webhook convention)
- signPayload(payload, secret) and erifySignature(payload, sig, secret) exported as pure utilities; erifySignature uses SubtleCrypto constant-time comparison to prevent timing attacks
- **Exponential backoff with full jitter** (computeNextDelay) — caps at maxDelayMs (default 30 s), configurable maxAttempts (default 5)
- Delivery status machine: pending → delivered | failed
- Headers per delivery: X-VeriNode-Signature-256, X-VeriNode-Event, X-VeriNode-Delivery
- getDeliveryRecords() returns a snapshot of all tracked deliveries
- All types exported: WebhookEvent, WebhookEventType, DeliveryRecord, DeliveryStatus, WebhookServiceConfig, WebhookService

### src/services/tests/webhookService.test.ts (new)
25 unit tests covering:
- Signing determinism and per-secret isolation
- Constant-time verification and malformed-signature rejection (wrong secret, tampered payload, bad format)
- Backoff growth bounds and jitter distribution
- Retry on HTTP 5xx and network-level failures; successful resolution on eventual 200
- Failed after maxAttempts exhausted
- Delivery records tracked during in-flight concurrent deliveries
- End-to-end sign-on-sender / verify-on-receiver scenario
- P99 < 100ms performance assertions for both signPayload and erifySignature (100-sample benchmark)
- Edge cases: empty payloads, large (>10 KB) payloads, unicode payloads

---

## Testing

- All 25 new tests pass (✓ src/services/tests/webhookService.test.ts (25 tests))
- TypeScript: zero diagnostics on both new files
- No existing tests broken by these changes
- Pre-existing failures (	reeFlattener.test.ts, sanitize.test.ts) are unrelated to this PR

---

## References

https://github.com/VeriNode-Labs/VeriNode-Frontend/issues/108