### PR TITLE
Database migration

### DIFF
--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -1,0 +1,52 @@
+# Database Migration Versioning and Rollback Architecture
+
+## Goals
+
+- Apply database changes in a strict, contiguous version order across VeriNode services.
+- Support one-command rollback to a known good version when canary analysis or health checks fail.
+- Keep critical-path migration bookkeeping below the 100 ms P99 target by recording compact metadata only.
+- Expose migration duration, failure, and rollback metrics for dashboards and alerts.
+
+## Core Design
+
+`DatabaseMigrationManager` owns migration orchestration. Each migration declares a numeric `version`, a human-readable `name`, a `description`, and reversible `up` and `down` handlers. Versions must start at `1` and remain contiguous, which prevents accidentally skipping a change during deploys.
+
+Migration state is abstracted behind `MigrationStateStore`, allowing services to persist applied versions in IndexedDB, an API-backed metadata table, or an in-memory test store. Applied records include the version, checksum, duration, direction, status, and timestamp so operators can audit what ran during a release.
+
+## Rollback Flow
+
+1. Select the last known healthy target version.
+2. Generate a rollback plan with `createPlan(targetVersion)`.
+3. Execute `migrate(context, targetVersion)`.
+4. The manager runs `down` handlers in reverse version order and removes successfully rolled-back records.
+5. If a rollback step fails, the manager emits a failure metric and stops so operators can inspect the partially rolled-back state.
+
+## Monitoring and Alerting
+
+The manager emits the following metrics when an `emitMetric` callback is provided:
+
+- `database_migration_duration_ms` tagged by version, name, and direction.
+- `database_migration_failure_total` tagged by version, name, and direction.
+- `database_migration_rollback_total` tagged by version, name, and direction.
+
+Recommended alerts:
+
+- Page when any `database_migration_failure_total` is greater than zero during a deployment window.
+- Warn when migration duration P99 exceeds 100 ms for critical-path migrations.
+- Page when rollback count is greater than zero and canary error rate remains above baseline for 10 minutes.
+
+## Blue-Green and Canary Deployment
+
+1. Deploy migrations to the green environment with writes paused or dual-written where applicable.
+2. Run `createPlan()` and review pending versions before promotion.
+3. Execute `migrate()` against green and verify health checks, backup integrity, and dashboard metrics.
+4. Shift 5% of traffic to green and watch canary latency, errors, and migration metrics for at least 15 minutes.
+5. Increase to 50%, then 100% if metrics remain healthy.
+6. Roll back to the previous version immediately if migration failures, checksum mismatches, or sustained SLO regressions appear.
+
+## Security Review Checklist
+
+- Confirm every migration is reversible or has an approved exception.
+- Confirm checksums are generated from reviewed migration metadata.
+- Confirm no migration logs secrets, credentials, payload contents, or user private data.
+- Confirm rollback instructions have been tested in a non-production environment.

--- a/docs/runbooks/database-migration-rollback.md
+++ b/docs/runbooks/database-migration-rollback.md
@@ -1,0 +1,29 @@
+# Runbook: Database Migration Rollback
+
+## When to Use
+
+Use this runbook when a database migration causes failed canary analysis, elevated API errors, checksum mismatches, or a sustained critical-path latency regression.
+
+## Preconditions
+
+- Identify the currently applied version from the migration records dashboard.
+- Identify the last known healthy target version.
+- Confirm a recent verified backup exists before rollback.
+- Notify the incident channel and deployment owner.
+
+## Procedure
+
+1. Stop further traffic promotion in the blue-green deployment tool.
+2. Generate the rollback plan for the target version and confirm versions are listed in descending order.
+3. Execute the rollback through the service migration command or administrative console.
+4. Watch `database_migration_rollback_total`, `database_migration_failure_total`, and `database_migration_duration_ms`.
+5. Run database health verification and application smoke tests.
+6. Shift traffic back to the healthy environment if rollback fails or user-facing errors continue.
+7. Record the failed version, error, duration, and remediation in the incident ticket.
+
+## Success Criteria
+
+- Current migration version matches the target version.
+- No new migration failures are emitted for 10 minutes.
+- Critical-path P99 latency is below 100 ms or back to pre-deploy baseline.
+- Backup integrity verification passes.

