### PR TITLE
Blueprint for chaos

### DIFF
--- a/docs/chaos-engineering-staging.md
+++ b/docs/chaos-engineering-staging.md
@@ -1,0 +1,74 @@
+# Blueprint for Chaos Engineering Testing in Staging
+
+This blueprint defines how VeriNode runs controlled failure experiments in staging while preserving the critical-path latency target of **< 100 ms P99**, the availability target of **99.99%**, and the requirement that every experiment pass security review before execution.
+
+## Architecture
+
+1. **Experiment registry** — `src/config/chaosEngineering.ts` stores the approved staging experiments, service scope, blast radius, abort conditions, dashboard panels, and runbook anchors.
+2. **Orchestrator** — CI or an operator workflow reads the registry, verifies readiness with `evaluateChaosReadiness`, and applies faults through the staging platform tooling.
+3. **Safety controller** — automated checks stop an experiment when any abort condition breaches its threshold for the configured duration.
+4. **Observability plane** — dashboards must expose latency, availability, error budget burn, synthetic transaction success, and security alerts before the experiment starts.
+5. **Deployment gate** — chaos experiments run against the green environment first, then move through canary analysis before staging traffic is fully shifted.
+
+## Guardrails
+
+- Limit each experiment to a maximum 10% blast radius and 30-minute duration.
+- Require SRE ownership and Security approval for every staging experiment.
+- Abort when critical path P99 latency exceeds 100 ms for 3 minutes.
+- Abort when synthetic availability drops below 99.99% for 2 minutes.
+- Abort when error-budget burn reaches 2x for 5 minutes.
+- Abort immediately on any security alert.
+
+## Approved staging experiments
+
+### Stellar RPC latency injection
+
+- **Registry ID:** `chaos-stg-rpc-latency`
+- **Services:** web app, Stellar RPC, indexer
+- **Fault:** inject latency on Stellar RPC read paths
+- **Expected steady state:** cache fallback and bounded retries keep critical reads below 100 ms P99
+- **Dashboards:** critical path P99, RPC fallback rate, synthetic transaction success, error budget burn
+
+### Wallet adapter failover
+
+- **Registry ID:** `chaos-stg-wallet-adapter-failover`
+- **Services:** web app, wallet adapter
+- **Fault:** disable the primary wallet adapter endpoint
+- **Expected steady state:** connection UX degrades gracefully and recovery banners render without blocking dashboards
+- **Dashboards:** wallet connect success, wallet error rate, frontend web vitals, support contact rate
+
+### Notification worker resource pressure
+
+- **Registry ID:** `chaos-stg-worker-resource-pressure`
+- **Services:** notification worker, observability
+- **Fault:** apply CPU and memory pressure to notification workers
+- **Expected steady state:** queues drain after autoscaling and alert delivery latency remains inside staging SLOs
+- **Dashboards:** worker CPU saturation, queue depth, alert delivery latency, autoscaler decisions
+
+## Execution runbook
+
+1. Confirm the target experiment is present in `stagingChaosExperiments` and `evaluateChaosReadiness` returns `ready: true`.
+2. Confirm the active staging deployment is the green environment and the previous blue environment is healthy for rollback.
+3. Announce the experiment window, expected blast radius, and rollback owner in the staging incident channel.
+4. Start synthetic canary transactions and verify baseline P99 latency, availability, error-budget burn, and security-alert metrics.
+5. Apply the fault at the configured blast radius.
+6. Watch abort conditions continuously; stop the experiment and roll back traffic on any breach.
+7. If steady state holds for the configured duration, remove the fault and continue observing recovery for 15 minutes.
+8. Record findings, metric links, screenshots, and follow-up work in the experiment report.
+
+## Monitoring and alerting checklist
+
+- Critical-path latency panel with P50, P95, and P99 overlays.
+- Synthetic availability panel with the 99.99% threshold annotated.
+- Error-budget burn alert at 2x over 5 minutes.
+- Security alert stream filtered to staging services in scope.
+- Service-specific saturation panels for CPU, memory, queue depth, fallback rate, and wallet connection errors.
+- Canary comparison between blue and green deployments before full traffic shift.
+
+## Security review checklist
+
+- Fault tooling can target staging only and cannot mutate production resources.
+- Experiment credentials are short-lived and scoped to approved services.
+- Audit logs capture the operator, experiment ID, start time, abort reason, and rollback outcome.
+- Customer-like test data remains synthetic and contains no production secrets.
+- Security signs off before the experiment is added to the approved registry.

