### PR TITLE
Api rate limiting

### DIFF
--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,64 @@
+# API Rate Limiting with Per-Tenant Token Buckets
+
+## Architecture
+
+VeriNode API ingress should run a token bucket for each `tenantId + scope` pair. The shared implementation lives in `src/services/rateLimiter.ts` and is intentionally dependency-free so it can be reused by Next.js route handlers, edge middleware, server-side service adapters, and tests.
+
+Each bucket has:
+
+- `capacity`: the maximum burst size a tenant can spend immediately.
+- `refillRatePerSecond`: the sustained request budget.
+- `tokens`: the current balance, refilled lazily on each check.
+- `updatedAtMs`: the last timestamp used for refill calculations.
+
+Tenant-specific policies override the default policy. Scopes split traffic classes such as `global`, `read`, `write`, `webhook`, or `admin` so expensive paths can carry a higher token `cost` without starving cheaper reads.
+
+## Critical Path Performance
+
+The in-process decision path is O(1): derive a map key, refill one bucket, compare token cost, and update counters. This keeps the local portion of API admission well below the 100 ms P99 target. Production deployments that need multi-instance consistency should back the same algorithm with an atomic Redis/Lua or edge-KV primitive and preserve the same result contract.
+
+## Monitoring and Alerts
+
+Export `getMetricsSnapshot()` on an interval to the metrics pipeline:
+
+- `rate_limit_allowed_total{tenant}`
+- `rate_limit_limited_total{tenant}`
+- `rate_limit_active_buckets`
+- `rate_limit_rejection_ratio{tenant}` = limited / (allowed + limited)
+
+Recommended alerts:
+
+1. Page when global rejection ratio is above 20% for 10 minutes.
+2. Page when a paid tenant rejection ratio is above its SLO for 5 minutes.
+3. Warn when active buckets grow 2x above the 7-day baseline, which may indicate tenant-ID abuse.
+4. Warn when limiter backing storage latency threatens the 100 ms P99 critical-path target.
+
+## Deployment Plan
+
+1. Ship in shadow mode: compute decisions and metrics, but do not reject requests.
+2. Enable enforcement for internal tenants and low-risk read scopes.
+3. Canary 5% of production tenants and compare latency, 429 rate, and support tickets.
+4. Expand with blue-green deployment after canary health is stable for one full traffic cycle.
+5. Keep a feature flag that falls back to shadow mode during incident response.
+
+## Security Notes
+
+- Never trust tenant IDs supplied only by arbitrary request headers; derive them from authenticated session, API key, or mTLS identity.
+- Avoid logging raw credentials or PII in rate-limit events.
+- Return standard `X-RateLimit-*` and `Retry-After` headers without revealing other tenant policies.
+- Use per-route `cost` values for expensive endpoints to reduce denial-of-wallet risk.
+
+## Runbook
+
+### High 429 Rate
+
+1. Check `rate_limit_rejection_ratio{tenant}` and determine whether the spike is isolated or global.
+2. Confirm recent deploys did not lower `capacity` or `refillRatePerSecond` unexpectedly.
+3. If legitimate traffic is blocked, temporarily raise the tenant policy or switch enforcement to shadow mode.
+4. If abusive traffic is confirmed, keep enforcement on and coordinate with security for API-key rotation or tenant suspension.
+
+### Limiter Storage Latency
+
+1. Compare API P99 latency with limiter storage latency.
+2. Fail open to shadow mode if availability is at risk.
+3. Scale or fail over backing storage before re-enabling hard enforcement.

