### PR TITLE
Dead letter queue

### DIFF
--- a/docs/dead-letter-queue.md
+++ b/docs/dead-letter-queue.md
@@ -1,0 +1,33 @@
+# Dead Letter Queue for Failed Message Processing
+
+## Architecture
+
+Failed Kafka messages are retried by the owning consumer group and then routed to a dead-letter queue (DLQ) after a terminal failure. The frontend models this with a redacted `DeadLetterMessage` envelope keyed by `consumerGroupId:topic:partition:offset`, which makes repeated failure reports idempotent and safe to replay after operator review.
+
+The monitoring hook fetches consumer lag, scaling status, and DLQ depth in parallel so dashboards have one refresh path for throughput and failure processing. The DLQ critical path is bounded to synchronous classification, deterministic ID generation, payload redaction, and metric summarization; there is no unbounded payload retention in the browser model.
+
+## Monitoring and alerting
+
+DLQ metrics include total depth, quarantined count, replay-ready count, replayed/discarded counts, oldest message age, and a `critical` flag. The alert threshold is critical when either:
+
+- at least 100 messages remain quarantined, or
+- the oldest failed message has been quarantined for at least 15 minutes.
+
+Dashboards should page the owning service when `critical` is true and include the topic, consumer group, partition, offset, reason, trace ID, and redacted payload preview.
+
+## Security
+
+Payload previews redact common sensitive fields such as `password`, `secret`, `token`, `privateKey`, and `authorization`. Production APIs should store encrypted full payloads server-side, expose only redacted previews to the frontend, and require an audited operator action before a message moves to `replay-ready`, `replayed`, or `discarded`.
+
+## Deployment and operations
+
+Deploy DLQ producers and replay workers with blue-green releases. During canary analysis, compare DLQ rate, retry-exhausted rate, handler latency, and replay success rate between old and new consumer pools. Roll back if canary DLQ rate exceeds baseline by more than the agreed service SLO window or if P99 processing latency exceeds 100 ms on critical paths.
+
+## Runbook
+
+1. Open the Kafka monitoring dashboard and inspect DLQ metrics.
+2. If `critical` is true, page the owning service and freeze automated replay.
+3. Inspect the redacted payload preview and trace ID to identify schema, poison-message, retry exhaustion, or handler errors.
+4. Patch the handler or schema mapping, deploy with blue-green, then mark safe messages as `replay-ready`.
+5. Replay in small batches during canary analysis and monitor replay success, duplicate side effects, and consumer lag.
+6. Mark irrecoverable poison messages as `discarded` only after audit approval.

