### PR TITLE
Pre commit hook suite

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+npm run precommit

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -1,0 +1,30 @@
+# Pre-Commit Hook Suite
+
+## Architecture
+
+The repository uses a checked-in Git hook path (`.githooks`) and a Node.js orchestration script (`scripts/pre-commit-check.mjs`) instead of an additional hook framework dependency. Running `npm install` executes the `prepare` script, which configures `core.hooksPath` to `.githooks` for the local clone.
+
+```text
+git commit
+  └─ .githooks/pre-commit
+      └─ npm run precommit
+          └─ scripts/pre-commit-check.mjs
+              ├─ git diff --cached --name-only --diff-filter=ACMR
+              ├─ npm run lint
+              └─ npm run test:precommit (hook/toolchain changes only)
+```
+
+## Enforcement Policy
+
+- Documentation-only commits pass without running expensive checks.
+- JavaScript and TypeScript source changes run ESLint so security and correctness rules execute before commit.
+- Hook test files and package/toolchain changes also run the pre-commit suite's Node.js tests. Type checking remains available through `npm run typecheck` and should be run before opening release-bound pull requests while the repository resolves its existing baseline type errors.
+- Generated or dependency directories such as `.next/` and `node_modules/` are ignored.
+- Emergency bypass is available with `SKIP_PRECOMMIT=1 git commit ...`; any bypass should be documented in the pull request and remediated immediately.
+
+## Operational Notes
+
+- The hook fails fast on the first failed check to keep developer feedback quick.
+- CI remains the authoritative gate for build, performance, and full regression coverage.
+- Security-sensitive rules such as the existing ban on `dangerouslySetInnerHTML` are enforced through ESLint during the hook.
+- Blue-green deployment and canary analysis are not triggered locally; they remain release-pipeline responsibilities after CI passes.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "test:e2e:wallet": "playwright test --project=wallet-ci",
     "test:e2e:wallet:headed": "playwright test --project=wallet-ci --headed",
     "test:e2e:wallet:debug": "playwright test --project=wallet-ci --debug",
-    "test:e2e:ci": "playwright test --project=wallet-ci"
+    "test:e2e:ci": "playwright test --project=wallet-ci",
+    "typecheck": "tsc --noEmit --pretty false",
+    "precommit": "node scripts/pre-commit-check.mjs",
+    "prepare": "node scripts/install-git-hooks.mjs",
+    "test:precommit": "node --test tests/precommit/*.test.mjs"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^16.0.1",

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+if (!existsSync('.git')) {
+  process.exit(0);
+}
+
+execFileSync('git', ['config', 'core.hooksPath', '.githooks'], { stdio: 'inherit' });
+console.log('Configured Git hooks path: .githooks');

--- a/scripts/pre-commit-check.mjs
+++ b/scripts/pre-commit-check.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const RUNNERS = {
+  lint: ['npm', ['run', 'lint']],
+  unit: ['npm', ['run', 'test:precommit']],
+};
+
+const SOURCE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+const TEST_EXTENSIONS = new Set(['.test.ts', '.test.tsx', '.spec.ts', '.spec.tsx']);
+
+export function parseStagedFiles(output) {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((file) => !file.startsWith('node_modules/') && !file.startsWith('.next/'));
+}
+
+export function planChecks(files) {
+  const hasPackageChange = files.some((file) => ['package.json', 'package-lock.json', 'tsconfig.json', 'eslint.config.mjs'].includes(file));
+  const hasSource = files.some((file) => SOURCE_EXTENSIONS.has(path.extname(file)));
+  const hasTests = files.some((file) => [...TEST_EXTENSIONS].some((suffix) => file.endsWith(suffix)));
+
+  if (files.length === 0) {
+    return [];
+  }
+
+  const checks = [];
+  if (hasSource || hasPackageChange) {
+    checks.push('lint');
+  }
+  if (hasTests || hasPackageChange) {
+    checks.push('unit');
+  }
+  return checks;
+}
+
+function stagedFiles() {
+  return parseStagedFiles(
+    execFileSync('git', ['diff', '--cached', '--name-only', '--diff-filter=ACMR'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    }),
+  );
+}
+
+function runCheck(name) {
+  const [command, args] = RUNNERS[name];
+  console.log(`\n▶ ${name}: ${command} ${args.join(' ')}`);
+  const result = spawnSync(command, args, { cwd: ROOT, stdio: 'inherit', shell: process.platform === 'win32' });
+  return result.status ?? 1;
+}
+
+export function runPreCommit(files = stagedFiles()) {
+  if (process.env.SKIP_PRECOMMIT === '1') {
+    console.log('Skipping pre-commit checks because SKIP_PRECOMMIT=1.');
+    return 0;
+  }
+
+  if (!existsSync(path.join(ROOT, 'package.json'))) {
+    console.error('pre-commit checks must run from the repository root.');
+    return 1;
+  }
+
+  const checks = planChecks(files);
+  if (checks.length === 0) {
+    console.log('No staged frontend files require pre-commit checks.');
+    return 0;
+  }
+
+  console.log(`Running pre-commit checks for ${files.length} staged file(s): ${checks.join(', ')}`);
+  for (const check of checks) {
+    const status = runCheck(check);
+    if (status !== 0) {
+      console.error(`\n✖ ${check} failed. Fix the issue or set SKIP_PRECOMMIT=1 only for emergencies.`);
+      return status;
+    }
+  }
+  console.log('\n✓ Pre-commit checks passed.');
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(runPreCommit());
+}

