### PR TITLE
feat(tracing): distributed tracing with OpenTelemetry and W3C trace c…

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,84 @@
+/**
+ * Next.js Instrumentation Hook — Distributed Tracing Bootstrap (#104)
+ *
+ * This file is loaded by Next.js once per runtime process (Node.js server and
+ * Edge runtime) before any application code runs.  It initialises the global
+ * `TracerProvider` so that all server-side spans share a single configured
+ * provider.
+ *
+ * Reference: https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ *
+ * Environment variables (all optional — sensible defaults apply):
+ *   NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT  — OTLP/HTTP collector URL
+ *   NEXT_PUBLIC_OTEL_EXPORTER_OTLP_HEADERS   — comma-separated "key=value" pairs
+ *   NEXT_PUBLIC_OTEL_SERVICE_NAME             — overrides "verinode-frontend"
+ *   NEXT_PUBLIC_OTEL_LOG_LEVEL                — set "debug" to enable console exporter
+ *   NEXT_PUBLIC_TRACE_SAMPLE_RATE             — float 0–1, default 1.0 (100%)
+ */
+
+export async function register(): Promise<void> {
+  const {
+    TracerProvider,
+    registerGlobalProvider,
+    ConsoleSpanExporter,
+    OtlpHttpExporter,
+    CompositeExporter,
+    TraceIdRatioSampler,
+    ParentBasedSampler,
+    AlwaysOnSampler,
+  } = await import('./src/services/tracing')
+
+  // ── Sampler ──────────────────────────────────────────────────────────────
+
+  const rawRate = process.env.NEXT_PUBLIC_TRACE_SAMPLE_RATE
+  const sampleRate = rawRate !== undefined ? parseFloat(rawRate) : 1.0
+  const rootSampler =
+    sampleRate >= 1.0
+      ? new AlwaysOnSampler()
+      : new TraceIdRatioSampler(Math.max(0, sampleRate))
+
+  const sampler = new ParentBasedSampler(rootSampler)
+
+  // ── Exporters ─────────────────────────────────────────────────────────────
+
+  const exporters = []
+
+  const endpoint = process.env.NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT
+  if (endpoint) {
+    // Parse optional "key=value,key2=value2" headers string.
+    const rawHeaders = process.env.NEXT_PUBLIC_OTEL_EXPORTER_OTLP_HEADERS ?? ''
+    const headers: Record<string, string> = {}
+    if (rawHeaders) {
+      for (const pair of rawHeaders.split(',')) {
+        const eqIdx = pair.indexOf('=')
+        if (eqIdx > 0) {
+          headers[pair.slice(0, eqIdx).trim()] = pair.slice(eqIdx + 1).trim()
+        }
+      }
+    }
+    exporters.push(new OtlpHttpExporter({ endpoint, headers }))
+  }
+
+  if (
+    process.env.NODE_ENV !== 'production' ||
+    process.env.NEXT_PUBLIC_OTEL_LOG_LEVEL === 'debug'
+  ) {
+    exporters.push(new ConsoleSpanExporter())
+  }
+
+  const exporter =
+    exporters.length === 0
+      ? { export: async () => {}, shutdown: async () => {} }
+      : exporters.length === 1
+        ? exporters[0]
+        : new CompositeExporter(exporters)
+
+  // ── Provider registration ─────────────────────────────────────────────────
+
+  const provider = new TracerProvider({
+    sampler,
+    exporters: [exporter],
+  })
+
+  registerGlobalProvider(provider)
+}

--- a/src/hooks/useTracing.ts
+++ b/src/hooks/useTracing.ts
@@ -1,0 +1,42 @@
+/**
+ * `useTracing` — React hook for distributed tracing (#104)
+ *
+ * Provides a stable `Tracer` reference tied to the calling component's
+ * instrumentation library name.  All spans created through this hook are
+ * automatically linked via the global `TracerProvider`.
+ *
+ * Usage:
+ * ```tsx
+ * function MyComponent() {
+ *   const tracer = useTracing('my-component')
+ *
+ *   async function handleClick() {
+ *     await tracer.withSpanAsync('button.click', { kind: 'INTERNAL' }, async (span) => {
+ *       span.setAttribute('ui.element', 'submit-button')
+ *       await submitForm()
+ *     })
+ *   }
+ * }
+ * ```
+ */
+
+'use client'
+
+import { useState } from 'react'
+import { getGlobalTracer } from '@/src/services/tracing'
+import type { Tracer } from '@/src/services/tracing'
+
+/**
+ * Returns a stable `Tracer` instance for the given instrumentation library
+ * name.  The reference is memoised per component mount — it never changes
+ * across re-renders, which makes it safe to include in dependency arrays.
+ *
+ * @param library  Instrumentation library name shown in span metadata.
+ *                 Defaults to `"verinode-frontend"`.
+ */
+export function useTracing(library = 'verinode-frontend'): Tracer {
+  // useState with an initialiser function runs exactly once per mount.
+  // Unlike useRef, reading `value` during render is explicitly allowed.
+  const [tracer] = useState<Tracer>(() => getGlobalTracer(library))
+  return tracer
+}

--- a/src/services/tracing/exporter.ts
+++ b/src/services/tracing/exporter.ts
@@ -1,0 +1,265 @@
+/**
+ * Span Exporters (#104)
+ *
+ * Two built-in exporters are provided:
+ *
+ *   1. `ConsoleSpanExporter`  — Pretty-prints finished spans to `console.debug`.
+ *      Intended for local development.  Enabled automatically when
+ *      `NEXT_PUBLIC_OTEL_LOG_LEVEL=debug`.
+ *
+ *   2. `OtlpHttpExporter`     — Sends spans to an OTLP/HTTP collector endpoint
+ *      in JSON format (application/json).  Compatible with Jaeger, Tempo, and
+ *      any OTEL-compliant collector.  Target URL is configured via
+ *      `NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT`.
+ *
+ *   3. `CompositeExporter`    — Fans out to multiple exporters.  Used by the
+ *      provider to combine console + remote exporters transparently.
+ *
+ * All exporters implement the `SpanExporter` interface from `types.ts` and
+ * swallow their own errors to honour the "must not throw" contract.
+ */
+
+import type { SpanExporter, ReadableSpan } from './types'
+
+// ─── ConsoleSpanExporter ──────────────────────────────────────────────────────
+
+/**
+ * Logs each completed span to the browser/Node console.
+ * Output is structured so it can be inspected in DevTools or piped to a log
+ * aggregator in local/staging environments.
+ */
+export class ConsoleSpanExporter implements SpanExporter {
+  async export(spans: ReadonlyArray<ReadableSpan>): Promise<void> {
+    for (const span of spans) {
+      const durationMs = span.endTimeMs - span.startTimeMs
+      console.debug('[OTel Span]', {
+        name: span.name,
+        traceId: span.traceId,
+        spanId: span.spanId,
+        parentSpanId: span.parentSpanId ?? '(root)',
+        kind: span.kind,
+        status: span.status,
+        durationMs,
+        attributes: span.attributes,
+        events: span.events,
+        library: span.instrumentationLibrary,
+      })
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    // No resources to release.
+  }
+}
+
+// ─── OtlpHttpExporter ─────────────────────────────────────────────────────────
+
+/** Options for `OtlpHttpExporter`. */
+export interface OtlpHttpExporterOptions {
+  /**
+   * Full URL to the OTLP HTTP collector endpoint.
+   * @example 'https://otelcollector.example.com/v1/traces'
+   */
+  endpoint: string
+  /**
+   * Additional HTTP headers sent with every export request.
+   * Use for authentication (e.g. `Authorization: Bearer <token>`).
+   */
+  headers?: Record<string, string>
+  /**
+   * Request timeout in milliseconds.
+   * @default 10_000
+   */
+  timeoutMs?: number
+}
+
+/**
+ * Convert a millisecond timestamp to a nanosecond string without BigInt
+ * (which is ES2020 and would fail the ES2017 tsconfig target).
+ *
+ * ms * 1_000_000 exceeds Number.MAX_SAFE_INTEGER for timestamps past year
+ * 2255, but for real-world wall-clock values the error is zero because both
+ * ms and the multiplier are integers and the product fits in a float64 without
+ * rounding for any epoch within the next few centuries.
+ */
+function msToNanoString(ms: number): string {
+  return String(ms * 1_000_000)
+}
+
+/**
+ * Converts a `ReadableSpan` array into the OTLP/HTTP JSON body.
+ *
+ * The mapping follows the OTLP proto → JSON mapping defined in:
+ *   https://opentelemetry.io/docs/specs/otlp/#otlphttp
+ *
+ * Kept minimal — only the fields consumed by common collectors are populated.
+ */
+function toOtlpBody(
+  spans: ReadonlyArray<ReadableSpan>,
+): Record<string, unknown> {
+  // Group spans by instrumentation library.
+  const byLibrary = new Map<string, ReadableSpan[]>()
+  for (const span of spans) {
+    const lib = span.instrumentationLibrary
+    const bucket = byLibrary.get(lib) ?? []
+    bucket.push(span)
+    byLibrary.set(lib, bucket)
+  }
+
+  const scopeSpans = Array.from(byLibrary.entries()).map(([library, libSpans]) => ({
+    scope: { name: library },
+    spans: libSpans.map((s) => ({
+      traceId: s.traceId,
+      spanId: s.spanId,
+      parentSpanId: s.parentSpanId ?? undefined,
+      name: s.name,
+      kind: spanKindToOtlp(s.kind),
+      startTimeUnixNano: msToNanoString(s.startTimeMs),
+      endTimeUnixNano: msToNanoString(s.endTimeMs),
+      attributes: attributesToOtlp(s.attributes),
+      events: s.events.map((e) => ({
+        name: e.name,
+        timeUnixNano: msToNanoString(e.timestampMs),
+        attributes: e.attributes ? attributesToOtlp(e.attributes) : [],
+      })),
+      status: {
+        code: statusToOtlp(s.status),
+        message: s.statusMessage ?? '',
+      },
+    })),
+  }))
+
+  return {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: [
+            { key: 'service.name', value: { stringValue: 'verinode-frontend' } },
+            { key: 'telemetry.sdk.name', value: { stringValue: 'verinode-otel' } },
+            { key: 'telemetry.sdk.language', value: { stringValue: 'webjs' } },
+          ],
+        },
+        scopeSpans,
+      },
+    ],
+  }
+}
+
+function spanKindToOtlp(kind: ReadableSpan['kind']): number {
+  switch (kind) {
+    case 'INTERNAL': return 1
+    case 'SERVER': return 2
+    case 'CLIENT': return 3
+    case 'PRODUCER': return 4
+    case 'CONSUMER': return 5
+    default: return 0 // SPAN_KIND_UNSPECIFIED
+  }
+}
+
+function statusToOtlp(status: ReadableSpan['status']): number {
+  switch (status) {
+    case 'OK': return 1
+    case 'ERROR': return 2
+    default: return 0 // STATUS_CODE_UNSET
+  }
+}
+
+function attributesToOtlp(
+  attrs: Record<string, unknown>,
+): Array<{ key: string; value: Record<string, unknown> }> {
+  return Object.entries(attrs).map(([key, value]) => ({
+    key,
+    value: valueToOtlp(value),
+  }))
+}
+
+function valueToOtlp(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string') return { stringValue: value }
+  if (typeof value === 'number') {
+    return Number.isInteger(value)
+      ? { intValue: String(value) }
+      : { doubleValue: value }
+  }
+  if (typeof value === 'boolean') return { boolValue: value }
+  if (Array.isArray(value)) {
+    return { arrayValue: { values: value.map(valueToOtlp) } }
+  }
+  return { stringValue: String(value) }
+}
+
+/**
+ * Sends completed spans to an OTLP/HTTP collector in JSON format.
+ *
+ * Failures are swallowed and logged to `console.warn` so that a broken
+ * collector does not interrupt application behaviour.
+ */
+export class OtlpHttpExporter implements SpanExporter {
+  private readonly endpoint: string
+  private readonly headers: Record<string, string>
+  private readonly timeoutMs: number
+  private shuttingDown = false
+
+  constructor(options: OtlpHttpExporterOptions) {
+    this.endpoint = options.endpoint
+    this.headers = options.headers ?? {}
+    this.timeoutMs = options.timeoutMs ?? 10_000
+  }
+
+  async export(spans: ReadonlyArray<ReadableSpan>): Promise<void> {
+    if (this.shuttingDown || spans.length === 0) return
+
+    const body = JSON.stringify(toOtlpBody(spans))
+
+    const controller = new AbortController()
+    const timerId = setTimeout(() => controller.abort(), this.timeoutMs)
+
+    try {
+      const response = await fetch(this.endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...this.headers,
+        },
+        body,
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        console.warn(
+          `[OTel] OTLP export failed: HTTP ${response.status} from ${this.endpoint}`,
+        )
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        console.warn(`[OTel] OTLP export timed out after ${this.timeoutMs}ms`)
+      } else {
+        console.warn('[OTel] OTLP export error:', err)
+      }
+    } finally {
+      clearTimeout(timerId)
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true
+  }
+}
+
+// ─── CompositeExporter ────────────────────────────────────────────────────────
+
+/**
+ * Fans a batch of spans out to multiple underlying exporters in parallel.
+ * Individual exporter failures do not prevent other exporters from receiving
+ * the batch.
+ */
+export class CompositeExporter implements SpanExporter {
+  constructor(private readonly exporters: ReadonlyArray<SpanExporter>) {}
+
+  async export(spans: ReadonlyArray<ReadableSpan>): Promise<void> {
+    await Promise.allSettled(this.exporters.map((e) => e.export(spans)))
+  }
+
+  async shutdown(): Promise<void> {
+    await Promise.allSettled(this.exporters.map((e) => e.shutdown()))
+  }
+}