--- a/src/__tests__/kafkaMonitoring.test.ts
+++ b/src/__tests__/kafkaMonitoring.test.ts
@@ -7,6 +7,10 @@ import {
   deriveGroupStatus,
   computeTargetInstances,
   buildScalingEvent,
+  buildDeadLetterMessage,
+  classifyDeadLetterReason,
+  createPayloadPreview,
+  summarizeDeadLetters,
   generateDemoSnapshot,
   generateDemoScalingStatuses,
   createDemoKafkaMonitoringService,
@@ -65,6 +69,57 @@ describe('deriveGroupStatus', () => {
   it('critical takes precedence over warning', () => {
     const partitions = [makePartition(5_000), makePartition(20_000)];
     expect(deriveGroupStatus(partitions)).toBe('critical');
+  });
+});
+
+
+// ── Dead-letter queue ───────────────────────────────────────────────────────
+
+describe('dead-letter queue helpers', () => {
+  it('classifies schema, poison, retry-exhausted, and handler failures', () => {
+    expect(classifyDeadLetterReason(new Error('schema validation failed'), 1)).toBe('schema-invalid');
+    expect(classifyDeadLetterReason(new Error('fatal poison message'), 1)).toBe('poison-message');
+    expect(classifyDeadLetterReason(new Error('temporary timeout'), 3)).toBe('retry-exhausted');
+    expect(classifyDeadLetterReason(new Error('temporary timeout'), 1)).toBe('handler-error');
+  });
+
+  it('builds deterministic message IDs and redacts sensitive payload fields', () => {
+    const message = buildDeadLetterMessage({
+      topic: 'validator-attestations',
+      partition: 4,
+      offset: 42,
+      consumerGroupId: 'attestation-processor',
+      attempts: 3,
+      error: new Error('handler failed'),
+      payload: { validatorIndex: 123, token: 'secret-token', nested: { privateKey: 'abc' } },
+      failedAt: 1000,
+    });
+
+    expect(message.id).toBe('attestation-processor:validator-attestations:4:42');
+    expect(message.reason).toBe('retry-exhausted');
+    expect(message.payloadPreview).toContain('[REDACTED]');
+    expect(message.payloadPreview).not.toContain('secret-token');
+    expect(message.payloadPreview).not.toContain('abc');
+  });
+
+  it('limits payload previews to a bounded size', () => {
+    const preview = createPayloadPreview('x'.repeat(1000));
+    expect(preview.length).toBeLessThanOrEqual(513);
+    expect(preview.endsWith('…')).toBe(true);
+  });
+
+  it('summarizes queue depth and critical age for alerting', () => {
+    const now = 20 * 60 * 1000;
+    const messages = [
+      { ...buildDeadLetterMessage({ topic: 't', partition: 0, offset: 1, consumerGroupId: 'g', attempts: 1, error: 'err', payload: {}, failedAt: 0 }), status: 'replay-ready' as const },
+      buildDeadLetterMessage({ topic: 't', partition: 0, offset: 2, consumerGroupId: 'g', attempts: 1, error: 'err', payload: {}, failedAt: now - 1000 }),
+    ];
+
+    const metrics = summarizeDeadLetters(messages, now);
+    expect(metrics.total).toBe(2);
+    expect(metrics.quarantined).toBe(1);
+    expect(metrics.replayReady).toBe(1);
+    expect(metrics.critical).toBe(true);
   });
 });
 
@@ -232,6 +287,21 @@ describe('createDemoKafkaMonitoringService', () => {
     expect(result.length).toBeGreaterThan(0);
   });
 
+  it('fetchDeadLetters resolves to redacted quarantined messages', async () => {
+    const svc = createDemoKafkaMonitoringService();
+    const result = await svc.fetchDeadLetters();
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0].status).toBe('quarantined');
+    expect(result[0].payloadPreview).toContain('[REDACTED]');
+  });
+
+  it('updateDeadLetterStatus transitions a message for replay', async () => {
+    const svc = createDemoKafkaMonitoringService();
+    const [message] = await svc.fetchDeadLetters();
+    const updated = await svc.updateDeadLetterStatus(message.id, 'replay-ready');
+    expect(updated.status).toBe('replay-ready');
+  });
+
   it('triggerManualScale updates the instance count', async () => {
     const svc = createDemoKafkaMonitoringService();
     const statuses = await svc.fetchScalingStatuses();
@@ -276,6 +346,19 @@ describe('kafkaSlice store', () => {
     }
 
     expect(useKafkaStore.getState().scalingHistory.length).toBe(200);
+  });
+
+  it('setDeadLetters and upsertDeadLetter update DLQ state', async () => {
+    const { useKafkaStore } = await import('../store/kafkaSlice');
+    useKafkaStore.getState().reset();
+
+    const message = buildDeadLetterMessage({ topic: 't', partition: 0, offset: 1, consumerGroupId: 'g', attempts: 3, error: 'err', payload: {} });
+    useKafkaStore.getState().setDeadLetters([message]);
+    useKafkaStore.getState().upsertDeadLetter({ ...message, status: 'replayed' });
+    useKafkaStore.getState().setDeadLetterMetrics(summarizeDeadLetters(Object.values(useKafkaStore.getState().deadLetters)));
+
+    expect(useKafkaStore.getState().deadLetters[message.id].status).toBe('replayed');
+    expect(useKafkaStore.getState().deadLetterMetrics.total).toBe(1);
   });
 
   it('markRefreshed sets isLoaded and lastRefreshedAt', async () => {

--- a/src/hooks/useKafkaMonitoring.ts
+++ b/src/hooks/useKafkaMonitoring.ts
@@ -15,6 +15,7 @@ import {
   createDemoKafkaMonitoringService,
   computeTargetInstances,
   buildScalingEvent,
+  summarizeDeadLetters,
 } from '../services/kafkaMonitoringService';
 import type { KafkaMonitoringProvider } from '../services/kafkaMonitoringService';
 
@@ -52,15 +53,18 @@ export function useKafkaMonitoring(options: UseKafkaMonitoringOptions = {}) {
 
     try {
       // Fetch lag snapshots and scaling statuses in parallel.
-      const [groups, statuses] = await Promise.all([
+      const [groups, statuses, deadLetters] = await Promise.all([
         svc.fetchConsumerLag(),
         svc.fetchScalingStatuses(),
+        svc.fetchDeadLetters(),
       ]);
 
       if (!mountedRef.current) return;
 
       store.setGroups(groups);
       statuses.forEach((s) => store.upsertScalingStatus(s));
+      store.setDeadLetters(deadLetters);
+      store.setDeadLetterMetrics(summarizeDeadLetters(deadLetters));
       store.markRefreshed();
 
       // Evaluate auto-scaling decisions for each group.
@@ -93,6 +97,20 @@ export function useKafkaMonitoring(options: UseKafkaMonitoringOptions = {}) {
       store.setError(err instanceof Error ? err.message : 'Kafka poll failed');
     }
   }, [store]);
+
+  const updateDeadLetterStatus = useCallback(
+    async (id: string, status: 'quarantined' | 'replay-ready' | 'replayed' | 'discarded') => {
+      try {
+        const message = await serviceRef.current.updateDeadLetterStatus(id, status);
+        store.upsertDeadLetter(message);
+        const current = useKafkaStore.getState().deadLetters;
+        store.setDeadLetterMetrics(summarizeDeadLetters(Object.values(current)));
+      } catch (err) {
+        store.setError(err instanceof Error ? err.message : 'DLQ update failed');
+      }
+    },
+    [store],
+  );
 
   // Trigger an immediate manual scale action.
   const triggerManualScale = useCallback(
@@ -146,10 +164,13 @@ export function useKafkaMonitoring(options: UseKafkaMonitoringOptions = {}) {
     groups: store.groups,
     scalingStatus: store.scalingStatus,
     scalingHistory: store.scalingHistory,
+    deadLetters: store.deadLetters,
+    deadLetterMetrics: store.deadLetterMetrics,
     isLoaded: store.isLoaded,
     error: store.error,
     lastRefreshedAt: store.lastRefreshedAt,
     triggerManualScale,
+    updateDeadLetterStatus,
     refresh: poll,
   };
 }

--- a/src/services/kafkaMonitoringService.ts
+++ b/src/services/kafkaMonitoringService.ts
@@ -8,6 +8,9 @@
 
 import type {
   ConsumerGroupLag,
+  DeadLetterMessage,
+  DeadLetterQueueMetrics,
+  DeadLetterReason,
   ConsumerGroupScalingConfig,
   PartitionLag,
   PartitionLagStatus,
@@ -32,6 +35,96 @@ export function deriveGroupStatus(partitions: PartitionLag[]): PartitionLagStatu
   if (partitions.some((p) => p.status === 'critical')) return 'critical';
   if (partitions.some((p) => p.status === 'warning')) return 'warning';
   return 'healthy';
+}
+
+
+// ── Dead-letter queue logic ─────────────────────────────────────────────────
+
+const MAX_PAYLOAD_PREVIEW_CHARS = 512;
+const DLQ_CRITICAL_AGE_MS = 15 * 60 * 1000;
+const DLQ_CRITICAL_DEPTH = 100;
+const SECRET_FIELD_PATTERN = /(password|secret|token|privateKey|authorization)/i;
+
+export interface FailedMessageInput {
+  topic: string;
+  partition: number;
+  offset: number;
+  consumerGroupId: string;
+  attempts: number;
+  error: unknown;
+  payload: unknown;
+  traceId?: string;
+  failedAt?: number;
+}
+
+export function classifyDeadLetterReason(error: unknown, attempts: number): DeadLetterReason {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  if (/schema|validation|parse|invalid json/i.test(message)) return 'schema-invalid';
+  if (/poison|non-retryable|fatal/i.test(message)) return 'poison-message';
+  if (attempts >= 3) return 'retry-exhausted';
+  if (message) return 'handler-error';
+  return 'unknown';
+}
+
+function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
+        key,
+        SECRET_FIELD_PATTERN.test(key) ? '[REDACTED]' : redactValue(nested),
+      ]),
+    );
+  }
+  return value;
+}
+
+export function createPayloadPreview(payload: unknown): string {
+  let serialized: string;
+  try {
+    serialized = typeof payload === 'string' ? payload : JSON.stringify(redactValue(payload));
+  } catch {
+    serialized = '[unserializable payload]';
+  }
+  return serialized.length > MAX_PAYLOAD_PREVIEW_CHARS
+    ? `${serialized.slice(0, MAX_PAYLOAD_PREVIEW_CHARS)}…`
+    : serialized;
+}
+
+export function buildDeadLetterMessage(input: FailedMessageInput): DeadLetterMessage {
+  const failedAt = input.failedAt ?? Date.now();
+  return {
+    id: `${input.consumerGroupId}:${input.topic}:${input.partition}:${input.offset}`,
+    topic: input.topic,
+    partition: input.partition,
+    offset: input.offset,
+    consumerGroupId: input.consumerGroupId,
+    attempts: input.attempts,
+    reason: classifyDeadLetterReason(input.error, input.attempts),
+    errorMessage: input.error instanceof Error ? input.error.message : String(input.error ?? 'Unknown error'),
+    payloadPreview: createPayloadPreview(input.payload),
+    firstFailedAt: failedAt,
+    lastFailedAt: failedAt,
+    status: 'quarantined',
+    traceId: input.traceId,
+  };
+}
+
+export function summarizeDeadLetters(
+  messages: DeadLetterMessage[],
+  now: number = Date.now(),
+): DeadLetterQueueMetrics {
+  const oldest = messages.reduce((age, message) => Math.max(age, now - message.firstFailedAt), 0);
+  const metrics = messages.reduce<DeadLetterQueueMetrics>((acc, message) => {
+    acc.total += 1;
+    if (message.status === 'quarantined') acc.quarantined += 1;
+    if (message.status === 'replay-ready') acc.replayReady += 1;
+    if (message.status === 'replayed') acc.replayed += 1;
+    if (message.status === 'discarded') acc.discarded += 1;
+    return acc;
+  }, { total: 0, quarantined: 0, replayReady: 0, replayed: 0, discarded: 0, oldestMessageAgeMs: oldest, critical: false });
+  metrics.critical = metrics.quarantined >= DLQ_CRITICAL_DEPTH || oldest >= DLQ_CRITICAL_AGE_MS;
+  return metrics;
 }
 
 // ── Auto-scaling logic ────────────────────────────────────────────────────────
