### PR TITLE
Developer onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# VeriNode Frontend local development defaults
+# Copy to .env.local automatically via `npm run setup:dev`.
+
+# Optional: Sentry DSN for frontend error reporting. Leave blank for local development.
+NEXT_PUBLIC_SENTRY_DSN=
+
+# Optional: OpenTelemetry collector endpoint. Leave blank to disable OTLP export locally.
+NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT=
+NEXT_PUBLIC_OTEL_LOG_LEVEL=info
+NEXT_PUBLIC_TRACE_SAMPLE_RATE=1
+
+# Optional: DVT API base URL. Leave blank to use demo/local fallbacks.
+NEXT_PUBLIC_DVT_API_URL=
+
+# Optional: Ethereum beacon node URL for validator alert data. Leave blank for demo mode.
+NEXT_PUBLIC_BEACON_NODE_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -24,12 +24,26 @@ Ensure you have the required toolchains installed:
 ```bash
 # Clone the repository (if running manually)
 git clone https://github.com/VeriNode-Labs/VeriNode-Frontend
+cd VeriNode-Frontend
 
-# Install dependencies or build
-npm install
+# Run the onboarding script
+npm run setup:dev
 
 # Start development server
 npm run dev
+```
+
+The onboarding script verifies the local Node.js version, creates `.env.local` from `.env.example` when needed, installs dependencies with `npm ci` when a lockfile is present, and runs the linter as a smoke check. Use flags for faster or CI-like runs:
+
+```bash
+# Preview actions without changing files or installing dependencies
+npm run setup:dev -- --dry-run
+
+# Keep existing dependencies and only validate environment/configuration
+npm run setup:dev -- --skip-install
+
+# Do not create .env.local from .env.example
+npm run setup:dev -- --skip-env
 ```
 
 ## 🧪 Testing

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Frontend for VeriNode â€” decentralized savings circles (ROSCA) protocol on Stellar Soroban",
   "scripts": {
+    "setup:dev": "node scripts/setup-dev.mjs",
     "dev": "next dev",
     "build": "next build",
     "build:analyze": "ANALYZE=true next build",

--- a/scripts/setup-dev.mjs
+++ b/scripts/setup-dev.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+import { existsSync, copyFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REQUIRED_NODE_MAJOR = 18;
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has('--dry-run');
+const skipInstall = args.has('--skip-install');
+const skipEnv = args.has('--skip-env');
+
+function log(message = '') {
+  console.log(message);
+}
+
+function run(command, commandArgs, options = {}) {
+  const display = [command, ...commandArgs].join(' ');
+  if (dryRun) {
+    log(`DRY RUN: ${display}`);
+    return;
+  }
+
+  const result = spawnSync(command, commandArgs, {
+    cwd: rootDir,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`Command failed: ${display}`);
+  }
+}
+
+function assertNodeVersion() {
+  const major = Number.parseInt(process.versions.node.split('.')[0] ?? '0', 10);
+  if (Number.isNaN(major) || major < REQUIRED_NODE_MAJOR) {
+    throw new Error(`Node.js ${REQUIRED_NODE_MAJOR}+ is required. Current version: ${process.version}`);
+  }
+  log(`✓ Node.js ${process.version} meets the v${REQUIRED_NODE_MAJOR}+ requirement`);
+}
+
+function ensureLocalEnv() {
+  if (skipEnv) {
+    log('• Skipping .env.local creation');
+    return;
+  }
+
+  const examplePath = resolve(rootDir, '.env.example');
+  const localPath = resolve(rootDir, '.env.local');
+
+  if (existsSync(localPath)) {
+    log('✓ .env.local already exists');
+    return;
+  }
+
+  if (!existsSync(examplePath)) {
+    log('• No .env.example found; skipping .env.local creation');
+    return;
+  }
+
+  if (dryRun) {
+    log('DRY RUN: copy .env.example to .env.local');
+    return;
+  }
+
+  copyFileSync(examplePath, localPath);
+  log('✓ Created .env.local from .env.example');
+}
+
+function installDependencies() {
+  if (skipInstall) {
+    log('• Skipping dependency installation');
+    return;
+  }
+
+  const installCommand = existsSync(resolve(rootDir, 'package-lock.json')) ? ['npm', ['ci']] : ['npm', ['install']];
+  run(installCommand[0], installCommand[1]);
+}
+
+function verifyProject() {
+  run('npm', ['run', 'lint']);
+}
+
+function printNextSteps() {
+  log('\nLocal development setup complete.');
+  log('Next steps:');
+  log('  1. Review .env.local and replace demo values if needed.');
+  log('  2. Start the app with: npm run dev');
+  log('  3. Run wallet E2E checks with: npm run test:e2e:wallet');
+}
+
+try {
+  log('Setting up VeriNode Frontend for local development...\n');
+  assertNodeVersion();
+  ensureLocalEnv();
+  installDependencies();
+  verifyProject();
+  printNextSteps();
+} catch (error) {
+  console.error(`\nSetup failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
### Motivation
- Provide a reproducible, one-command local development onboarding flow that verifies toolchain and project configuration.
- Ensure developers have a safe, tracked `.env.example` to bootstrap `.env.local` without committing local secrets.
- Run a lightweight smoke check (linter) and dependency installation to catch environment problems early.

### Description
- Add `scripts/setup-dev.mjs`, a Node.js onboarding script that asserts Node v18+, copies `.env.example` to `.env.local` when missing, installs dependencies using `npm ci` if a lockfile exists (or `npm install` otherwise), runs `npm run lint` as a smoke check, and prints next steps; the script supports `--dry-run`, `--skip-install`, and `--skip-env` flags.
- Add the `setup:dev` npm script to `package.json` to run the onboarding script via `npm run setup:dev`.
- Add a tracked `.env.example` with local development defaults (Sentry, OpenTelemetry, DVT API, beacon node) and update `.gitignore` to allow committing `.env.example` while still ignoring `*.env`.
- Update `README.md` to document the onboarding workflow and the script flags for dry runs and skipping steps.

### Testing
- Ran `npm run setup:dev -- --dry-run`, which completed successfully and exercised Node version check, env copy preview, install preview, and lint preview.
- Ran `npm run lint`, which completed successfully (ESLint produced existing warnings but no errors).

Closes #125