--- a/src/services/tracing/idGenerator.ts
+++ b/src/services/tracing/idGenerator.ts
@@ -1,0 +1,88 @@
+/**
+ * Cryptographically-secure trace and span ID generator (#104).
+ *
+ * Uses `crypto.getRandomValues` (Web Crypto API — available in all modern
+ * browsers and Node ≥ 15) to produce IDs that conform to the W3C Trace
+ * Context specification:
+ *
+ *   - Trace ID: 32 lowercase hex characters (128 bits)
+ *   - Span ID:  16 lowercase hex characters (64 bits)
+ *
+ * A deterministic fallback based on `Math.random` is used only when the
+ * Crypto API is genuinely unavailable (e.g., very old environments or mocked
+ * test contexts that strip globals).  The fallback is NOT cryptographically
+ * secure and is clearly flagged as such.
+ */
+
+import type { TraceId, SpanId } from './types'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Convert a `Uint8Array` to a lowercase hex string.
+ */
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Returns `true` when the Web Crypto API is available in the current
+ * environment.
+ */
+function hasCrypto(): boolean {
+  return (
+    typeof globalThis !== 'undefined' &&
+    typeof globalThis.crypto !== 'undefined' &&
+    typeof globalThis.crypto.getRandomValues === 'function'
+  )
+}
+
+/**
+ * Produce `byteCount` random bytes using Web Crypto when available, or a
+ * non-cryptographic fallback otherwise.
+ */
+function randomBytes(byteCount: number): Uint8Array {
+  const buf = new Uint8Array(byteCount)
+  if (hasCrypto()) {
+    globalThis.crypto.getRandomValues(buf)
+  } else {
+    // Non-secure fallback — only hit in stripped test environments.
+    for (let i = 0; i < byteCount; i++) {
+      buf[i] = Math.floor(Math.random() * 256)
+    }
+  }
+  return buf
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Generate a W3C-compliant 128-bit trace ID (32 lowercase hex chars).
+ *
+ * The all-zeroes value (`00000000000000000000000000000000`) is reserved by
+ * the spec as invalid; this implementation regenerates if it ever occurs
+ * (probability ≈ 2^{-128}, i.e. practically impossible).
+ */
+export function generateTraceId(): TraceId {
+  let hex: string
+  do {
+    hex = toHex(randomBytes(16))
+  } while (hex === '00000000000000000000000000000000')
+  return hex
+}
+
+/**
+ * Generate a W3C-compliant 64-bit span ID (16 lowercase hex chars).
+ *
+ * The all-zeroes value (`0000000000000000`) is reserved as invalid; this
+ * implementation regenerates if it ever occurs.
+ */
+export function generateSpanId(): SpanId {
+  let hex: string
+  do {
+    hex = toHex(randomBytes(8))
+  } while (hex === '0000000000000000')
+  return hex
+}

--- a/src/services/tracing/index.ts
+++ b/src/services/tracing/index.ts
@@ -1,0 +1,87 @@
+/**
+ * Distributed Tracing — Public API (#104)
+ *
+ * Single entry-point for the VeriNode distributed tracing package.
+ *
+ * Usage:
+ * ```ts
+ * import { getGlobalTracer, injectHeaders, extractFromHeaders } from '@/services/tracing'
+ *
+ * // Instrument an async operation:
+ * const tracer = getGlobalTracer()
+ * await tracer.withSpanAsync('my-operation', {}, async (span) => {
+ *   span.setAttribute('custom.key', 'value')
+ *   // ... do work ...
+ * })
+ *
+ * // Propagate context in outgoing fetch:
+ * const headers = injectHeaders(tracer.activeContext()!)
+ * await fetch('/api/endpoint', { headers })
+ * ```
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+export type {
+  TraceId,
+  SpanId,
+  TraceParent,
+  TraceState,
+  SpanKind,
+  SpanStatus,
+  AttributeValue,
+  SpanAttributes,
+  SpanEvent,
+  ReadableSpan,
+  Span,
+  SpanOptions,
+  PropagationContext,
+  TraceContext,
+  SpanExporter,
+  SamplingResult,
+  Sampler,
+} from './types'
+
+// ── ID generation ─────────────────────────────────────────────────────────────
+export { generateTraceId, generateSpanId } from './idGenerator'
+
+// ── Propagation ───────────────────────────────────────────────────────────────
+export {
+  parseTraceParent,
+  serializeTraceParent,
+  isSampled,
+  buildTraceParent,
+  parseTraceState,
+  serializeTraceState,
+  injectVeriNodeEntry,
+  extractContext,
+  injectContext,
+  injectHeaders,
+  extractFromHeaders,
+} from './propagation'
+
+// ── Samplers ──────────────────────────────────────────────────────────────────
+export {
+  AlwaysOnSampler,
+  AlwaysOffSampler,
+  TraceIdRatioSampler,
+  ParentBasedSampler,
+  defaultSampler,
+} from './sampler'
+
+// ── Exporters ─────────────────────────────────────────────────────────────────
+export {
+  ConsoleSpanExporter,
+  OtlpHttpExporter,
+  CompositeExporter,
+} from './exporter'
+export type { OtlpHttpExporterOptions } from './exporter'
+
+// ── Tracer / Provider ─────────────────────────────────────────────────────────
+export {
+  Tracer,
+  TracerProvider,
+  registerGlobalProvider,
+  getGlobalTracer,
+  getGlobalProvider,
+} from './tracer'
+export type { TracerProviderConfig } from './tracer'

--- a/src/services/tracing/propagation.ts
+++ b/src/services/tracing/propagation.ts
@@ -1,0 +1,227 @@
+/**
+ * W3C Trace Context Propagation (#104)
+ *
+ * Implements the W3C Trace Context Level 1 specification:
+ *   - `traceparent` header injection and extraction
+ *   - `tracestate` header injection and extraction
+ *
+ * Spec: https://www.w3.org/TR/trace-context/
+ *
+ * Design goals:
+ *   - Zero external dependencies.
+ *   - Strict parsing — malformed headers yield `null` rather than throwing.
+ *   - Immutable data structures for all parsed values.
+ */
+
+import type { TraceParent, TraceState, TraceContext, PropagationContext } from './types'
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Sampled flag bit within the `traceparent` flags byte. */
+const FLAG_SAMPLED = 0x01
+
+/** Maximum number of key=value pairs preserved in tracestate (per spec §3.3.1.1). */
+const MAX_TRACESTATE_ENTRIES = 32
+
+// ─── traceparent ─────────────────────────────────────────────────────────────
+
+/**
+ * Regex for a valid `traceparent` header value per W3C Trace Context spec §3.2.
+ *
+ * Groups:
+ *   1 – version  (2 hex)
+ *   2 – traceId  (32 hex)
+ *   3 – parentId (16 hex)
+ *   4 – flags    (2 hex)
+ */
+const TRACEPARENT_RE =
+  /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})(?:-.*)?$/i
+
+/**
+ * Parse a raw `traceparent` header string.
+ *
+ * Returns `null` for any invalid or version-`ff` header (spec §3.2.1 §3.2.2).
+ */
+export function parseTraceParent(raw: string): TraceParent | null {
+  if (typeof raw !== 'string') return null
+
+  const m = TRACEPARENT_RE.exec(raw.trim())
+  if (!m) return null
+
+  const version = m[1].toLowerCase()
+  const traceId = m[2].toLowerCase()
+  const parentId = m[3].toLowerCase()
+  const flags = m[4].toLowerCase()
+
+  // Version 'ff' is explicitly forbidden by the spec.
+  if (version === 'ff') return null
+
+  // All-zero traceId and parentId are invalid per spec §3.2.2.2 / §3.2.2.3.
+  if (traceId === '00000000000000000000000000000000') return null
+  if (parentId === '0000000000000000') return null
+
+  return { version: '00', traceId, parentId, flags }
+}
+
+/**
+ * Serialise a `TraceParent` into the canonical `traceparent` header value.
+ */
+export function serializeTraceParent(tp: TraceParent): string {
+  return `${tp.version}-${tp.traceId}-${tp.parentId}-${tp.flags}`
+}
+
+/**
+ * Returns `true` when the sampled flag bit is set in the flags byte.
+ */
+export function isSampled(flags: string): boolean {
+  return (parseInt(flags, 16) & FLAG_SAMPLED) === FLAG_SAMPLED
+}
+
+/**
+ * Build a `traceparent` string for a child span rooted at `parentContext`.
+ */
+export function buildTraceParent(context: TraceContext): string {
+  const flags = context.sampled ? '01' : '00'
+  return `00-${context.traceId}-${context.spanId}-${flags}`
+}
+
+// ─── tracestate ───────────────────────────────────────────────────────────────
+
+/**
+ * Vendor key regex from W3C Trace Context §3.3.2.1.
+ * Simple key:  `[a-z][a-z0-9_\-*\/]{0,255}`
+ * Tenant key:  `[a-z0-9][a-z0-9_\-*\/]{0,240}@[a-z][a-z0-9_\-*\/]{0,13}`
+ */
+const TRACESTATE_KEY_RE = /^[a-z][a-z0-9_\-*/]{0,255}$|^[a-z0-9][a-z0-9_\-*/]{0,240}@[a-z][a-z0-9_\-*/]{0,13}$/
+
+/**
+ * Vendor value regex — printable ASCII 0x20-0x7e, excluding ',' and '='.
+ */
+const TRACESTATE_VALUE_RE = /^[ -+\--<>-~]{0,256}$/
+
+/**
+ * Parse a raw `tracestate` header string into an ordered list of key=value
+ * pairs.  Invalid entries are silently dropped.  Entries are capped at
+ * `MAX_TRACESTATE_ENTRIES`.
+ *
+ * The spec allows multiple header values concatenated with commas.
+ */
+export function parseTraceState(raw: string): TraceState {
+  if (typeof raw !== 'string' || raw.trim() === '') return []
+
+  const entries: Array<{ key: string; value: string }> = []
+
+  for (const part of raw.split(',')) {
+    const trimmed = part.trim()
+    if (!trimmed) continue
+
+    const eqIdx = trimmed.indexOf('=')
+    if (eqIdx <= 0) continue
+
+    const key = trimmed.slice(0, eqIdx).trim()
+    const value = trimmed.slice(eqIdx + 1).trim()
+
+    if (!TRACESTATE_KEY_RE.test(key)) continue
+    if (!TRACESTATE_VALUE_RE.test(value)) continue
+
+    // Deduplicate: a key may only appear once (spec §3.3.1.1 step 2).
+    if (entries.some((e) => e.key === key)) continue
+
+    entries.push({ key, value })
+    if (entries.length >= MAX_TRACESTATE_ENTRIES) break
+  }
+
+  return entries
+}
+
+/**
+ * Serialise a `TraceState` into the canonical `tracestate` header value.
+ * Returns an empty string when the state is empty.
+ */
+export function serializeTraceState(state: TraceState): string {
+  return state.map(({ key, value }) => `${key}=${value}`).join(',')
+}
+
+/**
+ * Prepend or update the VeriNode vendor entry (`vn`) in `traceState`.
+ *
+ * Per spec §3.3.1.3 the mutating vendor must move its entry to the leftmost
+ * position in the list, dropping the previous occurrence if present.
+ */
+export function injectVeriNodeEntry(
+  state: TraceState,
+  spanId: string,
+  sampled: boolean,
+): TraceState {
+  const filtered = state.filter((e) => e.key !== 'vn')
+  const vnValue = `${spanId}-${sampled ? '1' : '0'}`
+  const updated = [{ key: 'vn', value: vnValue }, ...filtered]
+  // Cap to spec maximum.
+  return updated.slice(0, MAX_TRACESTATE_ENTRIES)
+}
+
+// ─── Context propagation helpers ─────────────────────────────────────────────
+
+/**
+ * Extract a `TraceContext` from `traceparent` + `tracestate` HTTP header
+ * strings.  Returns `null` when the `traceparent` is missing or invalid.
+ */
+export function extractContext(
+  traceparentHeader: string | null | undefined,
+  tracestateHeader: string | null | undefined,
+): TraceContext | null {
+  if (!traceparentHeader) return null
+
+  const tp = parseTraceParent(traceparentHeader)
+  if (!tp) return null
+
+  const traceState = parseTraceState(tracestateHeader ?? '')
+
+  return {
+    traceId: tp.traceId,
+    spanId: tp.parentId,
+    traceState,
+    sampled: isSampled(tp.flags),
+  }
+}
+
+/**
+ * Build the propagation header pair (`traceparent` + `tracestate`) from a
+ * `TraceContext`.  Inject the VeriNode vendor entry into tracestate.
+ */
+export function injectContext(context: TraceContext): PropagationContext {
+  const withVn = injectVeriNodeEntry(context.traceState, context.spanId, context.sampled)
+  return {
+    traceparent: buildTraceParent(context),
+    tracestate: serializeTraceState(withVn),
+  }
+}
+
+/**
+ * Attach `traceparent` (and optionally `tracestate`) headers to an existing
+ * `HeadersInit` object.  Returns a new `Headers` instance — does not mutate
+ * the original.
+ */
+export function injectHeaders(
+  context: TraceContext,
+  existing?: HeadersInit,
+): Headers {
+  const headers = new Headers(existing)
+  const { traceparent, tracestate } = injectContext(context)
+  headers.set('traceparent', traceparent)
+  if (tracestate) {
+    headers.set('tracestate', tracestate)
+  }
+  return headers
+}
+
+/**
+ * Extract a `TraceContext` directly from a `Headers` object (e.g., from an
+ * incoming `Request`).
+ */
+export function extractFromHeaders(headers: Headers): TraceContext | null {
+  return extractContext(
+    headers.get('traceparent'),
+    headers.get('tracestate'),
+  )
+}

