### PR TITLE
Structured logging

### DIFF
--- a/docs/observability/structured-logging.md
+++ b/docs/observability/structured-logging.md
@@ -1,0 +1,29 @@
+# Structured Logging with OpenTelemetry Semantic Conventions
+
+VeriNode emits application logs as single-line JSON records shaped after the OpenTelemetry log data model. The shared logger lives in `src/services/logging` and is safe to use in browser, Node.js, and Edge runtime code paths.
+
+## Architecture
+
+- Use `logger.info`, `logger.warn`, `logger.error`, etc. instead of ad-hoc `console.*` calls in application code.
+- Every record includes OpenTelemetry-aligned fields: `timestamp`, `observedTimestamp`, `severityText`, `severityNumber`, `body`, `resource`, and `attributes`.
+- Resource attributes include `service.name`, `service.version`, `deployment.environment.name`, `telemetry.sdk.name`, and `telemetry.sdk.language`.
+- When a trace span is active, the logger attaches `traceId`, `spanId`, and `trace.flags` so logs can be correlated with distributed traces.
+- Attributes should use OpenTelemetry semantic convention keys where applicable, such as `event.name`, `error.type`, `http.request.method`, `server.address`, `url.full`, or `user.id`.
+
+## Configuration
+
+The logger uses these environment variables when constructing resource attributes:
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `NEXT_PUBLIC_OTEL_SERVICE_NAME` | Service identity in logs and traces | `verinode-frontend` |
+| `NEXT_PUBLIC_APP_VERSION` | Deployed application version | `npm_package_version` or `0.1.0` |
+| `NEXT_PUBLIC_VERCEL_ENV` | Deployment environment name | `NODE_ENV` or `development` |
+
+## Operational guidance
+
+- Ship stdout/stderr to the collector or log backend; each emitted line is valid JSON.
+- Create alerts on `severityText` values of `ERROR` and `FATAL`, grouped by `resource.service.name` and `attributes.event.name`.
+- Build dashboards for log volume, error rate, and top error types using `severityNumber`, `event.name`, and `error.type`.
+- During canary or blue-green rollout, compare `ERROR`/`FATAL` rates and P99 latency traces between the baseline and candidate versions before increasing traffic.
+- Runbooks should include the trace correlation workflow: search the log backend by `traceId`, then pivot into the tracing backend for the same trace.

--- a/src/components/providers/PwaProvider.tsx
+++ b/src/components/providers/PwaProvider.tsx
@@ -3,6 +3,7 @@
 import { useEffect, type ReactNode } from "react"
 import { OfflineBanner } from "@/src/components/layout/OfflineBanner"
 import { usePwaInstall } from "@/src/hooks/usePwaInstall"
+import { logger } from "@/src/services/logging"
 
 function ServiceWorkerRegistrar() {
   useEffect(() => {
@@ -21,7 +22,7 @@ function ServiceWorkerRegistrar() {
           scope: "/",
         })
       } catch (err) {
-        console.warn("[PWA] Service worker registration failed", err)
+        logger.warn("service worker registration failed", { "event.name": "pwa.service_worker_registration_failed", "error.type": err instanceof Error ? err.name : typeof err })
       }
     }
 