--- a/src/services/rateLimiter.ts
+++ b/src/services/rateLimiter.ts
@@ -1,0 +1,200 @@
+/**
+ * API Rate Limiting with Per-Tenant Token Buckets (#113)
+ *
+ * A lightweight, dependency-free implementation intended for edge/API
+ * middleware and service adapters. It keeps one token bucket per tenant and
+ * route class, exposes deterministic clocks for tests, and emits compact
+ * metrics snapshots for dashboards and alerting pipelines.
+ */
+
+export type RateLimitDecision = 'allowed' | 'limited'
+
+export interface TokenBucketConfig {
+  /** Maximum burst capacity for this bucket. */
+  capacity: number
+  /** Tokens refilled per second. */
+  refillRatePerSecond: number
+}
+
+export interface TenantRateLimitPolicy extends TokenBucketConfig {
+  /** Tenant identifier used in logs/metrics. */
+  tenantId: string
+}
+
+export interface RateLimitRequest {
+  tenantId: string
+  /** Optional route or service key. Defaults to `global`. */
+  scope?: string
+  /** Token cost for this operation. Defaults to 1. */
+  cost?: number
+  /** Unix millisecond timestamp. Defaults to `Date.now()`. */
+  nowMs?: number
+}
+
+export interface RateLimitResult {
+  decision: RateLimitDecision
+  allowed: boolean
+  tenantId: string
+  scope: string
+  limit: number
+  remaining: number
+  retryAfterMs: number
+  resetAtMs: number
+}
+
+export interface RateLimitMetricsSnapshot {
+  allowed: number
+  limited: number
+  buckets: number
+  perTenant: Record<string, { allowed: number; limited: number }>
+}
+
+interface BucketState {
+  tokens: number
+  updatedAtMs: number
+}
+
+export interface RateLimiterOptions {
+  defaultPolicy: TokenBucketConfig
+  tenantPolicies?: TenantRateLimitPolicy[]
+  now?: () => number
+}
+
+const DEFAULT_SCOPE = 'global'
+const MS_PER_SECOND = 1_000
+
+function validatePolicy(policy: TokenBucketConfig): void {
+  if (!Number.isFinite(policy.capacity) || policy.capacity <= 0) {
+    throw new Error('Token bucket capacity must be a positive number')
+  }
+  if (!Number.isFinite(policy.refillRatePerSecond) || policy.refillRatePerSecond <= 0) {
+    throw new Error('Token bucket refill rate must be a positive number')
+  }
+}
+
+function bucketKey(tenantId: string, scope: string): string {
+  return `${tenantId}:${scope}`
+}
+
+function roundDownTokens(value: number): number {
+  return Math.max(0, Math.floor(value))
+}
+
+/** Pure token-bucket primitive exported for focused tests. */
+export function consumeFromTokenBucket(
+  state: BucketState,
+  config: TokenBucketConfig,
+  cost: number,
+  nowMs: number,
+): { state: BucketState; allowed: boolean; retryAfterMs: number; resetAtMs: number } {
+  validatePolicy(config)
+  if (!Number.isFinite(cost) || cost <= 0) throw new Error('Token cost must be a positive number')
+
+  const elapsedMs = Math.max(0, nowMs - state.updatedAtMs)
+  const refilledTokens = (elapsedMs / MS_PER_SECOND) * config.refillRatePerSecond
+  const tokens = Math.min(config.capacity, state.tokens + refilledTokens)
+  const allowed = tokens >= cost
+  const nextTokens = allowed ? tokens - cost : tokens
+  const missingTokens = Math.max(0, cost - tokens)
+  const retryAfterMs = allowed ? 0 : Math.ceil((missingTokens / config.refillRatePerSecond) * MS_PER_SECOND)
+  const resetAtMs = nowMs + Math.ceil(((config.capacity - nextTokens) / config.refillRatePerSecond) * MS_PER_SECOND)
+
+  return {
+    state: { tokens: nextTokens, updatedAtMs: nowMs },
+    allowed,
+    retryAfterMs,
+    resetAtMs,
+  }
+}
+
+export class PerTenantRateLimiter {
+  private readonly defaultPolicy: TokenBucketConfig
+  private readonly tenantPolicies = new Map<string, TokenBucketConfig>()
+  private readonly buckets = new Map<string, BucketState>()
+  private readonly now: () => number
+  private readonly metrics: RateLimitMetricsSnapshot = { allowed: 0, limited: 0, buckets: 0, perTenant: {} }
+
+  constructor(options: RateLimiterOptions) {
+    validatePolicy(options.defaultPolicy)
+    this.defaultPolicy = options.defaultPolicy
+    this.now = options.now ?? Date.now
+    for (const policy of options.tenantPolicies ?? []) {
+      validatePolicy(policy)
+      this.tenantPolicies.set(policy.tenantId, {
+        capacity: policy.capacity,
+        refillRatePerSecond: policy.refillRatePerSecond,
+      })
+    }
+  }
+
+  check(request: RateLimitRequest): RateLimitResult {
+    const tenantId = request.tenantId.trim()
+    if (!tenantId) throw new Error('tenantId is required for rate limiting')
+
+    const scope = request.scope?.trim() || DEFAULT_SCOPE
+    const cost = request.cost ?? 1
+    const nowMs = request.nowMs ?? this.now()
+    const policy = this.tenantPolicies.get(tenantId) ?? this.defaultPolicy
+    const key = bucketKey(tenantId, scope)
+    const state = this.buckets.get(key) ?? { tokens: policy.capacity, updatedAtMs: nowMs }
+    const outcome = consumeFromTokenBucket(state, policy, cost, nowMs)
+
+    this.buckets.set(key, outcome.state)
+    this.recordMetric(tenantId, outcome.allowed)
+
+    return {
+      decision: outcome.allowed ? 'allowed' : 'limited',
+      allowed: outcome.allowed,
+      tenantId,
+      scope,
+      limit: policy.capacity,
+      remaining: roundDownTokens(outcome.state.tokens),
+      retryAfterMs: outcome.retryAfterMs,
+      resetAtMs: outcome.resetAtMs,
+    }
+  }
+
+  getMetricsSnapshot(): RateLimitMetricsSnapshot {
+    return {
+      allowed: this.metrics.allowed,
+      limited: this.metrics.limited,
+      buckets: this.buckets.size,
+      perTenant: Object.fromEntries(
+        Object.entries(this.metrics.perTenant).map(([tenantId, counts]) => [tenantId, { ...counts }]),
+      ),
+    }
+  }
+
+  reset(): void {
+    this.buckets.clear()
+    this.metrics.allowed = 0
+    this.metrics.limited = 0
+    this.metrics.buckets = 0
+    this.metrics.perTenant = {}
+  }
+
+  private recordMetric(tenantId: string, allowed: boolean): void {
+    if (!this.metrics.perTenant[tenantId]) this.metrics.perTenant[tenantId] = { allowed: 0, limited: 0 }
+    if (allowed) {
+      this.metrics.allowed += 1
+      this.metrics.perTenant[tenantId].allowed += 1
+    } else {
+      this.metrics.limited += 1
+      this.metrics.perTenant[tenantId].limited += 1
+    }
+    this.metrics.buckets = this.buckets.size
+  }
+}
+
+export function createPerTenantRateLimiter(options: RateLimiterOptions): PerTenantRateLimiter {
+  return new PerTenantRateLimiter(options)
+}
+
+export function toRateLimitHeaders(result: RateLimitResult): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(result.limit),
+    'X-RateLimit-Remaining': String(result.remaining),
+    'X-RateLimit-Reset': String(Math.ceil(result.resetAtMs / MS_PER_SECOND)),
+    ...(result.allowed ? {} : { 'Retry-After': String(Math.ceil(result.retryAfterMs / MS_PER_SECOND)) }),
+  }
+}