--- a/src/services/db/migrations.ts
+++ b/src/services/db/migrations.ts
@@ -1,0 +1,226 @@
+import { sha256 } from '@/src/lib/crypto'
+
+export type MigrationDirection = 'up' | 'down'
+export type MigrationStatus = 'pending' | 'running' | 'applied' | 'rolled_back' | 'failed'
+
+export interface DatabaseMigrationContext<TDatabase = unknown> {
+  db: TDatabase
+  now: () => number
+  emitMetric?: (metric: MigrationMetric) => void
+  log?: (entry: MigrationLogEntry) => void
+}
+
+export interface DatabaseMigration<TDatabase = unknown> {
+  version: number
+  name: string
+  description: string
+  up: (context: DatabaseMigrationContext<TDatabase>) => Promise<void> | void
+  down: (context: DatabaseMigrationContext<TDatabase>) => Promise<void> | void
+  criticalPath?: boolean
+}
+
+export interface MigrationRecord {
+  version: number
+  name: string
+  checksum: string
+  appliedAt: number
+  status: Exclude<MigrationStatus, 'pending' | 'running'>
+  durationMs: number
+  direction: MigrationDirection
+  error?: string
+}
+
+export interface MigrationMetric {
+  name: 'database_migration_duration_ms' | 'database_migration_failure_total' | 'database_migration_rollback_total'
+  value: number
+  tags: Record<string, string>
+  timestamp: number
+}
+
+export interface MigrationLogEntry {
+  level: 'info' | 'error'
+  message: string
+  migrationVersion: number
+  migrationName: string
+  direction: MigrationDirection
+  durationMs?: number
+  error?: string
+}
+
+export interface MigrationPlan {
+  direction: MigrationDirection
+  fromVersion: number
+  toVersion: number
+  migrations: Array<Pick<DatabaseMigration, 'version' | 'name' | 'description' | 'criticalPath'>>
+}
+
+export interface MigrationStateStore {
+  getAppliedMigrations(): Promise<MigrationRecord[]>
+  recordMigration(record: MigrationRecord): Promise<void>
+  removeMigration(version: number): Promise<void>
+}
+
+export const MIGRATION_P99_TARGET_MS = 100
+
+export class InMemoryMigrationStateStore implements MigrationStateStore {
+  private records = new Map<number, MigrationRecord>()
+
+  async getAppliedMigrations(): Promise<MigrationRecord[]> {
+    return Array.from(this.records.values()).sort((a, b) => a.version - b.version)
+  }
+
+  async recordMigration(record: MigrationRecord): Promise<void> {
+    this.records.set(record.version, record)
+  }
+
+  async removeMigration(version: number): Promise<void> {
+    this.records.delete(version)
+  }
+}
+
+export class DatabaseMigrationManager<TDatabase = unknown> {
+  private migrations: DatabaseMigration<TDatabase>[]
+
+  constructor(
+    migrations: DatabaseMigration<TDatabase>[],
+    private readonly stateStore: MigrationStateStore,
+  ) {
+    this.migrations = [...migrations].sort((a, b) => a.version - b.version)
+    this.validateMigrations()
+  }
+
+  getAvailableMigrations(): DatabaseMigration<TDatabase>[] {
+    return [...this.migrations]
+  }
+
+  async getCurrentVersion(): Promise<number> {
+    const applied = await this.stateStore.getAppliedMigrations()
+    return applied.reduce((max, record) => Math.max(max, record.version), 0)
+  }
+
+  async createPlan(targetVersion = this.latestVersion()): Promise<MigrationPlan> {
+    const fromVersion = await this.getCurrentVersion()
+    const direction: MigrationDirection = targetVersion >= fromVersion ? 'up' : 'down'
+    const selected = direction === 'up'
+      ? this.migrations.filter((migration) => migration.version > fromVersion && migration.version <= targetVersion)
+      : this.migrations.filter((migration) => migration.version <= fromVersion && migration.version > targetVersion).reverse()
+
+    return {
+      direction,
+      fromVersion,
+      toVersion: targetVersion,
+      migrations: selected.map(({ version, name, description, criticalPath }) => ({
+        version,
+        name,
+        description,
+        criticalPath,
+      })),
+    }
+  }
+
+  async migrate(context: Omit<DatabaseMigrationContext<TDatabase>, 'now'> & { now?: () => number }, targetVersion = this.latestVersion()): Promise<MigrationPlan> {
+    const runtimeContext: DatabaseMigrationContext<TDatabase> = { ...context, now: context.now ?? Date.now }
+    const plan = await this.createPlan(targetVersion)
+
+    for (const planItem of plan.migrations) {
+      const migration = this.migrations.find((candidate) => candidate.version === planItem.version)
+      if (!migration) throw new Error(`Migration ${planItem.version} is not registered`)
+      await this.runMigration(migration, plan.direction, runtimeContext)
+    }
+
+    return plan
+  }
+
+  private async runMigration(
+    migration: DatabaseMigration<TDatabase>,
+    direction: MigrationDirection,
+    context: DatabaseMigrationContext<TDatabase>,
+  ): Promise<void> {
+    const start = context.now()
+    const tags = { version: String(migration.version), name: migration.name, direction }
+
+    try {
+      context.log?.({
+        level: 'info',
+        message: `Starting database migration ${direction}`,
+        migrationVersion: migration.version,
+        migrationName: migration.name,
+        direction,
+      })
+
+      await migration[direction](context)
+
+      const durationMs = context.now() - start
+      const checksum = await checksumMigration(migration)
+      const record: MigrationRecord = {
+        version: migration.version,
+        name: migration.name,
+        checksum,
+        appliedAt: context.now(),
+        status: direction === 'up' ? 'applied' : 'rolled_back',
+        durationMs,
+        direction,
+      }
+
+      if (direction === 'up') await this.stateStore.recordMigration(record)
+      else await this.stateStore.removeMigration(migration.version)
+
+      context.emitMetric?.({ name: 'database_migration_duration_ms', value: durationMs, tags, timestamp: context.now() })
+      if (direction === 'down') {
+        context.emitMetric?.({ name: 'database_migration_rollback_total', value: 1, tags, timestamp: context.now() })
+      }
+      context.log?.({
+        level: 'info',
+        message: `Completed database migration ${direction}`,
+        migrationVersion: migration.version,
+        migrationName: migration.name,
+        direction,
+        durationMs,
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown migration failure'
+      const durationMs = context.now() - start
+      context.emitMetric?.({ name: 'database_migration_failure_total', value: 1, tags, timestamp: context.now() })
+      context.log?.({
+        level: 'error',
+        message: `Failed database migration ${direction}`,
+        migrationVersion: migration.version,
+        migrationName: migration.name,
+        direction,
+        durationMs,
+        error: message,
+      })
+      throw new Error(`Migration ${migration.version} ${direction} failed: ${message}`)
+    }
+  }
+
+  private latestVersion(): number {
+    return this.migrations.at(-1)?.version ?? 0
+  }
+
+  private validateMigrations(): void {
+    const seen = new Set<number>()
+    let previous = 0
+    for (const migration of this.migrations) {
+      if (!Number.isInteger(migration.version) || migration.version < 1) {
+        throw new Error(`Migration ${migration.name} must use a positive integer version`)
+      }
+      if (seen.has(migration.version)) {
+        throw new Error(`Duplicate migration version ${migration.version}`)
+      }
+      if (migration.version !== previous + 1) {
+        throw new Error(`Migration versions must be contiguous; expected ${previous + 1} but received ${migration.version}`)
+      }
+      seen.add(migration.version)
+      previous = migration.version
+    }
+  }
+}
+
+export async function checksumMigration(migration: Pick<DatabaseMigration, 'version' | 'name' | 'description'>): Promise<string> {
+  return sha256(JSON.stringify({
+    version: migration.version,
+    name: migration.name,
+    description: migration.description,
+  }))
+}

--- a/src/services/db/tests/migrations.test.ts
+++ b/src/services/db/tests/migrations.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  DatabaseMigrationManager,
+  InMemoryMigrationStateStore,
+  MIGRATION_P99_TARGET_MS,
+  type DatabaseMigration,
+  type MigrationMetric,
+} from '@/src/services/db/migrations'
+
+interface FakeDb {
+  fields: string[]
+}
+
+const migrations: DatabaseMigration<FakeDb>[] = [
+  {
+    version: 1,
+    name: 'create-validator-index',
+    description: 'Creates the validator index used by offline storage lookups.',
+    criticalPath: true,
+    up: ({ db }) => {
+      db.fields.push('validatorIndex')
+    },
+    down: ({ db }) => {
+      db.fields = db.fields.filter((field) => field !== 'validatorIndex')
+    },
+  },
+  {
+    version: 2,
+    name: 'add-migration-audit-log',
+    description: 'Adds an append-only audit log for database migration records.',
+    up: ({ db }) => {
+      db.fields.push('migrationAuditLog')
+    },
+    down: ({ db }) => {
+      db.fields = db.fields.filter((field) => field !== 'migrationAuditLog')
+    },
+  },
+]
+
+function makeClock(stepMs = 3): () => number {
+  let current = 1_800_000_000_000
+  return () => {
+    current += stepMs
+    return current
+  }
+}
+
+describe('DatabaseMigrationManager', () => {
+  it('creates deterministic forward migration plans', async () => {
+    const manager = new DatabaseMigrationManager(migrations, new InMemoryMigrationStateStore())
+
+    await expect(manager.createPlan()).resolves.toMatchObject({
+      direction: 'up',
+      fromVersion: 0,
+      toVersion: 2,
+      migrations: [
+        { version: 1, name: 'create-validator-index', criticalPath: true },
+        { version: 2, name: 'add-migration-audit-log' },
+      ],
+    })
+  })
+
+  it('applies migrations, records versions, and emits duration metrics under the P99 target', async () => {
+    const db: FakeDb = { fields: [] }
+    const metrics: MigrationMetric[] = []
+    const store = new InMemoryMigrationStateStore()
+    const manager = new DatabaseMigrationManager(migrations, store)
+
+    await manager.migrate({ db, now: makeClock(), emitMetric: (metric) => metrics.push(metric) })
+
+    expect(db.fields).toEqual(['validatorIndex', 'migrationAuditLog'])
+    await expect(manager.getCurrentVersion()).resolves.toBe(2)
+    expect(metrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'database_migration_duration_ms', value: 3 }),
+      ]),
+    )
+    expect(Math.max(...metrics.map((metric) => metric.value))).toBeLessThan(MIGRATION_P99_TARGET_MS)
+  })
+
+  it('rolls migrations back in reverse order and removes applied records', async () => {
+    const db: FakeDb = { fields: [] }
+    const store = new InMemoryMigrationStateStore()
+    const manager = new DatabaseMigrationManager(migrations, store)
+
+    await manager.migrate({ db, now: makeClock() })
+    const rollbackPlan = await manager.migrate({ db, now: makeClock() }, 0)
+
+    expect(rollbackPlan).toMatchObject({ direction: 'down', fromVersion: 2, toVersion: 0 })
+    expect(rollbackPlan.migrations.map((migration) => migration.version)).toEqual([2, 1])
+    expect(db.fields).toEqual([])
+    await expect(manager.getCurrentVersion()).resolves.toBe(0)
+  })
+
+  it('rejects non-contiguous migration versions', () => {
+    expect(() => new DatabaseMigrationManager([migrations[1]], new InMemoryMigrationStateStore())).toThrow(
+      'Migration versions must be contiguous',
+    )
+  })
+
+  it('emits failure metrics and preserves the original failure message', async () => {
+    const metrics: MigrationMetric[] = []
+    const manager = new DatabaseMigrationManager<FakeDb>([
+      {
+        version: 1,
+        name: 'broken-migration',
+        description: 'Exercises migration failure reporting.',
+        up: () => {
+          throw new Error('DDL rejected')
+        },
+        down: vi.fn(),
+      },
+    ], new InMemoryMigrationStateStore())
+
+    await expect(manager.migrate({ db: { fields: [] }, now: makeClock(), emitMetric: (metric) => metrics.push(metric) })).rejects.toThrow(
+      'Migration 1 up failed: DDL rejected',
+    )
+    expect(metrics).toEqual([
+      expect.objectContaining({ name: 'database_migration_failure_total', value: 1 }),
+    ])
+  })
+})


