### PR TITLE
Code coverage threshold

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,15 @@ jobs:
         run: npm ci
       - name: Run Linter
         run: npm run lint
+      - name: Enforce Unit Test Coverage
+        run: npm run test:coverage
+      - name: Upload Coverage Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          if-no-files-found: error
       - name: Check Build
         run: npm run build
 

--- a/docs/coverage-thresholds.md
+++ b/docs/coverage-thresholds.md
@@ -1,0 +1,57 @@
+# Code Coverage Threshold Enforcement
+
+## Architecture
+
+Unit coverage is enforced by Vitest in the frontend CI pipeline. The `test:coverage`
+script runs the same unit test suite as `test:unit`, enables the V8 coverage
+provider, and applies the global threshold gates defined in `vitest.config.mts`.
+
+Coverage enforcement is intentionally part of the build job and runs after linting
+but before the production build. This order fails pull requests early when tested
+code drops below the agreed quality bar while keeping the existing build and
+performance jobs unchanged.
+
+## Threshold Policy
+
+The current global thresholds are:
+
+- Statements: 70%
+- Branches: 60%
+- Functions: 70%
+- Lines: 70%
+
+Coverage collection includes application TypeScript and TSX files under `src/` and
+excludes test files, colocated test directories, and declaration files. The CI job
+publishes the generated `coverage/` directory as a GitHub Actions artifact so the
+HTML/LCOV reports can be inspected after every run.
+
+## Monitoring and Alerting
+
+GitHub Actions is the source of truth for this gate:
+
+1. The `Frontend Build Check` workflow fails when coverage is below threshold.
+2. Branch protection should require the workflow before merge.
+3. The uploaded `coverage-report` artifact provides line-level diagnostics for
+   reviewers and maintainers.
+
+For operational alerting, configure repository or organization notifications for
+failed required checks. No runtime dashboard is required because this control is a
+CI quality gate and does not affect production request paths.
+
+## Deployment and Rollout
+
+This change is safe to roll out through the normal pull-request workflow because
+it only modifies CI behavior and test configuration. If coverage enforcement needs
+to be relaxed during rollout, adjust the thresholds in `vitest.config.mts` in a
+follow-up pull request after review.
+
+## Runbook
+
+When the coverage gate fails:
+
+1. Download the `coverage-report` artifact from the failed workflow run.
+2. Open `coverage/lcov-report/index.html` locally to identify uncovered files.
+3. Add or improve tests for the changed behavior.
+4. Run `npm run test:coverage` locally before pushing the fix.
+5. If a threshold adjustment is required, document the reason in the pull request
+   and keep the change scoped to `vitest.config.mts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitest/coverage-v8": "^3.2.6",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "fast-check": "^3.23.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:e2e:wallet": "playwright test --project=wallet-ci",
     "test:e2e:wallet:headed": "playwright test --project=wallet-ci --headed",
     "test:e2e:wallet:debug": "playwright test --project=wallet-ci --debug",
-    "test:e2e:ci": "playwright test --project=wallet-ci"
+    "test:e2e:ci": "playwright test --project=wallet-ci",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^16.0.1",
@@ -46,6 +47,7 @@
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^3.2.6",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "fast-check": "^3.23.2",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -32,5 +32,22 @@ export default defineConfig({
   test: {
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'lcov'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.test.{ts,tsx}',
+        'src/**/tests/**',
+        'src/**/*.d.ts',
+      ],
+      thresholds: {
+        statements: 70,
+        branches: 60,
+        functions: 70,
+        lines: 70,
+      },
+    },
   },
 })


### PR DESCRIPTION
### Motivation

- Add a CI quality gate that enforces unit test coverage thresholds so regressions in test coverage fail early in the build pipeline.  
- Ensure teams can inspect HTML/LCOV coverage reports by publishing them as workflow artifacts.  
- Provide a documented policy and runbook describing thresholds, scope, and recovery steps for maintainers.  

### Description

- Add a coverage enforcement step to the `Frontend Build Check` workflow that runs `npm run test:coverage` and uploads `coverage/` as the `coverage-report` artifact.  
- Add a `test:coverage` npm script and declare the V8 coverage provider dependency `@vitest/coverage-v8` in `package.json` / `package-lock.json`.  
- Configure Vitest in `vitest.config.mts` to use the `v8` provider, emit `text`, `json-summary`, and `lcov` reporters, include/exclude source patterns, and enforce global thresholds (`statements: 70`, `branches: 60`, `functions: 70`, `lines: 70`).  
- Add `docs/coverage-thresholds.md` documenting the architecture, thresholds, monitoring, rollout guidance, and a runbook for failures.  

### Testing

- Ran `npm run lint`, which completed successfully with existing warnings only.  
- Ran `npm run test:unit` (Vitest), which executed the suite but produced 7 failing tests and 269 passing tests, with failures in `src/utils/tests/treeFlattener.test.ts`, `src/services/db/tests/backupService.test.ts`, and `src/hooks/tests/useSlashingStream.test.ts`.  
- Attempted `npm run test:coverage` but it failed locally because the environment could not fetch/install `@vitest/coverage-v8` (npm `403 Forbidden`), so coverage collection could not be executed locally.  
- Attempted `npm run build` which failed locally due to Next.js being unable to fetch Google Fonts from `fonts.googleapis.com` in the environment, and is unrelated to the coverage changes.

Closes #126