--- a/src/services/tests/rateLimiter.test.ts
+++ b/src/services/tests/rateLimiter.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import {
+  consumeFromTokenBucket,
+  createPerTenantRateLimiter,
+  toRateLimitHeaders,
+} from '../rateLimiter'
+
+describe('consumeFromTokenBucket', () => {
+  it('allows requests while tokens are available', () => {
+    const outcome = consumeFromTokenBucket(
+      { tokens: 5, updatedAtMs: 0 },
+      { capacity: 10, refillRatePerSecond: 1 },
+      3,
+      0,
+    )
+
+    expect(outcome.allowed).toBe(true)
+    expect(outcome.state.tokens).toBe(2)
+    expect(outcome.retryAfterMs).toBe(0)
+  })
+
+  it('refills tokens based on elapsed time and caps at capacity', () => {
+    const outcome = consumeFromTokenBucket(
+      { tokens: 0, updatedAtMs: 0 },
+      { capacity: 10, refillRatePerSecond: 2 },
+      1,
+      6_000,
+    )
+
+    expect(outcome.allowed).toBe(true)
+    expect(outcome.state.tokens).toBe(9)
+  })
+
+  it('returns retry timing when the bucket is empty', () => {
+    const outcome = consumeFromTokenBucket(
+      { tokens: 0, updatedAtMs: 0 },
+      { capacity: 10, refillRatePerSecond: 2 },
+      4,
+      0,
+    )
+
+    expect(outcome.allowed).toBe(false)
+    expect(outcome.retryAfterMs).toBe(2_000)
+  })
+})
+
+describe('PerTenantRateLimiter', () => {
+  it('isolates token buckets per tenant', () => {
+    const limiter = createPerTenantRateLimiter({ defaultPolicy: { capacity: 1, refillRatePerSecond: 1 } })
+
+    expect(limiter.check({ tenantId: 'tenant-a', nowMs: 0 }).allowed).toBe(true)
+    expect(limiter.check({ tenantId: 'tenant-a', nowMs: 0 }).allowed).toBe(false)
+    expect(limiter.check({ tenantId: 'tenant-b', nowMs: 0 }).allowed).toBe(true)
+  })
+
+  it('supports tenant-specific policies and route scopes', () => {
+    const limiter = createPerTenantRateLimiter({
+      defaultPolicy: { capacity: 1, refillRatePerSecond: 1 },
+      tenantPolicies: [{ tenantId: 'enterprise', capacity: 3, refillRatePerSecond: 10 }],
+    })
+
+    expect(limiter.check({ tenantId: 'enterprise', scope: 'read', nowMs: 0 }).remaining).toBe(2)
+    expect(limiter.check({ tenantId: 'enterprise', scope: 'write', nowMs: 0 }).remaining).toBe(2)
+    expect(limiter.check({ tenantId: 'basic', scope: 'read', nowMs: 0 }).remaining).toBe(0)
+  })
+
+  it('records metrics for monitoring and alerting', () => {
+    const limiter = createPerTenantRateLimiter({ defaultPolicy: { capacity: 1, refillRatePerSecond: 1 } })
+
+    limiter.check({ tenantId: 'tenant-a', nowMs: 0 })
+    limiter.check({ tenantId: 'tenant-a', nowMs: 0 })
+
+    expect(limiter.getMetricsSnapshot()).toEqual({
+      allowed: 1,
+      limited: 1,
+      buckets: 1,
+      perTenant: { 'tenant-a': { allowed: 1, limited: 1 } },
+    })
+  })
+
+  it('generates standard rate limit response headers', () => {
+    const limiter = createPerTenantRateLimiter({ defaultPolicy: { capacity: 1, refillRatePerSecond: 1 } })
+    const limited = limiter.check({ tenantId: 'tenant-a', nowMs: 0 })
+
+    expect(toRateLimitHeaders(limited)).toEqual({
+      'X-RateLimit-Limit': '1',
+      'X-RateLimit-Remaining': '0',
+      'X-RateLimit-Reset': '1',
+    })
+
+    const rejected = limiter.check({ tenantId: 'tenant-a', nowMs: 0 })
+    expect(toRateLimitHeaders(rejected)['Retry-After']).toBe('1')
+  })
+})