--- a/src/services/tracing/sampler.ts
+++ b/src/services/tracing/sampler.ts
@@ -1,0 +1,127 @@
+/**
+ * Trace Samplers (#104)
+ *
+ * Implements two OpenTelemetry-aligned sampling strategies:
+ *
+ *   1. `AlwaysOnSampler`        — records every trace (100% sample rate).
+ *   2. `TraceIdRatioSampler`    — deterministic ratio-based sampling keyed on
+ *                                 the 128-bit trace ID.
+ *   3. `ParentBasedSampler`     — honours the sampling decision of the parent
+ *                                 span when one exists; falls back to a root
+ *                                 sampler for new traces.
+ *
+ * All implementations are pure, stateless, and carry no dependencies beyond
+ * the local `types.ts` module.
+ */
+
+import type { Sampler, SamplingResult, TraceId } from './types'
+
+// ─── AlwaysOnSampler ──────────────────────────────────────────────────────────
+
+/**
+ * Always records the span.  Use during development or when 100% coverage is
+ * required (e.g., synthetic canary transactions).
+ */
+export class AlwaysOnSampler implements Sampler {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  shouldSample(traceId: TraceId, spanName: string): SamplingResult {
+    return { shouldSample: true }
+  }
+}
+
+// ─── AlwaysOffSampler ─────────────────────────────────────────────────────────
+
+/**
+ * Never records any span.  Useful as a stub during testing when you want to
+ * disable tracing entirely without removing the instrumentation.
+ */
+export class AlwaysOffSampler implements Sampler {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  shouldSample(traceId: TraceId, spanName: string): SamplingResult {
+    return { shouldSample: false }
+  }
+}
+
+// ─── TraceIdRatioSampler ──────────────────────────────────────────────────────
+
+/**
+ * Deterministic ratio-based sampler that uses the first 8 bytes of the
+ * trace ID (interpreted as a big-endian unsigned 64-bit integer) to make a
+ * consistent sampling decision.
+ *
+ * A given `traceId` will always produce the same decision for a fixed ratio,
+ * ensuring that all spans of a trace are either all recorded or all dropped.
+ *
+ * `ratio` must be in the range [0, 1].  Values outside this range are clamped.
+ *
+ * @example
+ * const sampler = new TraceIdRatioSampler(0.1) // sample 10% of traces
+ */
+export class TraceIdRatioSampler implements Sampler {
+  private readonly threshold: number
+
+  constructor(ratio: number) {
+    const clamped = Math.max(0, Math.min(1, ratio))
+    // Compute threshold as a fraction of 2^32 (using only the lower 32 bits
+    // of the 64-bit prefix for simplicity while preserving determinism).
+    this.threshold = clamped * 0xffffffff
+  }
+
+  shouldSample(traceId: TraceId, spanName: string): SamplingResult {
+    // spanName is part of the Sampler interface contract; not used by ratio sampling.
+    void spanName
+    // Parse first 8 hex chars (32 bits) of the traceId.
+    const sample = parseInt(traceId.slice(0, 8), 16)
+    const shouldSample = sample <= this.threshold
+    return {
+      shouldSample,
+      attributes: shouldSample
+        ? { 'sampling.strategy': 'trace_id_ratio', 'sampling.ratio': this.threshold / 0xffffffff }
+        : undefined,
+    }
+  }
+}
+
+// ─── ParentBasedSampler ───────────────────────────────────────────────────────
+
+/**
+ * Defers the sampling decision to the `parentSampled` flag when a parent
+ * context is known.  For new root traces (no parent) it delegates to the
+ * provided `rootSampler`.
+ *
+ * This mirrors the OTel SDK `ParentBased` sampler and is the recommended
+ * default for distributed systems because it propagates the sampling decision
+ * made at the trace origin.
+ */
+export class ParentBasedSampler implements Sampler {
+  constructor(private readonly rootSampler: Sampler) {}
+
+  shouldSample(
+    traceId: TraceId,
+    spanName: string,
+    parentSampled?: boolean,
+  ): SamplingResult {
+    if (parentSampled !== undefined) {
+      return {
+        shouldSample: parentSampled,
+        attributes: {
+          'sampling.strategy': 'parent_based',
+          'sampling.parent_sampled': parentSampled,
+        },
+      }
+    }
+    // Root span — defer to root sampler.
+    return this.rootSampler.shouldSample(traceId, spanName)
+  }
+}
+
+// ─── Default export ───────────────────────────────────────────────────────────
+
+/**
+ * Default production sampler.
+ *
+ * - Respects parent sampling decisions for distributed traces.
+ * - Falls back to 100% sampling for root spans (conservative default;
+ *   override via `NEXT_PUBLIC_TRACE_SAMPLE_RATE` env var in TracerProvider).
+ */
+export const defaultSampler: Sampler = new ParentBasedSampler(new AlwaysOnSampler())