@@ -43,7 +44,7 @@ function SyncMessageListener() {
 
     const handler = (event: MessageEvent) => {
       if (event.data?.type === "SYNC_SUBMISSIONS") {
-        console.info("[PWA] Sync event received — draining submission queue")
+        logger.info("service worker sync message received", { "event.name": "pwa.sync_submissions_received" })
       }
     }
 

--- a/src/components/providers/WalletProvider.tsx
+++ b/src/components/providers/WalletProvider.tsx
@@ -12,6 +12,7 @@ import React, {
 import { useQueryClient } from '@tanstack/react-query';
 import type { WalletAccount, WalletProviderType } from '@/src/types/wallet';
 import { clearAllCaches } from '@/src/lib/reactQuery';
+import { logger } from '@/src/services/logging';
 
 interface WalletContextValue {
   activeAccount: WalletAccount | null;
@@ -97,7 +98,7 @@ function detectProvider(): WalletProviderType | null {
 
 function captureBreadcrumb(previousKey: string | null, newKey: string | null, flushDuration: number, cacheEntriesInvalidated: number) {
   if (typeof process !== 'undefined' && process.env.NODE_ENV === 'development') {
-    console.info('[WalletProvider] account switch:', { previousKey, newKey, flushDuration, cacheEntriesInvalidated });
+    logger.info('wallet account switch completed', { 'event.name': 'wallet.account_switch_completed', 'user.id': newKey ?? 'anonymous', 'wallet.previous_user_id': previousKey ?? 'anonymous', 'wallet.cache_flush.duration_ms': flushDuration, 'wallet.cache_entries_invalidated': cacheEntriesInvalidated });
   }
 }
 

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,3 +1,5 @@
+import { logger } from '@/src/services/logging';
+
 export type FeatureFlag =
   | 'staking'
   | 'governance'
@@ -36,7 +38,7 @@ export function persistOverrides(overrides: FeatureFlagOverride): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(overrides));
   } catch (e) {
-    console.error('feature-flags: failed to persist overrides', e);
+    logger.error('feature flag overrides persist failed', { 'event.name': 'feature_flags.persist_failed', 'db.system': 'web_storage', 'db.operation.name': 'setItem', 'db.collection.name': STORAGE_KEY, 'error.type': e instanceof Error ? e.name : typeof e });
   }
 }
 

--- a/src/lib/sessionStore.ts
+++ b/src/lib/sessionStore.ts
@@ -1,3 +1,5 @@
+import { logger } from '@/src/services/logging';
+
 export function getItem<T>(key: string): T | null {
   try {
     const raw = sessionStorage.getItem(key);
@@ -12,7 +14,7 @@ export function setItem<T>(key: string, value: T): void {
   try {
     sessionStorage.setItem(key, JSON.stringify(value));
   } catch (e) {
-    console.error('sessionStore: failed to write', key, e);
+    logger.error('session storage write failed', { 'event.name': 'session.storage_write_failed', 'db.system': 'web_storage', 'db.operation.name': 'setItem', 'db.collection.name': key, 'error.type': e instanceof Error ? e.name : typeof e });
   }
 }
 
@@ -20,6 +22,6 @@ export function removeItem(key: string): void {
   try {
     sessionStorage.removeItem(key);
   } catch (e) {
-    console.error('sessionStore: failed to remove', key, e);
+    logger.error('session storage remove failed', { 'event.name': 'session.storage_remove_failed', 'db.system': 'web_storage', 'db.operation.name': 'removeItem', 'db.collection.name': key, 'error.type': e instanceof Error ? e.name : typeof e });
   }
 }

--- a/src/services/logging/index.ts
+++ b/src/services/logging/index.ts
@@ -1,0 +1,9 @@
+export {
+  StructuredLogger,
+  logger,
+  type LogAttributes,
+  type LogAttributeValue,
+  type LogSeverity,
+  type LoggerOptions,
+  type StructuredLogRecord,
+} from './structuredLogger'

--- a/src/services/logging/structuredLogger.test.ts
+++ b/src/services/logging/structuredLogger.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+import { StructuredLogger } from './structuredLogger'
+
+describe('StructuredLogger', () => {
+  it('emits OpenTelemetry-aligned JSON records with resource and severity fields', () => {
+    const info = vi.fn()
+    const logger = new StructuredLogger({
+      serviceName: 'verinode-test',
+      serviceVersion: '1.2.3',
+      environment: 'test',
+      now: () => new Date('2026-07-25T00:00:00.000Z'),
+      console: { debug: vi.fn(), info, warn: vi.fn(), error: vi.fn() },
+      tracer: { activeContext: () => null },
+    })
+
+    const record = logger.info('wallet connected', {
+      'event.name': 'wallet.connected',
+      'user.id': 'pubkey-123',
+      omitted: undefined,
+    })
+
+    expect(record).toMatchObject({
+      timestamp: '2026-07-25T00:00:00.000Z',
+      observedTimestamp: '2026-07-25T00:00:00.000Z',
+      severityText: 'INFO',
+      severityNumber: 9,
+      body: 'wallet connected',
+      resource: {
+        'service.name': 'verinode-test',
+        'service.version': '1.2.3',
+        'deployment.environment.name': 'test',
+        'telemetry.sdk.name': 'verinode-otel',
+        'telemetry.sdk.language': 'webjs',
+      },
+      attributes: {
+        'event.name': 'wallet.connected',
+        'user.id': 'pubkey-123',
+      },
+    })
+    expect(record.attributes).not.toHaveProperty('omitted')
+    expect(record.attributes['log.record.uid']).toEqual(expect.any(String))
+    expect(info).toHaveBeenCalledWith(JSON.stringify(record))
+  })
+
+  it('correlates records with the active trace context', () => {
+    const warn = vi.fn()
+    const logger = new StructuredLogger({
+      console: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+      tracer: {
+        activeContext: () => ({
+          traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+          spanId: '00f067aa0ba902b7',
+          sampled: true,
+          traceState: [],
+        }),
+      },
+    })
+
+    const record = logger.warn('retry scheduled', { 'event.name': 'retry.scheduled' })
+
+    expect(record.traceId).toBe('4bf92f3577b34da6a3ce929d0e0e4736')
+    expect(record.spanId).toBe('00f067aa0ba902b7')
+    expect(record.attributes['trace.flags']).toBe('01')
+    expect(warn).toHaveBeenCalledWith(JSON.stringify(record))
+  })
+})

--- a/src/services/logging/structuredLogger.ts
+++ b/src/services/logging/structuredLogger.ts
@@ -1,0 +1,129 @@
+import { getGlobalTracer } from '@/src/services/tracing'
+
+export type LogSeverity = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
+export type LogAttributeValue = string | number | boolean | null | undefined | string[] | number[] | boolean[]
+export type LogAttributes = Record<string, LogAttributeValue>
+
+export interface StructuredLogRecord {
+  timestamp: string
+  observedTimestamp: string
+  severityText: Uppercase<LogSeverity>
+  severityNumber: number
+  body: string
+  attributes: Record<string, string | number | boolean | string[] | number[] | boolean[]>
+  resource: Record<string, string>
+  traceId?: string
+  spanId?: string
+}
+
+export interface LoggerOptions {
+  serviceName?: string
+  serviceVersion?: string
+  environment?: string
+  console?: Pick<Console, 'debug' | 'info' | 'warn' | 'error'>
+  now?: () => Date
+  tracer?: Pick<ReturnType<typeof getGlobalTracer>, 'activeContext'>
+}
+
+const SEVERITY_NUMBERS: Record<LogSeverity, number> = {
+  trace: 1,
+  debug: 5,
+  info: 9,
+  warn: 13,
+  error: 17,
+  fatal: 21,
+}
+
+function defaultServiceName(): string {
+  return process.env.NEXT_PUBLIC_OTEL_SERVICE_NAME ?? 'verinode-frontend'
+}
+
+function defaultServiceVersion(): string {
+  return process.env.NEXT_PUBLIC_APP_VERSION ?? process.env.npm_package_version ?? '0.1.0'
+}
+
+function defaultEnvironment(): string {
+  return process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.NODE_ENV ?? 'development'
+}
+
+function sanitizeAttributes(attributes: LogAttributes = {}): StructuredLogRecord['attributes'] {
+  const sanitized: StructuredLogRecord['attributes'] = {}
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === null || value === undefined) continue
+    sanitized[key] = value
+  }
+  return sanitized
+}
+
+function createLogRecordId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+  return `log_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`
+}
+
+function consoleMethod(severity: LogSeverity): 'debug' | 'info' | 'warn' | 'error' {
+  if (severity === 'trace' || severity === 'debug') return 'debug'
+  if (severity === 'warn') return 'warn'
+  if (severity === 'error' || severity === 'fatal') return 'error'
+  return 'info'
+}
+
+export class StructuredLogger {
+  private readonly serviceName: string
+  private readonly serviceVersion: string
+  private readonly environment: string
+  private readonly consoleSink: Pick<Console, 'debug' | 'info' | 'warn' | 'error'>
+  private readonly now: () => Date
+  private readonly tracer?: Pick<ReturnType<typeof getGlobalTracer>, 'activeContext'>
+
+  constructor(options: LoggerOptions = {}) {
+    this.serviceName = options.serviceName ?? defaultServiceName()
+    this.serviceVersion = options.serviceVersion ?? defaultServiceVersion()
+    this.environment = options.environment ?? defaultEnvironment()
+    this.consoleSink = options.console ?? console
+    this.now = options.now ?? (() => new Date())
+    this.tracer = options.tracer
+  }
+
+  log(severity: LogSeverity, body: string, attributes?: LogAttributes): StructuredLogRecord {
+    const timestamp = this.now().toISOString()
+    const activeContext = (this.tracer ?? getGlobalTracer('verinode-logger')).activeContext()
+    const record: StructuredLogRecord = {
+      timestamp,
+      observedTimestamp: timestamp,
+      severityText: severity.toUpperCase() as Uppercase<LogSeverity>,
+      severityNumber: SEVERITY_NUMBERS[severity],
+      body,
+      resource: {
+        'service.name': this.serviceName,
+        'service.version': this.serviceVersion,
+        'deployment.environment.name': this.environment,
+        'telemetry.sdk.name': 'verinode-otel',
+        'telemetry.sdk.language': 'webjs',
+      },
+      attributes: {
+        'log.record.uid': createLogRecordId(),
+        ...sanitizeAttributes(attributes),
+      },
+    }
+
+    if (activeContext) {
+      record.traceId = activeContext.traceId
+      record.spanId = activeContext.spanId
+      record.attributes['trace.flags'] = activeContext.sampled ? '01' : '00'
+    }
+
+    this.consoleSink[consoleMethod(severity)](JSON.stringify(record))
+    return record
+  }
+
+  trace(body: string, attributes?: LogAttributes): StructuredLogRecord { return this.log('trace', body, attributes) }
+  debug(body: string, attributes?: LogAttributes): StructuredLogRecord { return this.log('debug', body, attributes) }
+  info(body: string, attributes?: LogAttributes): StructuredLogRecord { return this.log('info', body, attributes) }
+  warn(body: string, attributes?: LogAttributes): StructuredLogRecord { return this.log('warn', body, attributes) }
+  error(body: string, attributes?: LogAttributes): StructuredLogRecord { return this.log('error', body, attributes) }
+  fatal(body: string, attributes?: LogAttributes): StructuredLogRecord { return this.log('fatal', body, attributes) }
+}
+
+export const logger = new StructuredLogger()


