### PR TITLE
Service mesh integration

### DIFF
--- a/deploy/istio/service-mesh-mtls.yaml
+++ b/deploy/istio/service-mesh-mtls.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: verinode
+  labels:
+    istio-injection: enabled
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default-strict-mtls
+  namespace: verinode
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: verinode-api-mtls
+  namespace: verinode
+spec:
+  host: verinode-api.verinode.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+  subsets:
+    - name: blue
+      labels:
+        version: blue
+    - name: green
+      labels:
+        version: green
+    - name: canary
+      labels:
+        version: canary
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: verinode-api-blue-green
+  namespace: verinode
+spec:
+  hosts:
+    - verinode-api.verinode.svc.cluster.local
+  http:
+    - name: primary
+      route:
+        - destination:
+            host: verinode-api.verinode.svc.cluster.local
+            subset: blue
+          weight: 90
+        - destination:
+            host: verinode-api.verinode.svc.cluster.local
+            subset: canary
+          weight: 10
+        - destination:
+            host: verinode-api.verinode.svc.cluster.local
+            subset: green
+          weight: 0
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: frontend-to-api-only
+  namespace: verinode
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: verinode-api
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/verinode/sa/verinode-frontend
+      to:
+        - operation:
+            methods: ["GET", "POST"]

--- a/docs/architecture/service-mesh-mtls.md
+++ b/docs/architecture/service-mesh-mtls.md
@@ -1,0 +1,36 @@
+# Service Mesh Integration with Mutual TLS
+
+## Goals
+
+VeriNode services run inside an Istio-compatible service mesh with mutual TLS enforced for every in-mesh hop. The implementation targets:
+
+- **Security:** `STRICT` PeerAuthentication for all workloads and request-scoped AuthorizationPolicy allow lists.
+- **Performance:** critical frontend-to-API paths stay below **100 ms P99**.
+- **Availability:** rollout gates preserve **99.99%** service availability.
+- **Operability:** Prometheus alerts and Grafana dashboards expose mTLS health, latency, error budget burn, and certificate expiry.
+
+## Architecture
+
+1. The `verinode` namespace is labeled for sidecar injection.
+2. Namespace-level `PeerAuthentication` enforces strict mTLS.
+3. `DestinationRule` configures Istio clients to originate ISTIO_MUTUAL TLS.
+4. `AuthorizationPolicy` denies unapproved service accounts by default and allows only the frontend workload to call the API workload.
+5. `VirtualService` supports blue, green, and canary subsets for controlled production rollout.
+6. Promotion gates use the policy helpers in `src/services/serviceMeshPolicy.ts` so application tests validate the same SLOs used by operations.
+
+## Rollout Strategy
+
+| Phase | Traffic | Gate |
+| --- | ---: | --- |
+| Baseline | 100% blue | Confirm telemetry, mTLS success, and no policy denies. |
+| Canary | 90% blue / 10% canary | P99 < 100 ms, availability >= 99.99%, mTLS success 100%, burn rate <= 1. |
+| Green | 100% green | Same canary gates for 30 minutes. |
+| Promote | 100% green | Update stable service labels and keep blue warm for rollback. |
+
+## Security Review Checklist
+
+- Confirm no workload uses `PERMISSIVE` or `DISABLE` mTLS in production.
+- Confirm every AuthorizationPolicy uses service-account principals rather than namespace wildcards.
+- Confirm certificates rotate before the two-hour alert threshold.
+- Confirm dashboards include failed handshakes and policy-deny spikes.
+- Confirm runbook rollback steps have been rehearsed in staging.

--- a/docs/runbooks/service-mesh-mtls.md
+++ b/docs/runbooks/service-mesh-mtls.md
@@ -1,0 +1,24 @@
+# Runbook: Service Mesh mTLS
+
+## Canary Deployment
+
+1. Apply `deploy/istio/service-mesh-mtls.yaml` to staging.
+2. Verify all pods have sidecars and are ready.
+3. Shift 10% traffic to canary.
+4. Watch the Service Mesh mTLS dashboard for at least 30 minutes.
+5. Promote only when the gate in `evaluateMeshPromotionGate` passes.
+
+## Rollback
+
+1. Set `VirtualService` weights back to `blue: 100`, `green: 0`, and `canary: 0`.
+2. Confirm P99 latency returns below 100 ms.
+3. Confirm availability recovers to at least 99.99%.
+4. Capture Envoy sidecar logs for the failed green/canary deployment.
+5. Open a security review if any mTLS failure or unexpected authorization deny occurred.
+
+## Alerts
+
+- **VeriNodeMeshP99LatencyHigh:** investigate Envoy retries, upstream saturation, and recent policy changes.
+- **VeriNodeMeshAvailabilityLow:** freeze promotion and roll back if the burn continues for five minutes.
+- **VeriNodeMeshMtlsHandshakeFailure:** treat as a security incident until certificate and identity scope are verified.
+- **VeriNodeMeshCertificateExpirySoon:** restart or recycle affected workloads if SDS rotation does not recover automatically.