--- a/src/services/tracing/span.ts
+++ b/src/services/tracing/span.ts
@@ -1,0 +1,172 @@
+/**
+ * Span implementation (#104)
+ *
+ * Provides the mutable `SpanImpl` class that records a single unit of work
+ * within a distributed trace.  Once `end()` is called the span is frozen and
+ * forwarded to the registered exporter(s) via the provider callback.
+ *
+ * The implementation is intentionally kept free of global side-effects so
+ * that it can be constructed and asserted in isolated unit tests without
+ * mocking the tracer provider.
+ */
+
+import type {
+  Span,
+  SpanKind,
+  SpanStatus,
+  SpanAttributes,
+  SpanEvent,
+  AttributeValue,
+  ReadableSpan,
+  TraceContext,
+  TraceState,
+  TraceId,
+  SpanId,
+} from './types'
+
+// ─── SpanImpl ─────────────────────────────────────────────────────────────────
+
+/** Callback invoked by the span when it ends so the provider can export it. */
+export type OnSpanEnd = (span: ReadableSpan) => void
+
+/**
+ * Mutable, fully-featured span implementation aligned with the OTel Span API.
+ *
+ * Consumers interact with the public `Span` interface — `SpanImpl` is an
+ * internal detail of the tracing package and is not exported from the
+ * package's public index.
+ */
+export class SpanImpl implements Span {
+  // ── identity ──────────────────────────────────────────────────────────────
+
+  readonly traceId: TraceId
+  readonly spanId: SpanId
+  readonly parentSpanId: SpanId | null
+  readonly name: string
+  readonly kind: SpanKind
+
+  // ── timing ────────────────────────────────────────────────────────────────
+
+  private readonly startTimeMs: number
+  private endTimeMsValue: number = 0
+
+  // ── state ─────────────────────────────────────────────────────────────────
+
+  private statusValue: SpanStatus = 'UNSET'
+  private statusMessage: string | undefined
+  private ended = false
+
+  // ── data ──────────────────────────────────────────────────────────────────
+
+  private readonly attrs: SpanAttributes = {}
+  private readonly eventsLog: SpanEvent[] = []
+  private readonly traceStateValue: TraceState
+  private readonly library: string
+
+  // ── callback ──────────────────────────────────────────────────────────────
+
+  private readonly onEnd: OnSpanEnd
+
+  constructor(params: {
+    traceId: TraceId
+    spanId: SpanId
+    parentSpanId: SpanId | null
+    name: string
+    kind: SpanKind
+    startTimeMs: number
+    traceState: TraceState
+    attributes?: SpanAttributes
+    instrumentationLibrary: string
+    onEnd: OnSpanEnd
+  }) {
+    this.traceId = params.traceId
+    this.spanId = params.spanId
+    this.parentSpanId = params.parentSpanId
+    this.name = params.name
+    this.kind = params.kind
+    this.startTimeMs = params.startTimeMs
+    this.traceStateValue = params.traceState
+    this.library = params.instrumentationLibrary
+    this.onEnd = params.onEnd
+
+    if (params.attributes) {
+      Object.assign(this.attrs, params.attributes)
+    }
+  }
+
+  // ── Span interface ────────────────────────────────────────────────────────
+
+  get isEnded(): boolean {
+    return this.ended
+  }
+
+  setAttribute(key: string, value: AttributeValue): this {
+    if (!this.ended) {
+      this.attrs[key] = value
+    }
+    return this
+  }
+
+  setAttributes(attributes: SpanAttributes): this {
+    if (!this.ended) {
+      Object.assign(this.attrs, attributes)
+    }
+    return this
+  }
+
+  addEvent(name: string, attributes?: SpanAttributes): this {
+    if (!this.ended) {
+      this.eventsLog.push({
+        name,
+        timestampMs: Date.now(),
+        attributes,
+      })
+    }
+    return this
+  }
+
+  setStatus(status: SpanStatus, message?: string): this {
+    if (!this.ended) {
+      // Per OTel spec, once OK is set it cannot be changed to a lower-priority status.
+      if (this.statusValue === 'OK' && status !== 'OK') return this
+      this.statusValue = status
+      this.statusMessage = message
+    }
+    return this
+  }
+
+  end(endTimeMs?: number): void {
+    if (this.ended) return
+    this.ended = true
+    this.endTimeMsValue = endTimeMs ?? Date.now()
+    this.onEnd(this.toReadable())
+  }
+
+  toReadable(): ReadableSpan {
+    return {
+      traceId: this.traceId,
+      spanId: this.spanId,
+      parentSpanId: this.parentSpanId,
+      name: this.name,
+      kind: this.kind,
+      startTimeMs: this.startTimeMs,
+      endTimeMs: this.endTimeMsValue,
+      status: this.statusValue,
+      statusMessage: this.statusMessage,
+      attributes: { ...this.attrs },
+      events: [...this.eventsLog],
+      traceState: this.traceStateValue,
+      instrumentationLibrary: this.library,
+    }
+  }
+
+  /** Expose the active trace context so child spans can link to this one. */
+  toTraceContext(sampled: boolean): TraceContext {
+    return {
+      traceId: this.traceId,
+      spanId: this.spanId,
+      traceState: this.traceStateValue,
+      sampled,
+    }
+  }
+}

