### PR TITLE
Distributed job scheduler

### DIFF
--- a/docs/distributed-job-scheduler.md
+++ b/docs/distributed-job-scheduler.md
@@ -1,0 +1,38 @@
+# Distributed Job Scheduler with Lease-based Worker Claiming
+
+This document describes the implementation for issue #116. The scheduler is built around durable jobs, short leases, idempotent completion, and metrics that let operators protect the `<100ms` P99 claim path and `99.99%` availability target.
+
+## Architecture
+
+1. Producers enqueue jobs with a queue name, priority, `runAt`, and `maxAttempts`.
+2. Workers claim jobs by queue using a compare-and-swap style lease update. A claimed job receives `leaseOwnerId`, `leaseToken`, and `leaseExpiresAt`.
+3. Workers complete or fail jobs only when both `leaseOwnerId` and `leaseToken` still match, preventing stale workers from acknowledging work after lease expiry.
+4. Expired leases are reclaimed back to `queued` unless the job has exhausted attempts, in which case it is moved to `dead-lettered`.
+5. Blue-green and canary deployment should route a small worker cohort to the new claim loop first, compare P99 claim latency and dead-letter rate, then shift the remaining workers.
+
+## Critical-path performance
+
+The pure claim algorithm normalizes expired leases, filters claimable jobs, orders by priority and FIFO tie-breakers, and leases at most `maxJobs`. Production storage should back this with indexes on `(queue, status, runAt, priority, createdAt)` and an atomic conditional update on `id` plus current lease fields.
+
+## Monitoring and alerting
+
+Track these signals per queue and worker pool:
+
+- `scheduler_claim_latency_ms` histogram with a critical alert when P99 is `>=100ms`.
+- `scheduler_expired_leases_total` warning when leases are waiting for reclaim.
+- `scheduler_dead_letter_total` warning when jobs exhaust retries.
+- `scheduler_claim_conflicts_total` for database contention and split-brain detection.
+- Worker heartbeat freshness and per-queue backlog age.
+
+## Security review checklist
+
+- Lease tokens are unguessable in production and are never logged with job payload secrets.
+- Job payloads are schema-validated before enqueue and before execution.
+- Workers authorize queue access through service identity, not user-supplied queue names.
+- Dead-letter payloads follow the same retention and redaction policy as audit logs.
+
+## Runbook
+
+1. If P99 claim latency breaches `100ms`, inspect database lock wait time, queue indexes, and worker concurrency.
+2. If expired leases grow, verify worker heartbeats and downstream RPC availability, then temporarily reduce lease duration only after confirming idempotency.
+3. If dead letters spike, pause producers for the affected queue, sample errors, replay safe jobs after fixing the root cause, and keep the canary below 10% until metrics recover.