### PR DESCRIPTION
### Motivation

- Provide a reusable, system-wide migration orchestration layer that enforces contiguous numeric versions and supports one-command rollbacks.
- Ensure migrations are auditable with checksums, timestamps, status, and metrics so operators can monitor, alert, and rollback safely.

### Description

- Add `DatabaseMigrationManager` with `createPlan`, `migrate`, contiguous-version validation, forward and reverse execution, metric hooks, and structured logging (`src/services/db/migrations.ts`).
- Add `MigrationStateStore` abstraction and an `InMemoryMigrationStateStore` for testing and local adapters, plus `checksumMigration` (uses `sha256`) to sign migration metadata.
- Add unit tests covering plan creation, forward application, rollback ordering, contiguous-version enforcement, and failure/metric reporting (`src/services/db/tests/migrations.test.ts`).
- Add architecture documentation and an operational rollback runbook describing monitoring, canary/blue-green flow, and security review checklist (`docs/database-migrations.md`, `docs/runbooks/database-migration-rollback.md`).

### Testing

- Ran `npm run test:unit -- src/services/db/tests/migrations.test.ts`, which executed the migration unit tests and passed (5 tests, 5 passed).
- Ran `npx eslint src/services/db/migrations.ts src/services/db/tests/migrations.test.ts` with no lint errors reported for the new files.
- Ran `npx tsc --noEmit` which failed due to pre-existing TypeScript errors elsewhere in the repository unrelated to these changes.

Closes #118