--- a/src/services/tracing/tracer.ts
+++ b/src/services/tracing/tracer.ts
@@ -1,0 +1,354 @@
+/**
+ * Tracer and TracerProvider (#104)
+ *
+ * Provides:
+ *   - `Tracer`         — creates spans and manages the async context stack.
+ *   - `TracerProvider` — root object that wires together the sampler,
+ *                        exporter, and batch processor.
+ *   - `getGlobalTracer()` — convenience accessor for the default tracer.
+ *
+ * Context propagation across async boundaries uses a simple call-stack array
+ * (`_contextStack`) because the AsyncLocalStorage / AsyncContext APIs are not
+ * reliably available in all target environments (browser + Edge runtime).
+ * For cross-service propagation the caller is responsible for forwarding the
+ * `TraceContext` object explicitly — see `withSpan` / `withSpanAsync`.
+ *
+ * Performance note:
+ *   Spans that are not sampled are still allocated but their `onEnd` callback
+ *   is a no-op so they add zero export overhead.  The allocation overhead is
+ *   negligible for typical UI code paths.
+ */
+
+import type {
+  Span,
+  SpanOptions,
+  SpanKind,
+  TraceContext,
+  SpanExporter,
+  Sampler,
+  ReadableSpan,
+} from './types'
+import { generateTraceId, generateSpanId } from './idGenerator'
+import { SpanImpl } from './span'
+import { defaultSampler } from './sampler'
+import { ConsoleSpanExporter, CompositeExporter } from './exporter'
+
+// ─── Batch processor ──────────────────────────────────────────────────────────
+
+const DEFAULT_BATCH_SIZE = 50
+const DEFAULT_FLUSH_INTERVAL_MS = 5_000
+
+/**
+ * Simple in-memory batch processor.  Flushes to the exporter either when the
+ * batch reaches `maxBatchSize` or after `flushIntervalMs` has elapsed.
+ */
+class BatchProcessor {
+  private queue: ReadableSpan[] = []
+  private timer: ReturnType<typeof setInterval> | null = null
+
+  constructor(
+    private readonly exporter: SpanExporter,
+    private readonly maxBatchSize = DEFAULT_BATCH_SIZE,
+    private readonly flushIntervalMs = DEFAULT_FLUSH_INTERVAL_MS,
+  ) {}
+
+  start(): void {
+    if (typeof setInterval === 'undefined') return
+    this.timer = setInterval(() => {
+      void this.flush()
+    }, this.flushIntervalMs)
+    // Allow the process to exit even when the timer is pending.
+    if (this.timer && typeof this.timer === 'object' && 'unref' in this.timer) {
+      // Node.js only
+      (this.timer as NodeJS.Timeout).unref()
+    }
+  }
+
+  onSpanEnd(span: ReadableSpan): void {
+    this.queue.push(span)
+    if (this.queue.length >= this.maxBatchSize) {
+      void this.flush()
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.queue.length === 0) return
+    const batch = this.queue.splice(0)
+    try {
+      await this.exporter.export(batch)
+    } catch {
+      // Swallow — exporter must not break the app.
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.timer !== null) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    await this.flush()
+    await this.exporter.shutdown()
+  }
+}
+
+// ─── Tracer ───────────────────────────────────────────────────────────────────
+
+/** Default instrumentation library name injected into all spans. */
+const DEFAULT_LIBRARY = 'verinode-frontend'
+
+/**
+ * Creates and manages spans within a single instrumentation library.
+ *
+ * Obtain a `Tracer` instance via `TracerProvider.getTracer()` or the
+ * `getGlobalTracer()` singleton helper.
+ */
+export class Tracer {
+  private readonly contextStack: TraceContext[] = []
+
+  constructor(
+    private readonly library: string,
+    private readonly processor: BatchProcessor,
+    private readonly sampler: Sampler,
+  ) {}
+
+  // ── Active context ────────────────────────────────────────────────────────
+
+  /** Returns the innermost active `TraceContext`, or `null` if none. */
+  activeContext(): TraceContext | null {
+    return this.contextStack.length > 0
+      ? this.contextStack[this.contextStack.length - 1]
+      : null
+  }
+
+  // ── Span creation ─────────────────────────────────────────────────────────
+
+  /**
+   * Start a new span.
+   *
+   * The span is linked to the active context (or `options.parentContext` when
+   * explicitly provided).  If no parent exists this becomes a root span with
+   * a fresh trace ID.
+   */
+  startSpan(name: string, options: SpanOptions = {}): Span {
+    const parent =
+      options.parentContext !== undefined
+        ? options.parentContext
+        : this.activeContext()
+
+    const traceId = parent?.traceId ?? generateTraceId()
+    const spanId = generateSpanId()
+    const traceState = parent?.traceState ?? []
+    const kind: SpanKind = options.kind ?? 'INTERNAL'
+
+    // Determine sampling.
+    const parentSampled = parent?.sampled
+    const { shouldSample, attributes: samplerAttrs } =
+      (this.sampler as unknown as {
+        shouldSample(
+          traceId: string,
+          name: string,
+          parentSampled?: boolean,
+        ): ReturnType<Sampler['shouldSample']>
+      }).shouldSample(traceId, name, parentSampled)
+
+    const onEnd = shouldSample
+      ? (span: ReadableSpan) => this.processor.onSpanEnd(span)
+      : () => { /* not sampled — discard */ }
+
+    const span = new SpanImpl({
+      traceId,
+      spanId,
+      parentSpanId: parent?.spanId ?? null,
+      name,
+      kind,
+      startTimeMs: options.startTimeMs ?? Date.now(),
+      traceState,
+      attributes: { ...samplerAttrs, ...options.attributes },
+      instrumentationLibrary: this.library,
+      onEnd,
+    })
+
+    return span
+  }
+
+  // ── Convenience wrappers ──────────────────────────────────────────────────
+
+  /**
+   * Execute a synchronous callback within a new span.  The span is
+   * automatically ended when the callback returns (or throws).
+   *
+   * The span is pushed onto the context stack for the duration of the call so
+   * that nested `startSpan()` calls link to it automatically.
+   */
+  withSpan<T>(name: string, options: SpanOptions, fn: (span: Span) => T): T {
+    const span = this.startSpan(name, options)
+    const impl = span as SpanImpl
+    const ctx = impl.toTraceContext(true)
+    this.contextStack.push(ctx)
+    try {
+      const result = fn(span)
+      span.setStatus('OK')
+      span.end()
+      return result
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      span.setStatus('ERROR', message)
+      span.end()
+      throw err
+    } finally {
+      this.contextStack.pop()
+    }
+  }
+
+  /**
+   * Execute an async callback within a new span.  Equivalent to `withSpan`
+   * but awaits the returned `Promise`.
+   */
+  async withSpanAsync<T>(
+    name: string,
+    options: SpanOptions,
+    fn: (span: Span) => Promise<T>,
+  ): Promise<T> {
+    const span = this.startSpan(name, options)
+    const impl = span as SpanImpl
+    const ctx = impl.toTraceContext(true)
+    this.contextStack.push(ctx)
+    try {
+      const result = await fn(span)
+      span.setStatus('OK')
+      span.end()
+      return result
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      span.setStatus('ERROR', message)
+      span.end()
+      throw err
+    } finally {
+      this.contextStack.pop()
+    }
+  }
+}
+
+// ─── TracerProvider ───────────────────────────────────────────────────────────
+
+/** Configuration for `TracerProvider`. */
+export interface TracerProviderConfig {
+  /**
+   * Sampling strategy.  Defaults to `ParentBasedSampler(AlwaysOnSampler)`.
+   */
+  sampler?: Sampler
+  /**
+   * Span exporters.  Multiple exporters are wrapped in a `CompositeExporter`.
+   * When omitted and `NODE_ENV !== 'production'` a `ConsoleSpanExporter` is
+   * used automatically.
+   */
+  exporters?: SpanExporter[]
+  /**
+   * Maximum spans per export batch.
+   * @default 50
+   */
+  maxBatchSize?: number
+  /**
+   * Milliseconds between automatic flush cycles.
+   * @default 5_000
+   */
+  flushIntervalMs?: number
+}
+
+/**
+ * Root object that creates `Tracer` instances and owns the batch processor.
+ *
+ * Typically one `TracerProvider` is created at application startup and
+ * registered as the global provider via `registerGlobalProvider()`.
+ */
+export class TracerProvider {
+  private readonly processor: BatchProcessor
+  private readonly sampler: Sampler
+  private readonly tracers = new Map<string, Tracer>()
+
+  constructor(config: TracerProviderConfig = {}) {
+    const {
+      sampler = defaultSampler,
+      exporters,
+      maxBatchSize = DEFAULT_BATCH_SIZE,
+      flushIntervalMs = DEFAULT_FLUSH_INTERVAL_MS,
+    } = config
+
+    this.sampler = sampler
+
+    // Build exporter.
+    let exporter: SpanExporter
+    if (exporters && exporters.length > 0) {
+      exporter =
+        exporters.length === 1 ? exporters[0] : new CompositeExporter(exporters)
+    } else {
+      // Default: console in dev, no-op in production.
+      const isDev =
+        typeof process !== 'undefined' && process.env.NODE_ENV !== 'production'
+      exporter = isDev
+        ? new ConsoleSpanExporter()
+        : { export: async () => {}, shutdown: async () => {} }
+    }
+
+    this.processor = new BatchProcessor(exporter, maxBatchSize, flushIntervalMs)
+    this.processor.start()
+  }
+
+  /**
+   * Returns a `Tracer` scoped to the given `library` name.
+   * Subsequent calls with the same name return the same instance.
+   */
+  getTracer(library = DEFAULT_LIBRARY): Tracer {
+    const existing = this.tracers.get(library)
+    if (existing) return existing
+    const tracer = new Tracer(library, this.processor, this.sampler)
+    this.tracers.set(library, tracer)
+    return tracer
+  }
+
+  /** Flush pending spans and shut down all exporters gracefully. */
+  async shutdown(): Promise<void> {
+    await this.processor.shutdown()
+  }
+
+  /** Force-flush all buffered spans without shutting down. */
+  async forceFlush(): Promise<void> {
+    await this.processor.flush()
+  }
+}
+
+// ─── Global provider registry ─────────────────────────────────────────────────
+
+let _globalProvider: TracerProvider | null = null
+
+/**
+ * Register a `TracerProvider` as the process-wide default.
+ * Must be called once at application startup (e.g., in `instrumentation.ts`).
+ */
+export function registerGlobalProvider(provider: TracerProvider): void {
+  _globalProvider = provider
+}
+
+/**
+ * Returns a `Tracer` from the global provider.
+ *
+ * Falls back to a no-op `TracerProvider` when no global provider has been
+ * registered, so callers never need to guard against `null`.
+ */
+export function getGlobalTracer(library = DEFAULT_LIBRARY): Tracer {
+  if (!_globalProvider) {
+    _globalProvider = new TracerProvider()
+  }
+  return _globalProvider.getTracer(library)
+}
+
+/**
+ * Returns the global provider, initialising a default one if needed.
+ * Useful for calling `shutdown()` / `forceFlush()` from teardown hooks.
+ */
+export function getGlobalProvider(): TracerProvider {
+  if (!_globalProvider) {
+    _globalProvider = new TracerProvider()
+  }
+  return _globalProvider
+}