--- a/src/__tests__/chaosEngineering.test.ts
+++ b/src/__tests__/chaosEngineering.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CHAOS_AVAILABILITY_TARGET_PERCENT,
+  CHAOS_LATENCY_P99_TARGET_MS,
+  CHAOS_MAX_BLAST_RADIUS_PERCENT,
+  CHAOS_MAX_DURATION_MINUTES,
+  evaluateChaosReadiness,
+  listReadyChaosExperiments,
+  stagingChaosExperiments,
+  type ChaosExperiment,
+} from '@/config/chaosEngineering'
+
+describe('staging chaos engineering registry', () => {
+  it('keeps default experiments within latency, availability, blast-radius, and duration guardrails', () => {
+    expect(CHAOS_LATENCY_P99_TARGET_MS).toBe(100)
+    expect(CHAOS_AVAILABILITY_TARGET_PERCENT).toBe(99.99)
+
+    for (const experiment of stagingChaosExperiments) {
+      expect(experiment.blastRadiusPercent).toBeGreaterThan(0)
+      expect(experiment.blastRadiusPercent).toBeLessThanOrEqual(CHAOS_MAX_BLAST_RADIUS_PERCENT)
+      expect(experiment.maxDurationMinutes).toBeGreaterThan(0)
+      expect(experiment.maxDurationMinutes).toBeLessThanOrEqual(CHAOS_MAX_DURATION_MINUTES)
+      expect(experiment.requiredApprovals).toContain('Security')
+      expect(experiment.abortConditions.length).toBeGreaterThan(0)
+      expect(experiment.dashboardPanels.length).toBeGreaterThanOrEqual(3)
+    }
+  })
+
+  it('marks every built-in staging experiment as ready', () => {
+    expect(listReadyChaosExperiments()).toHaveLength(stagingChaosExperiments.length)
+  })
+
+  it('reports actionable blockers for unsafe experiments', () => {
+    const unsafeExperiment: ChaosExperiment = {
+      ...stagingChaosExperiments[0],
+      blastRadiusPercent: 50,
+      maxDurationMinutes: 45,
+      requiredApprovals: ['SRE'],
+      abortConditions: [],
+      dashboardPanels: ['Critical path P99'],
+    }
+
+    expect(evaluateChaosReadiness(unsafeExperiment)).toEqual({
+      ready: false,
+      blockers: [
+        'Blast radius must be between 1% and 10%.',
+        'Duration must be between 1 and 30 minutes.',
+        'Security approval is required before staging chaos execution.',
+        'At least one automated abort condition is required.',
+        'At least three dashboard panels are required for operator visibility.',
+      ],
+    })
+  })
+})