@@ -184,11 +277,30 @@ export interface KafkaMonitoringProvider {
    * Returns the resulting ScalingEvent.
    */
   triggerManualScale(groupId: string, targetInstances: number): Promise<ScalingEvent>;
+
+  /** Fetch messages currently retained in the dead-letter queue. */
+  fetchDeadLetters(): Promise<DeadLetterMessage[]>;
+
+  /** Mark a dead-lettered message as replay-ready or replayed after operator review. */
+  updateDeadLetterStatus(id: string, status: DeadLetterMessage['status']): Promise<DeadLetterMessage>;
 }
 
 /** Demo provider — deterministic, zero network calls. */
 export function createDemoKafkaMonitoringService(): KafkaMonitoringProvider {
   const scalingStatuses = generateDemoScalingStatuses();
+  const deadLetters: DeadLetterMessage[] = [
+    buildDeadLetterMessage({
+      topic: 'validator-attestations',
+      partition: 2,
+      offset: 88421,
+      consumerGroupId: 'attestation-processor',
+      attempts: 3,
+      error: new Error('schema validation failed: missing validatorIndex'),
+      payload: { attestationId: 'att_88421', token: 'demo-secret', slot: 982121 },
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      failedAt: Date.now() - 5 * 60 * 1000,
+    }),
+  ];
 
   return {
     async fetchConsumerLag() {
@@ -197,6 +309,18 @@ export function createDemoKafkaMonitoringService(): KafkaMonitoringProvider {
 
     async fetchScalingStatuses() {
       return scalingStatuses;
+    },
+
+    async fetchDeadLetters() {
+      return deadLetters;
+    },
+
+    async updateDeadLetterStatus(id, status) {
+      const message = deadLetters.find((m) => m.id === id);
+      if (!message) throw new Error(`Dead-letter message not found: ${id}`);
+      message.status = status;
+      message.lastFailedAt = Date.now();
+      return message;
     },
 
     async triggerManualScale(groupId, targetInstances) {
@@ -233,6 +357,27 @@ export function createKafkaMonitoringService(baseUrl: string): KafkaMonitoringPr
       } catch {
         return [];
       }
+    },
+
+
+    async fetchDeadLetters() {
+      try {
+        const res = await fetch(`${baseUrl}/api/kafka/dead-letters`);
+        if (!res.ok) return [];
+        return (await res.json()) as DeadLetterMessage[];
+      } catch {
+        return [];
+      }
+    },
+
+    async updateDeadLetterStatus(id, status) {
+      const res = await fetch(`${baseUrl}/api/kafka/dead-letters/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      if (!res.ok) throw new Error(`DLQ update failed: ${res.status}`);
+      return (await res.json()) as DeadLetterMessage;
     },
 
     async triggerManualScale(groupId, targetInstances) {

--- a/src/store/kafkaSlice.ts
+++ b/src/store/kafkaSlice.ts
@@ -5,6 +5,8 @@ import { create } from 'zustand';
 import type {
   ConsumerGroupLag,
   KafkaMonitoringState,
+  DeadLetterMessage,
+  DeadLetterQueueMetrics,
   ScalingEvent,
   ScalingStatus,
 } from '../types/kafka';
@@ -16,6 +18,12 @@ interface KafkaMonitoringActions {
   setGroups: (groups: ConsumerGroupLag[]) => void;
   /** Update scaling status for a group. */
   upsertScalingStatus: (status: ScalingStatus) => void;
+  /** Replace dead-letter queue messages. */
+  setDeadLetters: (messages: DeadLetterMessage[]) => void;
+  /** Upsert a single dead-letter queue message. */
+  upsertDeadLetter: (message: DeadLetterMessage) => void;
+  /** Recompute dead-letter metrics from the current queue. */
+  setDeadLetterMetrics: (metrics: DeadLetterQueueMetrics) => void;
   /** Prepend a new scaling event to the history ring-buffer (max 200). */
   addScalingEvent: (event: ScalingEvent) => void;
   /** Mark store as loaded and record the refresh timestamp. */
@@ -28,10 +36,22 @@ interface KafkaMonitoringActions {
 
 const MAX_SCALING_HISTORY = 200;
 
+const emptyDeadLetterMetrics: DeadLetterQueueMetrics = {
+  total: 0,
+  quarantined: 0,
+  replayReady: 0,
+  replayed: 0,
+  discarded: 0,
+  oldestMessageAgeMs: 0,
+  critical: false,
+};
+
 const initialState: KafkaMonitoringState = {
   groups: {},
   scalingStatus: {},
   scalingHistory: [],
+  deadLetters: {},
+  deadLetterMetrics: emptyDeadLetterMetrics,
   isLoaded: false,
   error: null,
   lastRefreshedAt: null,
@@ -55,6 +75,18 @@ export const useKafkaStore = create<KafkaMonitoringState & KafkaMonitoringAction
       set((s) => ({
         scalingStatus: { ...s.scalingStatus, [status.groupId]: status },
       })),
+
+    setDeadLetters: (messages) =>
+      set(() => ({
+        deadLetters: Object.fromEntries(messages.map((m) => [m.id, m])),
+      })),
+
+    upsertDeadLetter: (message) =>
+      set((s) => ({
+        deadLetters: { ...s.deadLetters, [message.id]: message },
+      })),
+
+    setDeadLetterMetrics: (metrics) => set({ deadLetterMetrics: metrics }),
 
     addScalingEvent: (event) =>
       set((s) => ({

--- a/src/types/kafka.ts
+++ b/src/types/kafka.ts
@@ -4,6 +4,17 @@
 /** Health status of a single consumer group partition. */
 export type PartitionLagStatus = 'healthy' | 'warning' | 'critical';
 
+/** Processing state for a failed Kafka message routed to the dead-letter queue. */
+export type DeadLetterMessageStatus = 'quarantined' | 'replay-ready' | 'replayed' | 'discarded';
+
+/** Why a message was routed to the dead-letter queue. */
+export type DeadLetterReason =
+  | 'schema-invalid'
+  | 'handler-error'
+  | 'retry-exhausted'
+  | 'poison-message'
+  | 'unknown';
+
 /** A single partition's lag snapshot. */
 export interface PartitionLag {
   /** Kafka partition number (0-indexed). */
@@ -34,6 +45,37 @@ export interface ConsumerGroupLag {
   capturedAt: number;
   /** Derived group-level health. */
   status: PartitionLagStatus;
+}
+
+/** Failed message envelope retained for safe inspection and replay. */
+export interface DeadLetterMessage {
+  /** Stable deterministic ID for idempotent upserts. */
+  id: string;
+  topic: string;
+  partition: number;
+  offset: number;
+  consumerGroupId: string;
+  /** Number of delivery attempts before quarantine. */
+  attempts: number;
+  reason: DeadLetterReason;
+  errorMessage: string;
+  /** Redacted payload preview; secrets must not be stored here. */
+  payloadPreview: string;
+  firstFailedAt: number;
+  lastFailedAt: number;
+  status: DeadLetterMessageStatus;
+  traceId?: string;
+}
+
+/** Aggregated dead-letter metrics for alerting and dashboards. */
+export interface DeadLetterQueueMetrics {
+  total: number;
+  quarantined: number;
+  replayReady: number;
+  replayed: number;
+  discarded: number;
+  oldestMessageAgeMs: number;
+  critical: boolean;
 }
 
 /** Auto-scaling decision record for a consumer group. */
@@ -87,6 +129,10 @@ export interface KafkaMonitoringState {
   scalingStatus: Record<string, ScalingStatus>;
   /** History of scaling events (most-recent first). */
   scalingHistory: ScalingEvent[];
+  /** Failed messages routed to the dead-letter queue, keyed by message ID. */
+  deadLetters: Record<string, DeadLetterMessage>;
+  /** Aggregated dead-letter queue metrics. */
+  deadLetterMetrics: DeadLetterQueueMetrics;
   /** Whether initial data has been loaded. */
   isLoaded: boolean;
   /** Last poll error message, if any. */


### PR DESCRIPTION
### Motivation
- Model and surface failed Kafka messages in the frontend so operators can inspect, redact, and transition quarantined messages for safe replay. 
- Provide a single refresh path that includes consumer lag, scaling status, and DLQ state so dashboards and alerts reflect both throughput and failure processing.
- Keep the DLQ critical path lightweight and secure by redacting secrets and generating deterministic IDs for idempotent upserts.

### Description
- Add DLQ domain types and store fields in `src/types/kafka.ts` and extend the Kafka Zustand slice with `deadLetters` and `deadLetterMetrics` in `src/store/kafkaSlice.ts`.
- Implement DLQ helper logic in `src/services/kafkaMonitoringService.ts` including `classifyDeadLetterReason`, payload redaction (`createPayloadPreview`), deterministic ID generation (`buildDeadLetterMessage`), and metrics summarization (`summarizeDeadLetters`), plus demo/production provider endpoints (`fetchDeadLetters`, `updateDeadLetterStatus`).
- Extend the monitoring hook in `src/hooks/useKafkaMonitoring.ts` to poll DLQ data alongside lag/scaling snapshots, summarize DLQ metrics for dashboards, and expose `updateDeadLetterStatus` for operator transitions.
- Add unit tests and documentation: new DLQ-focused tests in `src/__tests__/kafkaMonitoring.test.ts` and an operational runbook at `docs/dead-letter-queue.md`.

### Testing
- Ran unit tests with `npm run test:unit -- src/__tests__/kafkaMonitoring.test.ts`, which passed (`39 tests` all green).
- Ran lint with `npm run lint`, which completed successfully with warnings but no errors.
- Ran type check with `npx tsc --noEmit`, which failed due to pre-existing unrelated repository type/configuration issues (missing `three` types, `.ts` extension imports, ES target BigInt errors, etc.) and not because of the DLQ changes.

Closes #115