--- a/src/services/tracing/tracing.test.ts
+++ b/src/services/tracing/tracing.test.ts
@@ -1,0 +1,690 @@
+/**
+ * Distributed Tracing — Unit Tests (#104)
+ *
+ * Covers:
+ *   - ID generation (format, uniqueness, invalidity guard)
+ *   - W3C traceparent parsing / serialisation
+ *   - W3C tracestate parsing / serialisation
+ *   - Context injection / extraction helpers
+ *   - Sampler implementations
+ *   - SpanImpl lifecycle (attributes, events, status, end guard)
+ *   - Tracer / TracerProvider wiring
+ *   - Exporter (ConsoleSpanExporter, CompositeExporter)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { generateTraceId, generateSpanId } from './idGenerator'
+import {
+  parseTraceParent,
+  serializeTraceParent,
+  isSampled,
+  buildTraceParent,
+  parseTraceState,
+  serializeTraceState,
+  injectVeriNodeEntry,
+  extractContext,
+  injectContext,
+  injectHeaders,
+  extractFromHeaders,
+} from './propagation'
+import {
+  AlwaysOnSampler,
+  AlwaysOffSampler,
+  TraceIdRatioSampler,
+  ParentBasedSampler,
+} from './sampler'
+import { SpanImpl } from './span'
+import {
+  TracerProvider,
+  Tracer,
+  registerGlobalProvider,
+  getGlobalTracer,
+  getGlobalProvider,
+} from './tracer'
+import { ConsoleSpanExporter, CompositeExporter } from './exporter'
+import type { ReadableSpan, TraceContext } from './types'
+
+// ─── ID Generator ─────────────────────────────────────────────────────────────
+
+describe('generateTraceId', () => {
+  it('produces a 32-char lowercase hex string', () => {
+    const id = generateTraceId()
+    expect(id).toMatch(/^[0-9a-f]{32}$/)
+  })
+
+  it('never returns the all-zero invalid value', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(generateTraceId()).not.toBe('00000000000000000000000000000000')
+    }
+  })
+
+  it('generates unique values', () => {
+    const ids = new Set(Array.from({ length: 500 }, generateTraceId))
+    expect(ids.size).toBe(500)
+  })
+})
+
+describe('generateSpanId', () => {
+  it('produces a 16-char lowercase hex string', () => {
+    const id = generateSpanId()
+    expect(id).toMatch(/^[0-9a-f]{16}$/)
+  })
+
+  it('never returns the all-zero invalid value', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(generateSpanId()).not.toBe('0000000000000000')
+    }
+  })
+
+  it('generates unique values', () => {
+    const ids = new Set(Array.from({ length: 500 }, generateSpanId))
+    expect(ids.size).toBe(500)
+  })
+})
+
+// ─── parseTraceParent ─────────────────────────────────────────────────────────
+
+describe('parseTraceParent', () => {
+  const VALID = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+
+  it('parses a valid traceparent', () => {
+    const tp = parseTraceParent(VALID)
+    expect(tp).not.toBeNull()
+    expect(tp!.version).toBe('00')
+    expect(tp!.traceId).toBe('4bf92f3577b34da6a3ce929d0e0e4736')
+    expect(tp!.parentId).toBe('00f067aa0ba902b7')
+    expect(tp!.flags).toBe('01')
+  })
+
+  it('returns null for empty string', () => {
+    expect(parseTraceParent('')).toBeNull()
+  })
+
+  it('returns null for version ff (reserved)', () => {
+    expect(parseTraceParent('ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')).toBeNull()
+  })
+
+  it('returns null for all-zero traceId', () => {
+    expect(parseTraceParent('00-00000000000000000000000000000000-00f067aa0ba902b7-01')).toBeNull()
+  })
+
+  it('returns null for all-zero parentId', () => {
+    expect(parseTraceParent('00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01')).toBeNull()
+  })
+
+  it('returns null for malformed input', () => {
+    expect(parseTraceParent('not-a-traceparent')).toBeNull()
+    expect(parseTraceParent('00-short-00f067aa0ba902b7-01')).toBeNull()
+  })
+
+  it('accepts future-version headers (ignores trailing data)', () => {
+    const future = '01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra'
+    const tp = parseTraceParent(future)
+    expect(tp).not.toBeNull()
+  })
+})
+
+describe('serializeTraceParent', () => {
+  it('round-trips a parsed traceparent', () => {
+    const raw = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+    const tp = parseTraceParent(raw)!
+    expect(serializeTraceParent(tp)).toBe(raw)
+  })
+})
+
+describe('isSampled', () => {
+  it('returns true for flags 01', () => expect(isSampled('01')).toBe(true))
+  it('returns false for flags 00', () => expect(isSampled('00')).toBe(false))
+  it('returns true for flags 03 (bit 0 set)', () => expect(isSampled('03')).toBe(true))
+})
+
+describe('buildTraceParent', () => {
+  it('includes sampled flag when sampled=true', () => {
+    const ctx: TraceContext = {
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      spanId: '00f067aa0ba902b7',
+      traceState: [],
+      sampled: true,
+    }
+    expect(buildTraceParent(ctx)).toBe('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
+  })
+
+  it('includes unsampled flag when sampled=false', () => {
+    const ctx: TraceContext = {
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      spanId: '00f067aa0ba902b7',
+      traceState: [],
+      sampled: false,
+    }
+    expect(buildTraceParent(ctx)).toBe('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00')
+  })
+})
+
+// ─── parseTraceState / serializeTraceState ────────────────────────────────────
+
+describe('parseTraceState', () => {
+  it('parses a single entry', () => {
+    const state = parseTraceState('vn=abc123-1')
+    expect(state).toHaveLength(1)
+    expect(state[0]).toEqual({ key: 'vn', value: 'abc123-1' })
+  })
+
+  it('parses multiple comma-separated entries', () => {
+    const state = parseTraceState('vn=abc-1,rojo=00f0')
+    expect(state).toHaveLength(2)
+    expect(state[0].key).toBe('vn')
+    expect(state[1].key).toBe('rojo')
+  })
+
+  it('deduplicates keys (first occurrence wins)', () => {
+    const state = parseTraceState('vn=first,vn=second')
+    expect(state).toHaveLength(1)
+    expect(state[0].value).toBe('first')
+  })
+
+  it('returns empty array for empty / whitespace string', () => {
+    expect(parseTraceState('')).toHaveLength(0)
+    expect(parseTraceState('   ')).toHaveLength(0)
+  })
+
+  it('silently drops entries with invalid keys', () => {
+    const state = parseTraceState('UPPER=val,valid=ok')
+    expect(state).toHaveLength(1)
+    expect(state[0].key).toBe('valid')
+  })
+
+  it('caps at 32 entries', () => {
+    const raw = Array.from({ length: 40 }, (_, i) => `k${i}=v`).join(',')
+    const state = parseTraceState(raw)
+    expect(state.length).toBeLessThanOrEqual(32)
+  })
+})
+
+describe('serializeTraceState', () => {
+  it('serialises entries as comma-separated key=value pairs', () => {
+    const state = [{ key: 'vn', value: 'abc-1' }, { key: 'rojo', value: '00f0' }]
+    expect(serializeTraceState(state)).toBe('vn=abc-1,rojo=00f0')
+  })
+
+  it('returns empty string for empty state', () => {
+    expect(serializeTraceState([])).toBe('')
+  })
+})
+
+describe('injectVeriNodeEntry', () => {
+  it('prepends the vn entry when none exists', () => {
+    const state = injectVeriNodeEntry([], 'deadbeef01234567', true)
+    expect(state[0]).toEqual({ key: 'vn', value: 'deadbeef01234567-1' })
+  })
+
+  it('replaces an existing vn entry and moves it to position 0', () => {
+    const existing = [{ key: 'vn', value: 'old-0' }, { key: 'other', value: 'x' }]
+    const state = injectVeriNodeEntry(existing, 'newspan0000000001', false)
+    expect(state[0]).toEqual({ key: 'vn', value: 'newspan0000000001-0' })
+    expect(state.find((e) => e.key === 'other')).toBeDefined()
+    expect(state.filter((e) => e.key === 'vn')).toHaveLength(1)
+  })
+})
+
+// ─── Context helpers ──────────────────────────────────────────────────────────
+
+describe('extractContext', () => {
+  it('extracts a valid context from traceparent + tracestate', () => {
+    const ctx = extractContext(
+      '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+      'vn=abc-1',
+    )
+    expect(ctx).not.toBeNull()
+    expect(ctx!.traceId).toBe('4bf92f3577b34da6a3ce929d0e0e4736')
+    expect(ctx!.spanId).toBe('00f067aa0ba902b7')
+    expect(ctx!.sampled).toBe(true)
+    expect(ctx!.traceState[0].key).toBe('vn')
+  })
+
+  it('returns null for missing traceparent', () => {
+    expect(extractContext(null, null)).toBeNull()
+    expect(extractContext(undefined, undefined)).toBeNull()
+  })
+
+  it('returns null for invalid traceparent', () => {
+    expect(extractContext('garbage', null)).toBeNull()
+  })
+})
+
+describe('injectContext', () => {
+  it('produces valid traceparent and non-empty tracestate', () => {
+    const ctx: TraceContext = {
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      spanId: '00f067aa0ba902b7',
+      traceState: [],
+      sampled: true,
+    }
+    const { traceparent, tracestate } = injectContext(ctx)
+    expect(traceparent).toBe('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
+    expect(tracestate).toContain('vn=')
+  })
+})
+
+describe('injectHeaders / extractFromHeaders', () => {
+  it('round-trips context through Headers', () => {
+    const ctx: TraceContext = {
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      spanId: '00f067aa0ba902b7',
+      traceState: [],
+      sampled: true,
+    }
+    const headers = injectHeaders(ctx)
+    const extracted = extractFromHeaders(headers)
+    expect(extracted).not.toBeNull()
+    expect(extracted!.traceId).toBe(ctx.traceId)
+    expect(extracted!.sampled).toBe(true)
+  })
+
+  it('merges with existing headers without mutation', () => {
+    const ctx: TraceContext = {
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      spanId: '00f067aa0ba902b7',
+      traceState: [],
+      sampled: false,
+    }
+    const original = new Headers({ 'x-custom': 'value' })
+    const headers = injectHeaders(ctx, original)
+    expect(headers.get('x-custom')).toBe('value')
+    expect(headers.get('traceparent')).toContain('4bf92f3577b34da6a3ce929d0e0e4736')
+    // Original must not be mutated
+    expect(original.has('traceparent')).toBe(false)
+  })
+})
+
+// ─── Samplers ─────────────────────────────────────────────────────────────────
+
+describe('AlwaysOnSampler', () => {
+  it('always samples', () => {
+    const s = new AlwaysOnSampler()
+    expect(s.shouldSample('any', 'op').shouldSample).toBe(true)
+  })
+})
+
+describe('AlwaysOffSampler', () => {
+  it('never samples', () => {
+    const s = new AlwaysOffSampler()
+    expect(s.shouldSample('any', 'op').shouldSample).toBe(false)
+  })
+})
+
+describe('TraceIdRatioSampler', () => {
+  it('samples 100% at ratio 1.0', () => {
+    const s = new TraceIdRatioSampler(1.0)
+    // All trace IDs start with 0xffffffff or less
+    for (let i = 0; i < 20; i++) {
+      expect(s.shouldSample(generateTraceId(), 'op').shouldSample).toBe(true)
+    }
+  })
+
+  it('samples 0% at ratio 0.0', () => {
+    const s = new TraceIdRatioSampler(0.0)
+    for (let i = 0; i < 20; i++) {
+      expect(s.shouldSample(generateTraceId(), 'op').shouldSample).toBe(false)
+    }
+  })
+
+  it('is deterministic for the same traceId', () => {
+    const s = new TraceIdRatioSampler(0.5)
+    const traceId = generateTraceId()
+    const first = s.shouldSample(traceId, 'op').shouldSample
+    for (let i = 0; i < 10; i++) {
+      expect(s.shouldSample(traceId, 'op').shouldSample).toBe(first)
+    }
+  })
+
+  it('clamps ratio below 0 to 0', () => {
+    const s = new TraceIdRatioSampler(-0.5)
+    expect(s.shouldSample(generateTraceId(), 'op').shouldSample).toBe(false)
+  })
+
+  it('clamps ratio above 1 to 1', () => {
+    const s = new TraceIdRatioSampler(1.5)
+    expect(s.shouldSample(generateTraceId(), 'op').shouldSample).toBe(true)
+  })
+})
+
+describe('ParentBasedSampler', () => {
+  it('uses parent decision when parentSampled=true', () => {
+    const s = new ParentBasedSampler(new AlwaysOffSampler())
+    expect(
+      (s as unknown as { shouldSample(t: string, n: string, p: boolean): { shouldSample: boolean } })
+        .shouldSample('tid', 'op', true).shouldSample
+    ).toBe(true)
+  })
+
+  it('uses parent decision when parentSampled=false', () => {
+    const s = new ParentBasedSampler(new AlwaysOnSampler())
+    expect(
+      (s as unknown as { shouldSample(t: string, n: string, p: boolean): { shouldSample: boolean } })
+        .shouldSample('tid', 'op', false).shouldSample
+    ).toBe(false)
+  })
+
+  it('falls back to root sampler when no parent', () => {
+    const s = new ParentBasedSampler(new AlwaysOffSampler())
+    expect(s.shouldSample('tid', 'op').shouldSample).toBe(false)
+  })
+})
+
+// ─── SpanImpl ─────────────────────────────────────────────────────────────────
+
+function makeSpan(overrides?: Partial<ConstructorParameters<typeof SpanImpl>[0]>): SpanImpl {
+  const collected: ReadableSpan[] = []
+  return new SpanImpl({
+    traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+    spanId: '00f067aa0ba902b7',
+    parentSpanId: null,
+    name: 'test-span',
+    kind: 'INTERNAL',
+    startTimeMs: 1000,
+    traceState: [],
+    instrumentationLibrary: 'test',
+    onEnd: (s) => collected.push(s),
+    ...overrides,
+  })
+}
+
+describe('SpanImpl', () => {
+  it('starts not ended', () => {
+    const span = makeSpan()
+    expect(span.isEnded).toBe(false)
+  })
+
+  it('sets and reads attributes', () => {
+    const span = makeSpan()
+    span.setAttribute('key', 'value')
+    span.setAttributes({ num: 42, flag: true })
+    const r = span.toReadable()
+    expect(r.attributes['key']).toBe('value')
+    expect(r.attributes['num']).toBe(42)
+    expect(r.attributes['flag']).toBe(true)
+  })
+
+  it('ignores setAttribute after end', () => {
+    const span = makeSpan()
+    span.end(2000)
+    span.setAttribute('late', 'value')
+    expect(span.toReadable().attributes['late']).toBeUndefined()
+  })
+
+  it('records events with timestamps', () => {
+    const span = makeSpan()
+    span.addEvent('cache-miss', { key: 'x' })
+    const r = span.toReadable()
+    expect(r.events).toHaveLength(1)
+    expect(r.events[0].name).toBe('cache-miss')
+    expect(r.events[0].attributes!['key']).toBe('x')
+    expect(typeof r.events[0].timestampMs).toBe('number')
+  })
+
+  it('sets status OK then cannot downgrade', () => {
+    const span = makeSpan()
+    span.setStatus('OK')
+    span.setStatus('ERROR', 'late error')
+    expect(span.toReadable().status).toBe('OK')
+  })
+
+  it('sets ERROR status with message', () => {
+    const span = makeSpan()
+    span.setStatus('ERROR', 'something went wrong')
+    const r = span.toReadable()
+    expect(r.status).toBe('ERROR')
+    expect(r.statusMessage).toBe('something went wrong')
+  })
+
+  it('end() records endTimeMs and calls onEnd', () => {
+    const collected: ReadableSpan[] = []
+    const span = new SpanImpl({
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      spanId: '00f067aa0ba902b7',
+      parentSpanId: null,
+      name: 'test',
+      kind: 'INTERNAL',
+      startTimeMs: 1000,
+      traceState: [],
+      instrumentationLibrary: 'test',
+      onEnd: (s) => collected.push(s),
+    })
+    span.end(2500)
+    expect(span.isEnded).toBe(true)
+    expect(collected).toHaveLength(1)
+    expect(collected[0].endTimeMs).toBe(2500)
+  })
+
+  it('calling end() twice is a no-op', () => {
+    const collected: ReadableSpan[] = []
+    const span = new SpanImpl({
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      spanId: '00f067aa0ba902b7',
+      parentSpanId: null,
+      name: 'test',
+      kind: 'INTERNAL',
+      startTimeMs: 1000,
+      traceState: [],
+      instrumentationLibrary: 'test',
+      onEnd: (s) => collected.push(s),
+    })
+    span.end(2000)
+    span.end(3000)
+    expect(collected).toHaveLength(1)
+    expect(collected[0].endTimeMs).toBe(2000)
+  })
+
+  it('toReadable returns immutable copies of attributes and events', () => {
+    const span = makeSpan()
+    span.setAttribute('x', 1)
+    const r1 = span.toReadable()
+    r1.attributes['x'] = 999
+    const r2 = span.toReadable()
+    expect(r2.attributes['x']).toBe(1)
+  })
+})
+
+// ─── Tracer / TracerProvider ──────────────────────────────────────────────────
+
+describe('Tracer', () => {
+  let collected: ReadableSpan[]
+  let provider: TracerProvider
+
+  beforeEach(() => {
+    collected = []
+    provider = new TracerProvider({
+      exporters: [{ export: async (s) => { collected.push(...s) }, shutdown: async () => {} }],
+      flushIntervalMs: 999999, // disable auto-flush in tests
+    })
+  })
+
+  afterEach(async () => {
+    await provider.shutdown()
+  })
+
+  it('startSpan creates a root span when no context is active', () => {
+    const tracer = provider.getTracer('test')
+    const span = tracer.startSpan('root-op')
+    expect(span.parentSpanId).toBeNull()
+    span.end()
+  })
+
+  it('startSpan links to explicit parentContext', () => {
+    const tracer = provider.getTracer('test')
+    const parentCtx: TraceContext = {
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      spanId: 'aabbccdd11223344',
+      traceState: [],
+      sampled: true,
+    }
+    const child = tracer.startSpan('child', { parentContext: parentCtx })
+    expect(child.traceId).toBe('4bf92f3577b34da6a3ce929d0e0e4736')
+    expect(child.parentSpanId).toBe('aabbccdd11223344')
+    child.end()
+  })
+
+  it('withSpan auto-ends the span and sets OK on success', async () => {
+    const tracer = provider.getTracer('test')
+    tracer.withSpan('op', {}, (span) => {
+      span.setAttribute('x', 1)
+    })
+    await provider.forceFlush()
+    expect(collected).toHaveLength(1)
+    expect(collected[0].status).toBe('OK')
+    expect(collected[0].attributes['x']).toBe(1)
+  })
+
+  it('withSpan sets ERROR on thrown exception and re-throws', async () => {
+    const tracer = provider.getTracer('test')
+    expect(() =>
+      tracer.withSpan('failing', {}, () => {
+        throw new Error('boom')
+      })
+    ).toThrow('boom')
+    await provider.forceFlush()
+    expect(collected[0].status).toBe('ERROR')
+    expect(collected[0].statusMessage).toBe('boom')
+  })
+
+  it('withSpanAsync awaits and sets OK', async () => {
+    const tracer = provider.getTracer('test')
+    await tracer.withSpanAsync('async-op', {}, async (span) => {
+      span.setAttribute('async', true)
+    })
+    await provider.forceFlush()
+    expect(collected[0].status).toBe('OK')
+    expect(collected[0].attributes['async']).toBe(true)
+  })
+
+  it('withSpanAsync sets ERROR on rejection', async () => {
+    const tracer = provider.getTracer('test')
+    await expect(
+      tracer.withSpanAsync('failing-async', {}, async () => {
+        throw new Error('async boom')
+      })
+    ).rejects.toThrow('async boom')
+    await provider.forceFlush()
+    expect(collected[0].status).toBe('ERROR')
+  })
+
+  it('nested withSpan creates parent-child relationship', async () => {
+    const tracer = provider.getTracer('test')
+    tracer.withSpan('parent', {}, () => {
+      tracer.withSpan('child', {}, (s) => s.setAttribute('nested', true))
+    })
+    await provider.forceFlush()
+    expect(collected).toHaveLength(2)
+    const child = collected.find((s) => s.name === 'child')!
+    const parent = collected.find((s) => s.name === 'parent')!
+    expect(child.parentSpanId).toBe(parent.spanId)
+    expect(child.traceId).toBe(parent.traceId)
+  })
+
+  it('getTracer with same name returns the same instance', () => {
+    const t1 = provider.getTracer('lib-a')
+    const t2 = provider.getTracer('lib-a')
+    expect(t1).toBe(t2)
+  })
+})
+
+// ─── getGlobalTracer / registerGlobalProvider ─────────────────────────────────
+
+describe('global provider', () => {
+  afterEach(async () => {
+    // Reset global by shutting down and re-bootstrapping lazily.
+    try { await getGlobalProvider().shutdown() } catch { /* noop */ }
+    // Force reset to null by calling register with a fresh provider.
+    registerGlobalProvider(new TracerProvider())
+  })
+
+  it('getGlobalTracer returns a Tracer instance', () => {
+    const tracer = getGlobalTracer()
+    expect(tracer).toBeInstanceOf(Tracer)
+  })
+
+  it('registerGlobalProvider replaces the global provider', () => {
+    const collected: ReadableSpan[] = []
+    const customProvider = new TracerProvider({
+      exporters: [{ export: async (s) => { collected.push(...s) }, shutdown: async () => {} }],
+      flushIntervalMs: 999999,
+    })
+    registerGlobalProvider(customProvider)
+    const tracer = getGlobalTracer('custom')
+    tracer.withSpan('test-global', {}, () => {})
+    return customProvider.forceFlush().then(() => {
+      expect(collected.some((s) => s.name === 'test-global')).toBe(true)
+    })
+  })
+})
+
+// ─── ConsoleSpanExporter ──────────────────────────────────────────────────────
+
+describe('ConsoleSpanExporter', () => {
+  it('logs spans to console.debug without throwing', async () => {
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const exporter = new ConsoleSpanExporter()
+    const span: ReadableSpan = {
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      spanId: '00f067aa0ba902b7',
+      parentSpanId: null,
+      name: 'console-test',
+      kind: 'CLIENT',
+      startTimeMs: 1000,
+      endTimeMs: 1050,
+      status: 'OK',
+      attributes: { 'http.method': 'GET' },
+      events: [],
+      traceState: [],
+      instrumentationLibrary: 'test',
+    }
+    await expect(exporter.export([span])).resolves.toBeUndefined()
+    expect(spy).toHaveBeenCalledOnce()
+    spy.mockRestore()
+  })
+
+  it('shutdown resolves without error', async () => {
+    const exporter = new ConsoleSpanExporter()
+    await expect(exporter.shutdown()).resolves.toBeUndefined()
+  })
+})
+
+// ─── CompositeExporter ────────────────────────────────────────────────────────
+
+describe('CompositeExporter', () => {
+  it('fans out to all child exporters', async () => {
+    const results: string[] = []
+    const a = { export: async () => { results.push('a') }, shutdown: async () => {} }
+    const b = { export: async () => { results.push('b') }, shutdown: async () => {} }
+    const composite = new CompositeExporter([a, b])
+    await composite.export([])
+    expect(results).toContain('a')
+    expect(results).toContain('b')
+  })
+
+  it('does not propagate errors from one exporter to another', async () => {
+    const results: string[] = []
+    const failing = {
+      export: async () => { throw new Error('exporter failure') },
+      shutdown: async () => {},
+    }
+    const succeeding = {
+      export: async () => { results.push('ok') },
+      shutdown: async () => {},
+    }
+    const composite = new CompositeExporter([failing, succeeding])
+    await expect(composite.export([])).resolves.toBeUndefined()
+    expect(results).toContain('ok')
+  })
+
+  it('shuts down all child exporters', async () => {
+    const shutdowns: string[] = []
+    const a = { export: async () => {}, shutdown: async () => { shutdowns.push('a') } }
+    const b = { export: async () => {}, shutdown: async () => { shutdowns.push('b') } }
+    const composite = new CompositeExporter([a, b])
+    await composite.shutdown()
+    expect(shutdowns).toContain('a')
+    expect(shutdowns).toContain('b')
+  })
+})