--- a/src/config/chaosEngineering.ts
+++ b/src/config/chaosEngineering.ts
@@ -1,0 +1,148 @@
+/**
+ * Staging chaos engineering guardrails and experiment registry.
+ *
+ * The data in this module is intentionally pure/static so CI, runbooks, and
+ * operator dashboards can share one source of truth for approved experiments.
+ */
+
+export type ChaosService =
+  | 'web-app'
+  | 'wallet-adapter'
+  | 'stellar-rpc'
+  | 'indexer'
+  | 'notification-worker'
+  | 'observability'
+
+export type ChaosFaultType = 'latency' | 'dependency-outage' | 'packet-loss' | 'resource-pressure' | 'process-kill'
+
+export type ChaosAbortCondition = {
+  readonly metric: string
+  readonly operator: '>=' | '>' | '<=' | '<'
+  readonly threshold: number
+  readonly durationMinutes: number
+}
+
+export type ChaosExperiment = {
+  readonly id: string
+  readonly title: string
+  readonly services: readonly ChaosService[]
+  readonly faultType: ChaosFaultType
+  readonly blastRadiusPercent: number
+  readonly maxDurationMinutes: number
+  readonly steadyStateHypothesis: string
+  readonly abortConditions: readonly ChaosAbortCondition[]
+  readonly requiredApprovals: readonly string[]
+  readonly dashboardPanels: readonly string[]
+  readonly runbook: string
+}
+
+export type ChaosReadinessResult = {
+  readonly ready: boolean
+  readonly blockers: readonly string[]
+}
+
+export const CHAOS_LATENCY_P99_TARGET_MS = 100
+export const CHAOS_AVAILABILITY_TARGET_PERCENT = 99.99
+export const CHAOS_MAX_BLAST_RADIUS_PERCENT = 10
+export const CHAOS_MAX_DURATION_MINUTES = 30
+
+export const defaultChaosAbortConditions: readonly ChaosAbortCondition[] = [
+  {
+    metric: 'critical_path_p99_ms',
+    operator: '>',
+    threshold: CHAOS_LATENCY_P99_TARGET_MS,
+    durationMinutes: 3,
+  },
+  {
+    metric: 'synthetic_availability_percent',
+    operator: '<',
+    threshold: CHAOS_AVAILABILITY_TARGET_PERCENT,
+    durationMinutes: 2,
+  },
+  {
+    metric: 'error_budget_burn_rate',
+    operator: '>=',
+    threshold: 2,
+    durationMinutes: 5,
+  },
+  {
+    metric: 'security_alert_count',
+    operator: '>',
+    threshold: 0,
+    durationMinutes: 1,
+  },
+]
+
+export const stagingChaosExperiments: readonly ChaosExperiment[] = [
+  {
+    id: 'chaos-stg-rpc-latency',
+    title: 'Inject Stellar RPC latency on read paths',
+    services: ['web-app', 'stellar-rpc', 'indexer'],
+    faultType: 'latency',
+    blastRadiusPercent: 5,
+    maxDurationMinutes: 15,
+    steadyStateHypothesis: 'Critical read paths remain below 100 ms P99 through cache fallback and bounded retries.',
+    abortConditions: defaultChaosAbortConditions,
+    requiredApprovals: ['SRE', 'Security', 'Frontend owner'],
+    dashboardPanels: ['Critical path P99', 'RPC fallback rate', 'Synthetic transaction success', 'Error budget burn'],
+    runbook: 'docs/chaos-engineering-staging.md#stellar-rpc-latency-injection',
+  },
+  {
+    id: 'chaos-stg-wallet-adapter-failover',
+    title: 'Disable primary wallet adapter endpoint',
+    services: ['web-app', 'wallet-adapter'],
+    faultType: 'dependency-outage',
+    blastRadiusPercent: 10,
+    maxDurationMinutes: 20,
+    steadyStateHypothesis: 'Wallet connection UX degrades gracefully and recovery banners render without blocking dashboards.',
+    abortConditions: defaultChaosAbortConditions,
+    requiredApprovals: ['SRE', 'Security', 'Product owner'],
+    dashboardPanels: ['Wallet connect success', 'Wallet error rate', 'Frontend web vitals', 'Support contact rate'],
+    runbook: 'docs/chaos-engineering-staging.md#wallet-adapter-failover',
+  },
+  {
+    id: 'chaos-stg-worker-resource-pressure',
+    title: 'Apply CPU and memory pressure to notification workers',
+    services: ['notification-worker', 'observability'],
+    faultType: 'resource-pressure',
+    blastRadiusPercent: 5,
+    maxDurationMinutes: 10,
+    steadyStateHypothesis: 'Worker queues drain after autoscaling and alert delivery latency remains inside staging SLOs.',
+    abortConditions: defaultChaosAbortConditions,
+    requiredApprovals: ['SRE', 'Backend owner', 'Security'],
+    dashboardPanels: ['Worker CPU saturation', 'Queue depth', 'Alert delivery latency', 'Autoscaler decisions'],
+    runbook: 'docs/chaos-engineering-staging.md#notification-worker-resource-pressure',
+  },
+]
+
+export function evaluateChaosReadiness(experiment: ChaosExperiment): ChaosReadinessResult {
+  const blockers: string[] = []
+
+  if (experiment.blastRadiusPercent <= 0 || experiment.blastRadiusPercent > CHAOS_MAX_BLAST_RADIUS_PERCENT) {
+    blockers.push(`Blast radius must be between 1% and ${CHAOS_MAX_BLAST_RADIUS_PERCENT}%.`)
+  }
+
+  if (experiment.maxDurationMinutes <= 0 || experiment.maxDurationMinutes > CHAOS_MAX_DURATION_MINUTES) {
+    blockers.push(`Duration must be between 1 and ${CHAOS_MAX_DURATION_MINUTES} minutes.`)
+  }
+
+  if (!experiment.requiredApprovals.includes('Security')) {
+    blockers.push('Security approval is required before staging chaos execution.')
+  }
+
+  if (experiment.abortConditions.length === 0) {
+    blockers.push('At least one automated abort condition is required.')
+  }
+
+  if (experiment.dashboardPanels.length < 3) {
+    blockers.push('At least three dashboard panels are required for operator visibility.')
+  }
+
+  return { ready: blockers.length === 0, blockers }
+}
+
+export function listReadyChaosExperiments(
+  experiments: readonly ChaosExperiment[] = stagingChaosExperiments,
+): readonly ChaosExperiment[] {
+  return experiments.filter((experiment) => evaluateChaosReadiness(experiment).ready)
+}