--- a/tests/precommit/pre-commit-check.test.mjs
+++ b/tests/precommit/pre-commit-check.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseStagedFiles, planChecks } from '../../scripts/pre-commit-check.mjs';
+
+test('parseStagedFiles removes blank and generated entries', () => {
+  assert.deepEqual(parseStagedFiles('\nsrc/app/page.tsx\n.next/cache/file\nnode_modules/pkg/index.js\nREADME.md\n'), [
+    'src/app/page.tsx',
+    'README.md',
+  ]);
+});
+
+test('planChecks skips documentation-only changes', () => {
+  assert.deepEqual(planChecks(['README.md', 'docs/pre-commit-hooks.md']), []);
+});
+
+test('planChecks runs lint for source changes', () => {
+  assert.deepEqual(planChecks(['src/services/auditLogService.ts']), ['lint']);
+});
+
+test('planChecks includes unit tests for test and toolchain changes', () => {
+  assert.deepEqual(planChecks(['src/services/tests/webhookService.test.ts']), ['lint', 'unit']);
+  assert.deepEqual(planChecks(['package.json']), ['lint', 'unit']);
+});


### PR DESCRIPTION
### Motivation

- Enforce code quality and security rules locally to give developers fast feedback before pushing changes.
- Make checks staged-file-aware so expensive or irrelevant workflows (e.g., CI-level typechecks) are skipped for documentation-only commits.
- Provide an easy, reproducible local installation path for Git hooks without adding a third-party hook framework.

### Description

- Add a checked-in hook at `.githooks/pre-commit` that delegates to the repository pre-commit command `npm run precommit`.
- Implement a staged-file-aware Node.js runner `scripts/pre-commit-check.mjs` that ignores `.next/` and `node_modules/`, plans checks based on staged files, runs `npm run lint` and the hook test suite, and supports `SKIP_PRECOMMIT=1` to bypass checks in emergencies.
- Add `scripts/install-git-hooks.mjs` to set `core.hooksPath` to `.githooks` during `prepare`, add Node.js tests `tests/precommit/pre-commit-check.test.mjs` exercising file parsing and check planning, and add documentation `docs/pre-commit-hooks.md` describing architecture and policy.
- Update `package.json` scripts to include `precommit`, `prepare`, `test:precommit`, and `typecheck` to wire the new hook, installer, and test commands.

### Testing

- Ran the pre-commit unit tests with `npm run test:precommit` (which executes `node --test tests/precommit/*.test.mjs`), and they passed.
- Ran the orchestrated pre-commit flow with `npm run precommit`, and it completed successfully for the staged files exercised during development.
- Ran `npm run lint` which succeeded but reported 25 existing warnings in the repository.
- Verified hook installation with `node scripts/install-git-hooks.mjs` and checked the configured hooks path, which succeeded.
- Noted that `npm run typecheck` and the full `npm run test:unit` surfaced pre-existing TypeScript errors and failing unit tests unrelated to the hook suite, and therefore failed.

Closes #122