--- a/src/services/tracing/types.ts
+++ b/src/services/tracing/types.ts
@@ -1,0 +1,218 @@
+/**
+ * OpenTelemetry-compatible Distributed Tracing — Type Definitions (#104)
+ *
+ * Implements the W3C Trace Context specification (traceparent / tracestate)
+ * and an OpenTelemetry-aligned span model.  All primitives are pure TypeScript
+ * interfaces and value types — no external runtime dependencies.
+ *
+ * Spec references:
+ *   - W3C Trace Context: https://www.w3.org/TR/trace-context/
+ *   - OpenTelemetry API: https://opentelemetry.io/docs/specs/otel/trace/api/
+ */
+
+// ─── Identifiers ─────────────────────────────────────────────────────────────
+
+/** 32 lowercase hex characters — 128-bit trace identifier. */
+export type TraceId = string
+
+/** 16 lowercase hex characters — 64-bit span identifier. */
+export type SpanId = string
+
+// ─── W3C Trace Context ───────────────────────────────────────────────────────
+
+/**
+ * Parsed representation of a W3C `traceparent` header value.
+ *
+ * Format: `{version}-{traceId}-{parentId}-{flags}`
+ * Example: `00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`
+ */
+export interface TraceParent {
+  /** Must be `"00"` — the only version currently standardised. */
+  version: '00'
+  /** 128-bit trace identifier (32 hex chars). */
+  traceId: TraceId
+  /** 64-bit parent span identifier (16 hex chars). */
+  parentId: SpanId
+  /** 8-bit flags byte (2 hex chars). Bit 0 = sampled. */
+  flags: string
+}
+
+/**
+ * Parsed representation of a W3C `tracestate` header value.
+ *
+ * A list of vendor-specific key-value pairs, ordered by recency (most recent
+ * vendor first).  Each key must match `[a-z][a-z0-9_\-*\/]{0,255}` (or the
+ * multi-tenant form) per the spec.
+ */
+export type TraceState = ReadonlyArray<{ key: string; value: string }>
+
+// ─── Span ─────────────────────────────────────────────────────────────────────
+
+/** OpenTelemetry canonical span kinds. */
+export type SpanKind = 'INTERNAL' | 'SERVER' | 'CLIENT' | 'PRODUCER' | 'CONSUMER'
+
+/** Lifecycle status of a span. */
+export type SpanStatus = 'UNSET' | 'OK' | 'ERROR'
+
+/** Attribute value types supported by OTLP / OTel SDK. */
+export type AttributeValue = string | number | boolean | string[] | number[] | boolean[]
+
+/** Span attribute map. */
+export type SpanAttributes = Record<string, AttributeValue>
+
+/** A single timed event attached to a span. */
+export interface SpanEvent {
+  /** Human-readable event name. */
+  name: string
+  /** Wall-clock timestamp (milliseconds since epoch). */
+  timestampMs: number
+  /** Optional attributes associated with the event. */
+  attributes?: SpanAttributes
+}
+
+/** An immutable, fully-ended span record ready for export. */
+export interface ReadableSpan {
+  /** 128-bit trace identifier shared by all spans in the same trace. */
+  traceId: TraceId
+  /** 64-bit identifier unique within the trace. */
+  spanId: SpanId
+  /** Parent span identifier, or `null` for root spans. */
+  parentSpanId: SpanId | null
+  /** Human-readable operation name. */
+  name: string
+  /** Span kind (default: INTERNAL). */
+  kind: SpanKind
+  /** Wall-clock start time (ms since epoch). */
+  startTimeMs: number
+  /** Wall-clock end time (ms since epoch).  Set only after `end()` is called. */
+  endTimeMs: number
+  /** Outcome status. */
+  status: SpanStatus
+  /** Optional status message (used when status === ERROR). */
+  statusMessage?: string
+  /** Key-value attributes attached to this span. */
+  attributes: SpanAttributes
+  /** Ordered list of events added during the span's lifetime. */
+  events: ReadonlyArray<SpanEvent>
+  /** Propagated trace state (vendor extensions). */
+  traceState: TraceState
+  /** Name of the instrumentation library that created the span. */
+  instrumentationLibrary: string
+}
+
+// ─── Active / mutable span interface ─────────────────────────────────────────
+
+/**
+ * The mutable view of a span available while it is still active.
+ * Mirrors the OTel Span API surface used throughout the codebase.
+ */
+export interface Span {
+  /** Read access to the span's trace-context fields. */
+  readonly traceId: TraceId
+  readonly spanId: SpanId
+  readonly parentSpanId: SpanId | null
+  readonly name: string
+  readonly kind: SpanKind
+
+  /**
+   * Set (or override) a single attribute.  Calling after `end()` is a no-op.
+   */
+  setAttribute(key: string, value: AttributeValue): this
+
+  /** Bulk-set attributes from a plain object. */
+  setAttributes(attributes: SpanAttributes): this
+
+  /** Append a timed event to the span. */
+  addEvent(name: string, attributes?: SpanAttributes): this
+
+  /** Mark the span as successfully completed. */
+  setStatus(status: SpanStatus, message?: string): this
+
+  /**
+   * End the span.  Once called all mutation methods become no-ops.
+   * `endTimeMs` defaults to `Date.now()` when omitted.
+   */
+  end(endTimeMs?: number): void
+
+  /** Snapshot the span as an immutable record for export / assertion. */
+  toReadable(): ReadableSpan
+
+  /** Whether `end()` has already been called. */
+  readonly isEnded: boolean
+}
+
+// ─── Tracer ───────────────────────────────────────────────────────────────────
+
+/** Options accepted when starting a new span. */
+export interface SpanOptions {
+  /**
+   * Override the span kind (default: INTERNAL).
+   */
+  kind?: SpanKind
+  /**
+   * Initial attributes applied before the body runs.
+   */
+  attributes?: SpanAttributes
+  /**
+   * Explicit parent context.  When omitted the tracer uses the active context.
+   */
+  parentContext?: TraceContext | null
+  /**
+   * Override the wall-clock start time (ms since epoch).
+   * Useful when wrapping an already-measured operation.
+   */
+  startTimeMs?: number
+}
+
+/** Propagation context carried on `fetch` / cross-boundary calls. */
+export interface PropagationContext {
+  /** Serialised `traceparent` header value. */
+  traceparent: string
+  /** Serialised `tracestate` header value (may be empty string). */
+  tracestate: string
+}
+
+/**
+ * Minimal context object used to link parent ↔ child spans.
+ * Carry this through async boundaries to preserve distributed trace chains.
+ */
+export interface TraceContext {
+  traceId: TraceId
+  spanId: SpanId
+  traceState: TraceState
+  /** True when this span should be sampled / recorded. */
+  sampled: boolean
+}
+
+// ─── Exporter ─────────────────────────────────────────────────────────────────
+
+/** A sink that receives completed spans. */
+export interface SpanExporter {
+  /**
+   * Called by the tracer provider whenever a batch of spans is ready.
+   * Must not throw — handle internal errors and return a resolved promise.
+   */
+  export(spans: ReadonlyArray<ReadableSpan>): Promise<void>
+
+  /** Called once during provider shutdown. */
+  shutdown(): Promise<void>
+}
+
+// ─── Sampling ─────────────────────────────────────────────────────────────────
+
+/** Sampling decision returned by a `Sampler`. */
+export interface SamplingResult {
+  /** Whether this trace should be recorded. */
+  shouldSample: boolean
+  /** Additional attributes to attach to the span (e.g. sampling ratio). */
+  attributes?: SpanAttributes
+}
+
+/**
+ * Determines whether a given trace should be recorded.
+ * Two built-in implementations are provided: `AlwaysOnSampler` and
+ * `TraceIdRatioSampler`.
+ */
+export interface Sampler {
+  shouldSample(traceId: TraceId, spanName: string): SamplingResult
+}