### PR DESCRIPTION
### Motivation

- Provide a documented, auditable blueprint for running controlled chaos experiments in staging with clear operator runbooks and observability requirements.
- Encode guardrails to preserve critical-path performance targets (`< 100 ms` P99) and availability targets (`99.99%`) while limiting blast radius and duration.
- Ensure every staging experiment requires Security approval and automated abort conditions so unsafe experiments are rejected early.

### Description

- Add a typed, static experiment registry at `src/config/chaosEngineering.ts` with constants (`CHAOS_LATENCY_P99_TARGET_MS`, `CHAOS_AVAILABILITY_TARGET_PERCENT`, `CHAOS_MAX_BLAST_RADIUS_PERCENT`, `CHAOS_MAX_DURATION_MINUTES`), `defaultChaosAbortConditions`, `stagingChaosExperiments`, and helpers `evaluateChaosReadiness` and `listReadyChaosExperiments`.
- Register three canonical staging experiments (RPC latency injection, wallet adapter failover, notification worker resource pressure) with blast-radius, duration, dashboard, approval and abort-condition metadata.
- Add a human-facing runbook and checklist documenting architecture, guardrails, approved experiments, monitoring, deployment gate, and security review at `docs/chaos-engineering-staging.md`.
- Add unit tests in `src/__tests__/chaosEngineering.test.ts` that assert guardrail constants, that built-in experiments are ready, and that unsafe experiments report actionable blockers.

### Testing

- Ran the unit test for the new registry with `npm run test:unit -- --run src/__tests__/chaosEngineering.test.ts`, and the test file passed (3 tests) under Vitest. 
- Ran linter with `npm run lint -- src/config/chaosEngineering.ts src/__tests__/chaosEngineering.test.ts`, which completed successfully. 
- An attempt to run `npm test -- --run src/__tests__/chaosEngineering.test.ts` failed because the repository does not define a top-level `test` script, so `test:unit` was used instead.

Closes #120### Motivation

- Provide a documented, auditable blueprint for running controlled chaos experiments in staging with clear operator runbooks and observability requirements.
- Encode guardrails to preserve critical-path performance targets (`< 100 ms` P99) and availability targets (`99.99%`) while limiting blast radius and duration.
- Ensure every staging experiment requires Security approval and automated abort conditions so unsafe experiments are rejected early.

### Description

- Add a typed, static experiment registry at `src/config/chaosEngineering.ts` with constants (`CHAOS_LATENCY_P99_TARGET_MS`, `CHAOS_AVAILABILITY_TARGET_PERCENT`, `CHAOS_MAX_BLAST_RADIUS_PERCENT`, `CHAOS_MAX_DURATION_MINUTES`), `defaultChaosAbortConditions`, `stagingChaosExperiments`, and helpers `evaluateChaosReadiness` and `listReadyChaosExperiments`.
- Register three canonical staging experiments (RPC latency injection, wallet adapter failover, notification worker resource pressure) with blast-radius, duration, dashboard, approval and abort-condition metadata.
- Add a human-facing runbook and checklist documenting architecture, guardrails, approved experiments, monitoring, deployment gate, and security review at `docs/chaos-engineering-staging.md`.
- Add unit tests in `src/__tests__/chaosEngineering.test.ts` that assert guardrail constants, that built-in experiments are ready, and that unsafe experiments report actionable blockers.

### Testing

- Ran the unit test for the new registry with `npm run test:unit -- --run src/__tests__/chaosEngineering.test.ts`, and the test file passed (3 tests) under Vitest. 
- Ran linter with `npm run lint -- src/config/chaosEngineering.ts src/__tests__/chaosEngineering.test.ts`, which completed successfully. 
- An attempt to run `npm test -- --run src/__tests__/chaosEngineering.test.ts` failed because the repository does not define a top-level `test` script, so `test:unit` was used instead.

Closes #120