### PR DESCRIPTION
### Motivation
- Provide a single, consistent structured-logging facility shaped after the OpenTelemetry log model so logs are machine-readable and easy to query.
- Enable trace-to-log correlation by attaching active `traceId`/`spanId` and trace flags to records for end-to-end observability.
- Replace ad-hoc `console.*` calls in a few key code paths with semantic events to improve operational alerting and dashboards.

### Description
- Add a new shared logger at `src/services/logging/structuredLogger.ts` (exported via `src/services/logging/index.ts`) that emits single-line JSON records with `timestamp`, `observedTimestamp`, `severityText`, `severityNumber`, `body`, `resource`, sanitized `attributes`, and optional `traceId`/`spanId` and `trace.flags` when a trace is active.
- Provide a stable record UID generator (`createLogRecordId`) and severity→console mapping, and make the logger safe for browser, Node.js, and Edge runtime usage.
- Replace selected console usage with structured events in `src/lib/sessionStore.ts`, `src/lib/feature-flags.ts`, `src/components/providers/PwaProvider.tsx`, and `src/components/providers/WalletProvider.tsx` to emit semantic `event.name` attributes.
- Add documentation at `docs/observability/structured-logging.md` and unit tests at `src/services/logging/structuredLogger.test.ts` that validate record shape and trace/span correlation.

### Testing
- Ran `npm run test:unit -- src/services/logging/structuredLogger.test.ts`, which passed (2 tests).
- Ran `npm run lint`, which completed successfully but reported existing repository warnings (no errors).
- Ran `npx tsc --noEmit`, which failed due to pre-existing repository TypeScript errors unrelated to these logging changes.

Closes #114