### PR DESCRIPTION
Closes #104 

…ontext propagation (#104)

Implements a zero-dependency distributed tracing layer aligned with the OpenTelemetry API and W3C Trace Context specification.

What was changed:

- src/services/tracing/types.ts: full OTel-aligned type definitions (TraceId, SpanId, TraceParent, TraceState, Span, ReadableSpan, SpanExporter, Sampler, TraceContext, PropagationContext)

- src/services/tracing/idGenerator.ts: cryptographically-secure trace/span ID generation via Web Crypto API with deterministic fallback

- src/services/tracing/propagation.ts: W3C traceparent/tracestate header parsing, serialisation, injection and extraction; injectHeaders/extractFromHeaders helpers for outgoing fetch calls

- src/services/tracing/sampler.ts: AlwaysOnSampler, AlwaysOffSampler, TraceIdRatioSampler, ParentBasedSampler implementations

- src/services/tracing/span.ts: mutable SpanImpl with attribute/event recording, status lifecycle, end-guard, and immutable ReadableSpan snapshots

- src/services/tracing/exporter.ts: ConsoleSpanExporter (dev), OtlpHttpExporter (OTLP/HTTP JSON), CompositeExporter (fan-out)

- src/services/tracing/tracer.ts: Tracer with sync/async withSpan wrappers and context stack; TracerProvider with batch processor; global provider registry

- src/services/tracing/index.ts: single public entry-point re-exporting all types and utilities

- instrumentation.ts: Next.js instrumentation hook that bootstraps the global TracerProvider on server startup using NEXT_PUBLIC_OTEL_* env vars

- src/hooks/useTracing.ts: useTracing() React hook returning a stable Tracer per component mount via useState initialiser

- src/services/tracing/tracing.test.ts: 69 unit tests covering IDs, propagation, samplers, span lifecycle, tracer wiring, and exporters (all passing)

## Summary

<!-- Briefly describe the changes introduced by this PR. -->

## Related Issue

Closes #

## Changes

<!-- List the files added or modified and what each does. -->

### New files
- 
### Modified files
- 

## Testing

<!-- Describe how the changes were tested. -->

- [ ] TypeScript: no type errors (`npm run build`)
- [ ] Linting: no errors (`npm run lint`)
- [ ] Unit tests pass (`npm run test:unit`)
- [ ] E2E tests pass (`npm run test:e2e:ci`)

## Notes

<!-- Any additional context, known limitations, or follow-up work. -->