--- a/monitoring/service-mesh-alerts.yaml
+++ b/monitoring/service-mesh-alerts.yaml
@@ -1,0 +1,31 @@
+groups:
+  - name: verinode-service-mesh
+    rules:
+      - alert: VeriNodeMeshP99LatencyHigh
+        expr: histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{destination_service_namespace="verinode"}[5m])) by (le, destination_service)) > 100
+        for: 5m
+        labels:
+          severity: page
+        annotations:
+          summary: VeriNode mesh P99 latency exceeded 100ms
+      - alert: VeriNodeMeshAvailabilityLow
+        expr: (sum(rate(istio_requests_total{destination_service_namespace="verinode",response_code!~"5.."}[5m])) / sum(rate(istio_requests_total{destination_service_namespace="verinode"}[5m])) * 100) < 99.99
+        for: 5m
+        labels:
+          severity: page
+        annotations:
+          summary: VeriNode mesh availability is below 99.99%
+      - alert: VeriNodeMeshMtlsHandshakeFailure
+        expr: sum(rate(istio_requests_total{destination_service_namespace="verinode",response_flags=~".*UF.*|.*UO.*"}[5m])) > 0
+        for: 2m
+        labels:
+          severity: security
+        annotations:
+          summary: VeriNode mesh mTLS handshake failures detected
+      - alert: VeriNodeMeshCertificateExpirySoon
+        expr: min(istio_agent_secret_expiration_seconds{namespace="verinode"} - time()) < 7200
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: VeriNode mesh workload certificate expires in less than 2 hours

--- a/monitoring/service-mesh-dashboard.json
+++ b/monitoring/service-mesh-dashboard.json
@@ -1,0 +1,44 @@
+{
+  "title": "VeriNode Service Mesh mTLS",
+  "schemaVersion": 39,
+  "panels": [
+    {
+      "title": "P99 Request Latency",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{destination_service_namespace=\"verinode\"}[5m])) by (le, destination_service))"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms", "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 100 }] } } }
+    },
+    {
+      "title": "Availability %",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(rate(istio_requests_total{destination_service_namespace=\"verinode\",response_code!~\"5..\"}[5m])) / sum(rate(istio_requests_total{destination_service_namespace=\"verinode\"}[5m])) * 100"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percent", "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 99.99 }] } } }
+    },
+    {
+      "title": "mTLS Handshake Failures",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(istio_requests_total{destination_service_namespace=\"verinode\",response_flags=~\".*UF.*|.*UO.*\"}[5m]))"
+        }
+      ]
+    },
+    {
+      "title": "Certificate Seconds Until Expiry",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "min(istio_agent_secret_expiration_seconds{namespace=\"verinode\"} - time()) by (pod)"
+        }
+      ]
+    }
+  ]
+}