--- a/src/services/distributedJobScheduler.ts
+++ b/src/services/distributedJobScheduler.ts
@@ -1,0 +1,120 @@
+import type {
+  ClaimJobOptions,
+  CompleteJobOptions,
+  FailJobOptions,
+  SchedulerAlert,
+  SchedulerJob,
+  SchedulerMetricsSnapshot,
+} from '../types/distributedScheduler';
+
+const DEFAULT_MAX_JOBS = 1;
+const MAX_LEASE_MS = 15 * 60 * 1000;
+
+export function createLeaseToken(jobId: string, workerId: string, now: number): string {
+  return `${jobId}:${workerId}:${now}:${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function isClaimable(job: SchedulerJob, queue: string, now: number): boolean {
+  if (job.queue !== queue || job.status === 'completed' || job.status === 'dead-lettered') return false;
+  if (job.status === 'queued') return job.runAt <= now;
+  return job.status === 'leased' && (job.leaseExpiresAt ?? 0) <= now;
+}
+
+export function reclaimExpiredLeases<Payload>(jobs: SchedulerJob<Payload>[], now: number): SchedulerJob<Payload>[] {
+  return jobs.map((job) => {
+    if (job.status !== 'leased' || (job.leaseExpiresAt ?? Number.POSITIVE_INFINITY) > now) return job;
+    return {
+      ...job,
+      status: job.attempts >= job.maxAttempts ? 'dead-lettered' : 'queued',
+      leaseOwnerId: undefined,
+      leaseToken: undefined,
+      leaseExpiresAt: undefined,
+      updatedAt: now,
+    };
+  });
+}
+
+export function claimJobs<Payload>(
+  jobs: SchedulerJob<Payload>[],
+  options: ClaimJobOptions,
+  tokenFactory: (jobId: string, workerId: string, now: number) => string = createLeaseToken,
+): { jobs: SchedulerJob<Payload>[]; claimed: SchedulerJob<Payload>[] } {
+  const maxJobs = options.maxJobs ?? DEFAULT_MAX_JOBS;
+  const leaseDurationMs = Math.min(options.leaseDurationMs, MAX_LEASE_MS);
+  const normalized = reclaimExpiredLeases(jobs, options.now);
+  const claimableIds = normalized
+    .filter((job) => isClaimable(job, options.queue, options.now))
+    .sort((a, b) => b.priority - a.priority || a.runAt - b.runAt || a.createdAt - b.createdAt)
+    .slice(0, maxJobs)
+    .map((job) => job.id);
+  const claimableIdSet = new Set(claimableIds);
+
+  const claimedById = new Map<string, SchedulerJob<Payload>>();
+  const nextJobs = normalized.map((job) => {
+    if (!claimableIdSet.has(job.id)) return job;
+    const leaseToken = tokenFactory(job.id, options.workerId, options.now);
+    const nextJob: SchedulerJob<Payload> = {
+      ...job,
+      status: 'leased',
+      attempts: job.attempts + 1,
+      leaseOwnerId: options.workerId,
+      leaseToken,
+      leaseExpiresAt: options.now + leaseDurationMs,
+      updatedAt: options.now,
+    };
+    claimedById.set(job.id, nextJob);
+    return nextJob;
+  });
+  const claimed = claimableIds.flatMap((id) => {
+    const job = claimedById.get(id);
+    return job ? [job] : [];
+  });
+
+  return { jobs: nextJobs, claimed };
+}
+
+export function completeJob<Payload>(jobs: SchedulerJob<Payload>[], options: CompleteJobOptions): SchedulerJob<Payload>[] {
+  return jobs.map((job) => {
+    if (job.leaseToken !== options.leaseToken || job.leaseOwnerId !== options.workerId || job.status !== 'leased') return job;
+    return { ...job, status: 'completed', leaseToken: undefined, leaseOwnerId: undefined, leaseExpiresAt: undefined, updatedAt: options.now };
+  });
+}
+
+export function failJob<Payload>(jobs: SchedulerJob<Payload>[], options: FailJobOptions): SchedulerJob<Payload>[] {
+  return jobs.map((job) => {
+    if (job.leaseToken !== options.leaseToken || job.leaseOwnerId !== options.workerId || job.status !== 'leased') return job;
+    const exhausted = job.attempts >= job.maxAttempts;
+    return {
+      ...job,
+      status: exhausted ? 'dead-lettered' : 'failed',
+      leaseToken: undefined,
+      leaseOwnerId: undefined,
+      leaseExpiresAt: undefined,
+      runAt: exhausted ? job.runAt : options.now + options.retryDelayMs,
+      updatedAt: options.now,
+      lastError: options.error,
+    };
+  });
+}
+
+export function schedulerMetrics(jobs: SchedulerJob[], claimLatenciesMs: number[] = [], now = Date.now()): SchedulerMetricsSnapshot {
+  const sorted = [...claimLatenciesMs].sort((a, b) => a - b);
+  const p99Index = sorted.length === 0 ? -1 : Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.99) - 1);
+  return {
+    queued: jobs.filter((job) => job.status === 'queued' || job.status === 'failed').length,
+    leased: jobs.filter((job) => job.status === 'leased').length,
+    completed: jobs.filter((job) => job.status === 'completed').length,
+    failed: jobs.filter((job) => job.status === 'failed').length,
+    deadLettered: jobs.filter((job) => job.status === 'dead-lettered').length,
+    expiredLeases: jobs.filter((job) => job.status === 'leased' && (job.leaseExpiresAt ?? 0) <= now).length,
+    p99ClaimLatencyMs: p99Index >= 0 ? sorted[p99Index] : 0,
+  };
+}
+
+export function schedulerAlerts(metrics: SchedulerMetricsSnapshot): SchedulerAlert[] {
+  const alerts: SchedulerAlert[] = [];
+  if (metrics.p99ClaimLatencyMs >= 100) alerts.push({ id: 'scheduler-claim-p99', severity: 'critical', message: 'Job claim P99 is above the 100ms target.' });
+  if (metrics.expiredLeases > 0) alerts.push({ id: 'scheduler-expired-leases', severity: 'warning', message: 'Expired leases are waiting to be reclaimed.' });
+  if (metrics.deadLettered > 0) alerts.push({ id: 'scheduler-dead-letter', severity: 'warning', message: 'Jobs reached max attempts and moved to the dead-letter queue.' });
+  return alerts;
+}

--- a/src/services/tests/distributedJobScheduler.test.ts
+++ b/src/services/tests/distributedJobScheduler.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  claimJobs,
+  completeJob,
+  failJob,
+  reclaimExpiredLeases,
+  schedulerAlerts,
+  schedulerMetrics,
+} from '../distributedJobScheduler';
+import type { SchedulerJob } from '../../types/distributedScheduler';
+
+const baseJob = (overrides: Partial<SchedulerJob> = {}): SchedulerJob => ({
+  id: 'job-1',
+  queue: 'validator-duty',
+  payload: { validatorIndex: 42 },
+  status: 'queued',
+  priority: 1,
+  attempts: 0,
+  maxAttempts: 3,
+  runAt: 1_000,
+  createdAt: 900,
+  updatedAt: 900,
+  ...overrides,
+});
+
+const tokenFactory = (jobId: string, workerId: string, now: number) => `${jobId}:${workerId}:${now}:token`;
+
+describe('distributed job scheduler', () => {
+  it('claims eligible jobs by priority and FIFO tie-breakers', () => {
+    const jobs = [
+      baseJob({ id: 'low', priority: 1, createdAt: 10 }),
+      baseJob({ id: 'high-newer', priority: 5, createdAt: 20 }),
+      baseJob({ id: 'high-older', priority: 5, createdAt: 5 }),
+    ];
+
+    const result = claimJobs(jobs, { workerId: 'worker-a', queue: 'validator-duty', now: 2_000, leaseDurationMs: 30_000, maxJobs: 2 }, tokenFactory);
+
+    expect(result.claimed.map((job) => job.id)).toEqual(['high-older', 'high-newer']);
+    expect(result.claimed.every((job) => job.leaseOwnerId === 'worker-a')).toBe(true);
+    expect(result.claimed.every((job) => job.leaseExpiresAt === 32_000)).toBe(true);
+  });
+
+  it('reclaims expired leases without double-completing stale tokens', () => {
+    const leased = baseJob({ status: 'leased', attempts: 1, leaseOwnerId: 'worker-a', leaseToken: 'old-token', leaseExpiresAt: 1_500 });
+
+    const reclaimed = reclaimExpiredLeases([leased], 2_000);
+    expect(reclaimed[0].status).toBe('queued');
+    expect(reclaimed[0].leaseToken).toBeUndefined();
+
+    const completed = completeJob(reclaimed, { workerId: 'worker-a', leaseToken: 'old-token', now: 2_100 });
+    expect(completed[0].status).toBe('queued');
+  });
+
+  it('moves exhausted jobs to the dead-letter queue after a failed lease', () => {
+    const leased = baseJob({ status: 'leased', attempts: 3, maxAttempts: 3, leaseOwnerId: 'worker-a', leaseToken: 'lease-token', leaseExpiresAt: 5_000 });
+
+    const failed = failJob([leased], { workerId: 'worker-a', leaseToken: 'lease-token', now: 2_000, retryDelayMs: 10_000, error: 'rpc timeout' });
+
+    expect(failed[0].status).toBe('dead-lettered');
+    expect(failed[0].lastError).toBe('rpc timeout');
+  });
+
+  it('emits monitoring alerts for latency, expired leases, and dead letters', () => {
+    const jobs = [
+      baseJob({ id: 'leased', status: 'leased', leaseExpiresAt: 1_000 }),
+      baseJob({ id: 'dead', status: 'dead-lettered' }),
+    ];
+
+    const metrics = schedulerMetrics(jobs, [10, 20, 125], 2_000);
+    expect(metrics.expiredLeases).toBe(1);
+    expect(schedulerAlerts(metrics).map((alert) => alert.id)).toEqual([
+      'scheduler-claim-p99',
+      'scheduler-expired-leases',
+      'scheduler-dead-letter',
+    ]);
+  });
+});

--- a/src/types/distributedScheduler.ts
+++ b/src/types/distributedScheduler.ts
@@ -1,0 +1,53 @@
+export type JobStatus = 'queued' | 'leased' | 'completed' | 'failed' | 'dead-lettered';
+
+export interface SchedulerJob<Payload = unknown> {
+  id: string;
+  queue: string;
+  payload: Payload;
+  status: JobStatus;
+  priority: number;
+  attempts: number;
+  maxAttempts: number;
+  runAt: number;
+  createdAt: number;
+  updatedAt: number;
+  leaseOwnerId?: string;
+  leaseToken?: string;
+  leaseExpiresAt?: number;
+  lastError?: string;
+}
+
+export interface ClaimJobOptions {
+  workerId: string;
+  queue: string;
+  now: number;
+  leaseDurationMs: number;
+  maxJobs?: number;
+}
+
+export interface CompleteJobOptions {
+  workerId: string;
+  leaseToken: string;
+  now: number;
+}
+
+export interface FailJobOptions extends CompleteJobOptions {
+  error: string;
+  retryDelayMs: number;
+}
+
+export interface SchedulerMetricsSnapshot {
+  queued: number;
+  leased: number;
+  completed: number;
+  failed: number;
+  deadLettered: number;
+  expiredLeases: number;
+  p99ClaimLatencyMs: number;
+}
+
+export interface SchedulerAlert {
+  id: string;
+  severity: 'warning' | 'critical';
+  message: string;
+}


### PR DESCRIPTION
### Motivation

- Provide a system-wide distributed job scheduler that uses short leases and idempotent worker claiming to meet the `<100ms` P99 claim latency and `99.99%` availability targets described in issue #116.
- Ensure safe handling of expired leases, stale acknowledgements, retries, and dead-lettering while enabling operators to monitor critical signals and run safe rollouts.

### Description

- Add scheduler domain types in `src/types/distributedScheduler.ts` describing jobs, options, metrics, and alerts.
- Implement core scheduler logic in `src/services/distributedJobScheduler.ts` including lease token generation, `isClaimable`, `reclaimExpiredLeases`, `claimJobs`, `completeJob`, `failJob`, P99 claim latency calculation, and `schedulerAlerts` generation.
- Add unit tests in `src/services/tests/distributedJobScheduler.test.ts` covering priority/FIFO claiming, expired-lease reclaiming, stale-token-safe completion, dead-letter transitions, and alert emission.
- Document architecture, monitoring/alerting, security checklist, deployment guidance, and runbook in `docs/distributed-job-scheduler.md`.

### Testing

- Ran the unit suite for the new scheduler tests with `npm run test:unit -- --run src/services/tests/distributedJobScheduler.test.ts`, and all tests passed (`4 passed`).
- Linted the added files with `npm run lint -- src/services/distributedJobScheduler.ts src/services/tests/distributedJobScheduler.test.ts src/types/distributedScheduler.ts`, and linting passed for those files.
- Performed a repository type-check with `npx tsc --noEmit`, which reported pre-existing unrelated type errors elsewhere in the repository and is not caused by these changes.

Closes #116