### PR DESCRIPTION
### Motivation
- Implement a system-wide, dependency-free per-tenant token-bucket rate limiter to provide admission control for API ingress and service adapters as described in issue #113.
- Provide scoped buckets and tenant-specific policies so different routes (e.g. `read`, `write`, `webhook`) and paid tenants can have distinct budgets and costs.
- Expose deterministic clocks and compact metrics so the primitive can be used in unit tests, dashboards, and shadow-mode rollout workflows.

### Description
- Add `src/services/rateLimiter.ts`, a lightweight token-bucket implementation exposing `consumeFromTokenBucket`, `PerTenantRateLimiter`, `createPerTenantRateLimiter`, and `toRateLimitHeaders`, with tenant policy validation, scoped buckets, metrics collection, and deterministic `now` injection for tests. 
- Add unit tests in `src/services/tests/rateLimiter.test.ts` covering token consumption, refill behaviour, retry timing, tenant isolation, scoped/tenant-specific policies, metrics, and standard `X-RateLimit-*` / `Retry-After` header generation. 
- Add documentation `docs/rate-limiting.md` describing architecture, monitoring/alerting recommendations, deployment (shadow/canary/blue-green) plan, security notes, and an incident runbook. 
- Keep the implementation dependency-free so it can be reused in Next.js route handlers, edge middleware, or backed by a consistent store (Redis/Lua or edge-KV) for multi-instance deployments.

### Testing
- Ran unit tests with `npm run test:unit -- src/services/tests/rateLimiter.test.ts`, which passed: 7 tests passed. 
- Ran linter with `npm run lint -- src/services/rateLimiter.ts src/services/tests/rateLimiter.test.ts`, which completed successfully. 
- Ran `npx tsc --noEmit` which failed due to unrelated pre-existing TypeScript errors elsewhere in the repository (e.g. e2e tests, missing dev dependencies, and other legacy type issues) and not caused by the added files.

Closes #113