--- a/src/services/serviceMeshPolicy.ts
+++ b/src/services/serviceMeshPolicy.ts
@@ -1,0 +1,140 @@
+/**
+ * Service mesh policy helpers for VeriNode edge and API services.
+ *
+ * These helpers keep the operational mTLS/SLO contract testable in source code
+ * so Kubernetes/Istio manifests, dashboards, and runbooks can share the same
+ * rollout gates instead of duplicating thresholds in prose only.
+ */
+
+export type MeshMode = 'STRICT' | 'PERMISSIVE' | 'DISABLE'
+export type MeshRolloutPhase = 'baseline' | 'canary' | 'blue' | 'green' | 'promote'
+
+export interface MeshServicePolicy {
+  service: string
+  namespace: string
+  meshMode: MeshMode
+  criticalPathP99Ms: number
+  availabilityTarget: number
+  canaryPercent: number
+  errorBudgetBurnRate: number
+  certificateTtlHours: number
+  telemetrySampleRate: number
+}
+
+export interface MeshRuntimeMetrics {
+  p99LatencyMs: number
+  availability: number
+  mtlsSuccessRate: number
+  errorBudgetBurnRate: number
+  certificateExpiresInHours: number
+}
+
+export interface MeshGateResult {
+  allowed: boolean
+  reasons: string[]
+}
+
+export const DEFAULT_MESH_POLICY: MeshServicePolicy = Object.freeze({
+  service: 'verinode-frontend',
+  namespace: 'verinode',
+  meshMode: 'STRICT',
+  criticalPathP99Ms: 100,
+  availabilityTarget: 99.99,
+  canaryPercent: 10,
+  errorBudgetBurnRate: 1,
+  certificateTtlHours: 24,
+  telemetrySampleRate: 1,
+})
+
+const SERVICE_NAME_PATTERN = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/
+
+export function normalizeMeshPolicy(overrides: Partial<MeshServicePolicy> = {}): MeshServicePolicy {
+  const policy = { ...DEFAULT_MESH_POLICY, ...overrides }
+
+  if (!SERVICE_NAME_PATTERN.test(policy.service)) {
+    throw new Error('service must be a valid Kubernetes DNS label')
+  }
+
+  if (!SERVICE_NAME_PATTERN.test(policy.namespace)) {
+    throw new Error('namespace must be a valid Kubernetes DNS label')
+  }
+
+  if (policy.meshMode !== 'STRICT') {
+    throw new Error('meshMode must be STRICT for production mTLS enforcement')
+  }
+
+  if (policy.criticalPathP99Ms > DEFAULT_MESH_POLICY.criticalPathP99Ms) {
+    throw new Error('criticalPathP99Ms cannot exceed the 100ms P99 target')
+  }
+
+  if (policy.availabilityTarget < DEFAULT_MESH_POLICY.availabilityTarget) {
+    throw new Error('availabilityTarget cannot be below 99.99%')
+  }
+
+  if (policy.canaryPercent <= 0 || policy.canaryPercent > 25) {
+    throw new Error('canaryPercent must be between 1 and 25')
+  }
+
+  if (policy.errorBudgetBurnRate <= 0 || policy.errorBudgetBurnRate > 1) {
+    throw new Error('errorBudgetBurnRate must be > 0 and <= 1')
+  }
+
+  if (policy.certificateTtlHours < 1 || policy.certificateTtlHours > 24) {
+    throw new Error('certificateTtlHours must be between 1 and 24 hours')
+  }
+
+  if (policy.telemetrySampleRate <= 0 || policy.telemetrySampleRate > 1) {
+    throw new Error('telemetrySampleRate must be > 0 and <= 1')
+  }
+
+  return policy
+}
+
+export function evaluateMeshPromotionGate(
+  metrics: MeshRuntimeMetrics,
+  policy: MeshServicePolicy = DEFAULT_MESH_POLICY,
+): MeshGateResult {
+  const normalized = normalizeMeshPolicy(policy)
+  const reasons: string[] = []
+
+  if (metrics.p99LatencyMs > normalized.criticalPathP99Ms) {
+    reasons.push(`p99 latency ${metrics.p99LatencyMs}ms exceeds ${normalized.criticalPathP99Ms}ms`)
+  }
+
+  if (metrics.availability < normalized.availabilityTarget) {
+    reasons.push(`availability ${metrics.availability}% is below ${normalized.availabilityTarget}%`)
+  }
+
+  if (metrics.mtlsSuccessRate < 100) {
+    reasons.push(`mTLS success rate ${metrics.mtlsSuccessRate}% is below 100%`)
+  }
+
+  if (metrics.errorBudgetBurnRate > normalized.errorBudgetBurnRate) {
+    reasons.push(`error budget burn ${metrics.errorBudgetBurnRate} exceeds ${normalized.errorBudgetBurnRate}`)
+  }
+
+  if (metrics.certificateExpiresInHours < 2) {
+    reasons.push('workload certificate expires in less than 2 hours')
+  }
+
+  return { allowed: reasons.length === 0, reasons }
+}
+
+export function buildMeshTrafficWeights(phase: MeshRolloutPhase, canaryPercent = DEFAULT_MESH_POLICY.canaryPercent) {
+  const canary = normalizeMeshPolicy({ canaryPercent }).canaryPercent
+
+  switch (phase) {
+    case 'baseline':
+    case 'blue':
+      return { blue: 100, green: 0, canary: 0 }
+    case 'canary':
+      return { blue: 100 - canary, green: 0, canary }
+    case 'green':
+      return { blue: 0, green: 100, canary: 0 }
+    case 'promote':
+      return { blue: 0, green: 100, canary: 0 }
+    default:
+      phase satisfies never
+      throw new Error('unsupported rollout phase')
+  }
+}

--- a/src/services/tests/serviceMeshPolicy.test.ts
+++ b/src/services/tests/serviceMeshPolicy.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_MESH_POLICY,
+  buildMeshTrafficWeights,
+  evaluateMeshPromotionGate,
+  normalizeMeshPolicy,
+} from '../serviceMeshPolicy'
+
+describe('service mesh policy', () => {
+  it('defaults to strict mTLS and issue SLOs', () => {
+    expect(DEFAULT_MESH_POLICY.meshMode).toBe('STRICT')
+    expect(DEFAULT_MESH_POLICY.criticalPathP99Ms).toBe(100)
+    expect(DEFAULT_MESH_POLICY.availabilityTarget).toBe(99.99)
+    expect(DEFAULT_MESH_POLICY.certificateTtlHours).toBe(24)
+  })
+
+  it('rejects insecure or out-of-bound policy changes', () => {
+    expect(() => normalizeMeshPolicy({ meshMode: 'PERMISSIVE' })).toThrow(/STRICT/)
+    expect(() => normalizeMeshPolicy({ criticalPathP99Ms: 101 })).toThrow(/100ms/)
+    expect(() => normalizeMeshPolicy({ availabilityTarget: 99.9 })).toThrow(/99.99/)
+    expect(() => normalizeMeshPolicy({ canaryPercent: 50 })).toThrow(/between 1 and 25/)
+  })
+
+  it('allows promotion only when latency, availability, mTLS, burn rate, and cert TTL are healthy', () => {
+    expect(
+      evaluateMeshPromotionGate({
+        p99LatencyMs: 82,
+        availability: 99.995,
+        mtlsSuccessRate: 100,
+        errorBudgetBurnRate: 0.7,
+        certificateExpiresInHours: 8,
+      }),
+    ).toEqual({ allowed: true, reasons: [] })
+  })
+
+  it('explains every failed promotion gate', () => {
+    const result = evaluateMeshPromotionGate({
+      p99LatencyMs: 125,
+      availability: 99.95,
+      mtlsSuccessRate: 99.99,
+      errorBudgetBurnRate: 1.3,
+      certificateExpiresInHours: 1,
+    })
+
+    expect(result.allowed).toBe(false)
+    expect(result.reasons).toHaveLength(5)
+  })
+
+  it('builds deterministic blue-green and canary traffic weights', () => {
+    expect(buildMeshTrafficWeights('baseline')).toEqual({ blue: 100, green: 0, canary: 0 })
+    expect(buildMeshTrafficWeights('canary', 15)).toEqual({ blue: 85, green: 0, canary: 15 })
+    expect(buildMeshTrafficWeights('green')).toEqual({ blue: 0, green: 100, canary: 0 })
+  })
+})


### PR DESCRIPTION
### Motivation

- Implement a system-wide service mesh mTLS rollout with strict mTLS, programmatic promotion gates, and SLOs (100 ms P99, 99.99% availability) to protect production traffic paths. 
- Consolidate operational thresholds into code so application tests, runbooks, and manifests share the same promotion gates and rollout criteria. 
- Provide the manifests, alerts, dashboards, and runbook needed to operate blue/green + canary deployments safely.

### Description

- Add `src/services/serviceMeshPolicy.ts` which defines policy types, `DEFAULT_MESH_POLICY`, `normalizeMeshPolicy`, `evaluateMeshPromotionGate`, and `buildMeshTrafficWeights` with strict validation and deterministic traffic weights. 
- Add unit tests `src/services/tests/serviceMeshPolicy.test.ts` that cover secure defaults, invalid-policy rejection, promotion gate success/failure behavior, and traffic-weight generation. 
- Add Istio manifests `deploy/istio/service-mesh-mtls.yaml` (namespace injection label, `PeerAuthentication` STRICT, `DestinationRule` with `ISTIO_MUTUAL`, `VirtualService` subsets for blue/green/canary, and `AuthorizationPolicy` for frontend→API). 
- Add operational docs and runbook `docs/architecture/service-mesh-mtls.md` and `docs/runbooks/service-mesh-mtls.md`, and monitoring artifacts `monitoring/service-mesh-alerts.yaml` and `monitoring/service-mesh-dashboard.json` (Prometheus alerts and Grafana dashboard panels for P99, availability, mTLS handshake failures, and certificate expiry).

### Testing

- Ran unit tests with `npm run test:unit -- src/services/tests/serviceMeshPolicy.test.ts`, which passed (5 tests). 
- Ran linter with `npm run lint`, which completed successfully but reported existing repository warnings (no new lint errors). 
- Ran type check with `npx tsc --noEmit`, which surfaced pre-existing unrelated TypeScript errors elsewhere in the repository and did not pass; these errors are not related to the new service mesh files.

Closes #112