### PR TITLE
Multi region replication

### DIFF
--- a/app/network/dr/page.tsx
+++ b/app/network/dr/page.tsx
@@ -1,0 +1,11 @@
+import { DisasterRecoveryDashboard } from '@/components/disaster-recovery/DisasterRecoveryDashboard'
+
+export default function DisasterRecoveryPage() {
+  return (
+    <main className="min-h-screen bg-slate-50 p-6 md:p-10">
+      <div className="mx-auto max-w-6xl">
+        <DisasterRecoveryDashboard />
+      </div>
+    </main>
+  )
+}

--- a/docs/multi-region-disaster-recovery.md
+++ b/docs/multi-region-disaster-recovery.md
@@ -1,0 +1,45 @@
+# Multi-Region Replication and Disaster Recovery
+
+## Goals
+
+- Keep critical user flows below **100ms P99** whenever traffic remains in a healthy home region.
+- Maintain **99.99% availability** through active-primary plus warm-secondary regional topology.
+- Bound data loss with a **500ms replication-lag RPO guardrail** for frontend state, queued submissions, and operational telemetry.
+- Require a security review for all traffic-shift, key-rotation, and incident-audit changes.
+
+## Architecture
+
+1. **Active primary region** serves normal frontend traffic and emits replication telemetry.
+2. **Warm secondary regions** continuously receive asynchronous replicated state and are eligible for promotion only when heartbeat, P99 latency, and replication-lag checks pass.
+3. **Observer regions** participate in monitoring and synthetic read checks but are not promoted automatically.
+4. The frontend DR service evaluates region health, creates a failover decision, and exposes the same policy values to dashboards and tests.
+
+## Monitoring and alerting
+
+Alert when any of the following remains true for two consecutive checks:
+
+- Primary heartbeat is older than 30 seconds.
+- Critical-path P99 latency is above 100ms.
+- Replication lag is above 500ms.
+- Canary error rate exceeds 0.1% during a blue-green traffic shift.
+- Availability sample drops below 99.99%.
+
+Dashboards should include region role, health, P99 latency, replication lag, heartbeat age, canary status, and the current failover decision.
+
+## Blue-green and canary deployment
+
+1. Deploy the new build to the green environment in every secondary region.
+2. Run synthetic read-after-write checks against replicated state.
+3. Shift 10% of traffic to green and compare error rate and P99 latency against the policy budget.
+4. Ramp to 50%, then 100%, only if canary analysis passes.
+5. Keep the previous blue deployment available until the post-deploy DR drill passes.
+
+## Disaster recovery drill
+
+Run a scheduled drill at least monthly and after changes to routing, storage, authentication, or bridge transaction flows. Record:
+
+- RPO: maximum observed replication lag.
+- RTO: elapsed time from simulated primary failure to serving traffic in the promoted region.
+- Canary outcome and error budget.
+- Smoke-test evidence for wallet session, bridge transaction, validator dashboard, and network pages.
+- Security-review sign-off for audit logs and access-control changes.

--- a/docs/runbooks/disaster-recovery-failover.md
+++ b/docs/runbooks/disaster-recovery-failover.md
@@ -1,0 +1,23 @@
+# Disaster Recovery Failover Runbook
+
+## Preconditions
+
+- Incident commander confirms primary region is unavailable or failing hard health checks.
+- Security reviewer is assigned before changing routing or promotion permissions.
+- Latest replication dashboard shows at least one secondary region inside the 500ms RPO guardrail.
+
+## Procedure
+
+1. Freeze writes on the unhealthy primary and snapshot pending queues.
+2. Promote the healthiest secondary region selected by the failover decision engine.
+3. Rotate global load-balancer traffic to the promoted region.
+4. Run smoke tests for wallet sessions, bridge transactions, validator dashboards, and network pages.
+5. Start a 10% canary and validate error rate below 0.1% with P99 latency below 100ms for critical paths.
+6. Ramp traffic to 50%, then 100%, if canary analysis remains green.
+7. Attach replication telemetry, smoke-test output, and audit logs to the incident record.
+
+## Rollback
+
+- If canary analysis fails, pin traffic to the last stable region.
+- If every secondary exceeds the RPO guardrail, stop automatic promotion and keep the incident in manual review.
+- Restore writes only after security review confirms routing and access controls are correct.

--- a/src/components/disaster-recovery/DisasterRecoveryDashboard.tsx
+++ b/src/components/disaster-recovery/DisasterRecoveryDashboard.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import {
+  DEFAULT_REPLICATION_POLICY,
+  createFailoverPlan,
+  evaluateReplicationHealth,
+  runDisasterRecoveryDrill,
+} from '@/services/disasterRecoveryService'
+import type { ReplicationRegion } from '@/types/disasterRecovery'
+
+const DEMO_REGIONS: ReplicationRegion[] = [
+  {
+    id: 'us-east-1',
+    displayName: 'US East',
+    role: 'primary',
+    status: 'healthy',
+    p99LatencyMs: 72,
+    replicationLagMs: 118,
+    lastHeartbeatAt: Date.now() - 4_000,
+    dataResidency: 'US',
+  },
+  {
+    id: 'eu-west-1',
+    displayName: 'EU West',
+    role: 'secondary',
+    status: 'healthy',
+    p99LatencyMs: 88,
+    replicationLagMs: 135,
+    lastHeartbeatAt: Date.now() - 5_000,
+    dataResidency: 'EU',
+  },
+  {
+    id: 'ap-southeast-1',
+    displayName: 'AP Southeast',
+    role: 'observer',
+    status: 'degraded',
+    p99LatencyMs: 122,
+    replicationLagMs: 410,
+    lastHeartbeatAt: Date.now() - 12_000,
+    dataResidency: 'APAC',
+  },
+]
+
+const statusClass = {
+  pass: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+  warn: 'border-amber-200 bg-amber-50 text-amber-800',
+  fail: 'border-red-200 bg-red-50 text-red-800',
+}
+
+export function DisasterRecoveryDashboard({ regions = DEMO_REGIONS }: { regions?: ReplicationRegion[] }) {
+  const health = evaluateReplicationHealth(regions, DEFAULT_REPLICATION_POLICY)
+  const plan = createFailoverPlan(regions, DEFAULT_REPLICATION_POLICY)
+  const drill = runDisasterRecoveryDrill(regions, DEFAULT_REPLICATION_POLICY, 18_000, 0.04)
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="mb-6 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-wide text-blue-600">Disaster recovery</p>
+          <h2 className="text-2xl font-bold text-slate-950">Multi-region replication readiness</h2>
+          <p className="mt-2 max-w-3xl text-sm text-slate-600">
+            Tracks P99 latency, replication lag, heartbeat freshness, failover plan, and blue-green canary readiness
+            against the 99.99% availability target.
+          </p>
+        </div>
+        <div className={`rounded-full border px-4 py-2 text-sm font-semibold ${statusClass[drill.status]}`}>
+          Drill status: {drill.status.toUpperCase()}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Metric label="P99 target" value={`< ${DEFAULT_REPLICATION_POLICY.criticalPathP99TargetMs}ms`} />
+        <Metric label="RPO guardrail" value={`${DEFAULT_REPLICATION_POLICY.maxReplicationLagMs}ms`} />
+        <Metric label="Availability target" value={`${DEFAULT_REPLICATION_POLICY.availabilityTarget}%`} />
+      </div>
+
+      <div className="mt-6 overflow-hidden rounded-xl border border-slate-200">
+        <table className="min-w-full divide-y divide-slate-200 text-sm">
+          <thead className="bg-slate-50 text-left text-slate-600">
+            <tr>
+              <th className="px-4 py-3 font-semibold">Region</th>
+              <th className="px-4 py-3 font-semibold">Role</th>
+              <th className="px-4 py-3 font-semibold">P99 latency</th>
+              <th className="px-4 py-3 font-semibold">Replication lag</th>
+              <th className="px-4 py-3 font-semibold">Health</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {regions.map((region) => {
+              const item = health.find((entry) => entry.regionId === region.id)
+              return (
+                <tr key={region.id} className="text-slate-700">
+                  <td className="px-4 py-3 font-medium text-slate-950">{region.displayName}</td>
+                  <td className="px-4 py-3 capitalize">{region.role}</td>
+                  <td className="px-4 py-3">{region.p99LatencyMs}ms</td>
+                  <td className="px-4 py-3">{region.replicationLagMs}ms</td>
+                  <td className="px-4 py-3">
+                    <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${statusClass[item?.status ?? 'warn']}`}>
+                      {(item?.status ?? 'warn').toUpperCase()}
+                    </span>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-6 grid gap-4 lg:grid-cols-2">
+        <div className="rounded-xl border border-slate-200 p-4">
+          <h3 className="font-semibold text-slate-950">Failover decision</h3>
+          <p className="mt-2 text-sm text-slate-600">{plan.reason}</p>
+          <p className="mt-3 text-sm font-semibold text-slate-800">Decision: {plan.decision}</p>
+        </div>
+        <div className="rounded-xl border border-slate-200 p-4">
+          <h3 className="font-semibold text-slate-950">Canary analysis</h3>
+          <p className="mt-2 text-sm text-slate-600">
+            RPO {drill.rpoMs}ms, RTO {drill.rtoMs}ms, availability sample {drill.availabilityPercent.toFixed(2)}%.
+          </p>
+          <p className="mt-3 text-sm font-semibold text-slate-800">
+            Canary: {drill.canaryPassed ? 'within error budget' : 'blocked'}
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <p className="text-sm text-slate-500">{label}</p>
+      <p className="mt-1 text-2xl font-bold text-slate-950">{value}</p>
+    </div>
+  )
+}

--- a/src/services/disasterRecoveryService.ts
+++ b/src/services/disasterRecoveryService.ts
@@ -1,0 +1,157 @@
+import type {
+  DisasterRecoveryDrillResult,
+  FailoverPlan,
+  ReplicationHealth,
+  ReplicationPolicy,
+  ReplicationRegion,
+} from '@/types/disasterRecovery'
+
+export const DEFAULT_REPLICATION_POLICY: ReplicationPolicy = {
+  mode: 'async',
+  criticalPathP99TargetMs: 100,
+  maxReplicationLagMs: 500,
+  heartbeatTimeoutMs: 30_000,
+  availabilityTarget: 99.99,
+  canaryErrorBudgetPercent: 0.1,
+  canaryLatencyBudgetMs: 100,
+}
+
+export const DEFAULT_FAILOVER_RUNBOOK_STEPS = [
+  'Freeze writes on the unhealthy primary and snapshot pending queues.',
+  'Promote the healthiest secondary region and rotate traffic through the global load balancer.',
+  'Run read-after-write, wallet session, bridge transaction, and validator dashboard smoke tests.',
+  'Start a 10% canary, compare error rate and P99 latency against budgets, then ramp to 50% and 100%.',
+  'Keep replication telemetry and audit logs attached to the incident record for security review.',
+]
+
+function isHeartbeatStale(region: ReplicationRegion, policy: ReplicationPolicy, now: number): boolean {
+  return now - region.lastHeartbeatAt > policy.heartbeatTimeoutMs
+}
+
+function rankPromotionCandidate(region: ReplicationRegion): number {
+  const statusPenalty = region.status === 'healthy' ? 0 : region.status === 'degraded' ? 10_000 : 100_000
+  return statusPenalty + region.p99LatencyMs + region.replicationLagMs
+}
+
+export function evaluateReplicationHealth(
+  regions: ReplicationRegion[],
+  policy: ReplicationPolicy = DEFAULT_REPLICATION_POLICY,
+  now = Date.now(),
+): ReplicationHealth[] {
+  return regions.map((region) => {
+    const messages: string[] = []
+
+    if (region.status !== 'healthy') {
+      messages.push(`${region.displayName} reports ${region.status} status.`)
+    }
+
+    if (region.p99LatencyMs > policy.criticalPathP99TargetMs) {
+      messages.push(
+        `${region.displayName} P99 latency is ${region.p99LatencyMs}ms, above the ${policy.criticalPathP99TargetMs}ms target.`,
+      )
+    }
+
+    if (region.replicationLagMs > policy.maxReplicationLagMs) {
+      messages.push(
+        `${region.displayName} replication lag is ${region.replicationLagMs}ms, above the ${policy.maxReplicationLagMs}ms RPO guardrail.`,
+      )
+    }
+
+    if (isHeartbeatStale(region, policy, now)) {
+      messages.push(`${region.displayName} heartbeat is stale.`)
+    }
+
+    const hasHardFailure = region.status === 'unavailable' || isHeartbeatStale(region, policy, now)
+    const status = hasHardFailure ? 'fail' : messages.length > 0 ? 'warn' : 'pass'
+
+    return { regionId: region.id, status, messages }
+  })
+}
+
+export function createFailoverPlan(
+  regions: ReplicationRegion[],
+  policy: ReplicationPolicy = DEFAULT_REPLICATION_POLICY,
+  now = Date.now(),
+): FailoverPlan {
+  const primary = regions.find((region) => region.role === 'primary')
+  const health = evaluateReplicationHealth(regions, policy, now)
+  const primaryHealth = primary ? health.find((item) => item.regionId === primary.id) : null
+
+  if (!primary) {
+    return {
+      decision: 'manual-review',
+      targetRegionId: null,
+      reason: 'No primary region is configured.',
+      runbookSteps: DEFAULT_FAILOVER_RUNBOOK_STEPS,
+    }
+  }
+
+  if (primaryHealth?.status !== 'fail') {
+    return {
+      decision: primaryHealth?.status === 'warn' ? 'manual-review' : 'stay-primary',
+      targetRegionId: primary.id,
+      reason: primaryHealth?.messages.join(' ') || `${primary.displayName} is within replication and latency budgets.`,
+      runbookSteps: DEFAULT_FAILOVER_RUNBOOK_STEPS,
+    }
+  }
+
+  const candidates = regions
+    .filter((region) => region.role === 'secondary')
+    .filter((region) => {
+      const item = health.find((entry) => entry.regionId === region.id)
+      return item?.status !== 'fail' && region.replicationLagMs <= policy.maxReplicationLagMs
+    })
+    .sort((a, b) => rankPromotionCandidate(a) - rankPromotionCandidate(b))
+
+  if (candidates.length === 0) {
+    return {
+      decision: 'manual-review',
+      targetRegionId: null,
+      reason: 'Primary failed, but no secondary region satisfies heartbeat and replication-lag guardrails.',
+      runbookSteps: DEFAULT_FAILOVER_RUNBOOK_STEPS,
+    }
+  }
+
+  return {
+    decision: 'promote-secondary',
+    targetRegionId: candidates[0].id,
+    reason: `${primary.displayName} failed health checks; ${candidates[0].displayName} has the best latency and replication posture.`,
+    runbookSteps: DEFAULT_FAILOVER_RUNBOOK_STEPS,
+  }
+}
+
+export function runDisasterRecoveryDrill(
+  regions: ReplicationRegion[],
+  policy: ReplicationPolicy = DEFAULT_REPLICATION_POLICY,
+  simulatedRecoveryMs: number,
+  canaryErrorPercent: number,
+  now = Date.now(),
+): DisasterRecoveryDrillResult {
+  const health = evaluateReplicationHealth(regions, policy, now)
+  const findings = health.flatMap((item) => item.messages)
+  const rpoMs = Math.max(0, ...regions.map((region) => region.replicationLagMs))
+  const rtoMs = simulatedRecoveryMs
+  const healthyRegions = health.filter((item) => item.status === 'pass').length
+  const availabilityPercent = regions.length === 0 ? 0 : (healthyRegions / regions.length) * 100
+  const canaryPassed = canaryErrorPercent <= policy.canaryErrorBudgetPercent && rpoMs <= policy.maxReplicationLagMs
+
+  if (rpoMs > policy.maxReplicationLagMs) {
+    findings.push(`Observed RPO ${rpoMs}ms exceeds ${policy.maxReplicationLagMs}ms.`)
+  }
+
+  if (rtoMs > policy.heartbeatTimeoutMs) {
+    findings.push(`Observed RTO ${rtoMs}ms exceeds ${policy.heartbeatTimeoutMs}ms failover target.`)
+  }
+
+  if (!canaryPassed) {
+    findings.push('Canary analysis failed; hold blue-green promotion and keep traffic pinned to the stable region.')
+  }
+
+  const status = findings.some((finding) => finding.includes('exceeds') || finding.includes('failed'))
+    ? 'fail'
+    : findings.length > 0 || availabilityPercent < policy.availabilityTarget
+      ? 'warn'
+      : 'pass'
+
+  return { status, rpoMs, rtoMs, availabilityPercent, canaryPassed, findings }
+}

--- a/src/services/tests/disasterRecoveryService.test.ts
+++ b/src/services/tests/disasterRecoveryService.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_REPLICATION_POLICY,
+  createFailoverPlan,
+  evaluateReplicationHealth,
+  runDisasterRecoveryDrill,
+} from '../disasterRecoveryService'
+import type { ReplicationRegion } from '@/types/disasterRecovery'
+
+const now = 1_700_000_000_000
+
+function region(overrides: Partial<ReplicationRegion>): ReplicationRegion {
+  return {
+    id: 'us-east-1',
+    displayName: 'US East',
+    role: 'primary',
+    status: 'healthy',
+    p99LatencyMs: 75,
+    replicationLagMs: 120,
+    lastHeartbeatAt: now - 5_000,
+    dataResidency: 'US',
+    ...overrides,
+  }
+}
+
+describe('evaluateReplicationHealth', () => {
+  it('passes regions within the <100ms P99 and replication budgets', () => {
+    const [health] = evaluateReplicationHealth([region({})], DEFAULT_REPLICATION_POLICY, now)
+
+    expect(health.status).toBe('pass')
+    expect(health.messages).toEqual([])
+  })
+
+  it('warns when latency exceeds the critical path target', () => {
+    const [health] = evaluateReplicationHealth(
+      [region({ p99LatencyMs: DEFAULT_REPLICATION_POLICY.criticalPathP99TargetMs + 1 })],
+      DEFAULT_REPLICATION_POLICY,
+      now,
+    )
+
+    expect(health.status).toBe('warn')
+    expect(health.messages[0]).toContain('P99 latency')
+  })
+
+  it('fails stale heartbeats to drive disaster recovery escalation', () => {
+    const [health] = evaluateReplicationHealth(
+      [region({ lastHeartbeatAt: now - DEFAULT_REPLICATION_POLICY.heartbeatTimeoutMs - 1 })],
+      DEFAULT_REPLICATION_POLICY,
+      now,
+    )
+
+    expect(health.status).toBe('fail')
+    expect(health.messages).toContain('US East heartbeat is stale.')
+  })
+})
+
+describe('createFailoverPlan', () => {
+  it('keeps traffic on a healthy primary', () => {
+    const plan = createFailoverPlan([region({})], DEFAULT_REPLICATION_POLICY, now)
+
+    expect(plan.decision).toBe('stay-primary')
+    expect(plan.targetRegionId).toBe('us-east-1')
+  })
+
+  it('promotes the healthiest secondary when the primary is unavailable', () => {
+    const plan = createFailoverPlan(
+      [
+        region({ status: 'unavailable' }),
+        region({ id: 'eu-west-1', displayName: 'EU West', role: 'secondary', p99LatencyMs: 85, replicationLagMs: 110 }),
+        region({ id: 'ap-southeast-1', displayName: 'AP Southeast', role: 'secondary', p99LatencyMs: 95, replicationLagMs: 300 }),
+      ],
+      DEFAULT_REPLICATION_POLICY,
+      now,
+    )
+
+    expect(plan.decision).toBe('promote-secondary')
+    expect(plan.targetRegionId).toBe('eu-west-1')
+    expect(plan.runbookSteps).toHaveLength(5)
+  })
+
+  it('requires manual review when no secondary is inside RPO guardrails', () => {
+    const plan = createFailoverPlan(
+      [
+        region({ status: 'unavailable' }),
+        region({ id: 'eu-west-1', displayName: 'EU West', role: 'secondary', replicationLagMs: 2_000 }),
+      ],
+      DEFAULT_REPLICATION_POLICY,
+      now,
+    )
+
+    expect(plan.decision).toBe('manual-review')
+    expect(plan.targetRegionId).toBeNull()
+  })
+})
+
+describe('runDisasterRecoveryDrill', () => {
+  it('passes a clean blue-green canary drill', () => {
+    const result = runDisasterRecoveryDrill(
+      [
+        region({}),
+        region({ id: 'eu-west-1', displayName: 'EU West', role: 'secondary' }),
+      ],
+      DEFAULT_REPLICATION_POLICY,
+      15_000,
+      0.05,
+      now,
+    )
+
+    expect(result.status).toBe('pass')
+    expect(result.canaryPassed).toBe(true)
+    expect(result.rpoMs).toBe(120)
+  })
+
+  it('fails when RPO or canary error budget exceeds policy', () => {
+    const result = runDisasterRecoveryDrill(
+      [region({ replicationLagMs: 1_000 })],
+      DEFAULT_REPLICATION_POLICY,
+      15_000,
+      0.5,
+      now,
+    )
+
+    expect(result.status).toBe('fail')
+    expect(result.canaryPassed).toBe(false)
+    expect(result.findings).toEqual(expect.arrayContaining([expect.stringContaining('Observed RPO')]))
+  })
+})

--- a/src/types/disasterRecovery.ts
+++ b/src/types/disasterRecovery.ts
@@ -1,0 +1,48 @@
+export type RegionRole = 'primary' | 'secondary' | 'observer'
+export type RegionStatus = 'healthy' | 'degraded' | 'unavailable'
+export type ReplicationMode = 'sync' | 'async'
+export type FailoverDecision = 'stay-primary' | 'promote-secondary' | 'manual-review'
+export type DrillStatus = 'pass' | 'warn' | 'fail'
+
+export interface ReplicationRegion {
+  id: string
+  displayName: string
+  role: RegionRole
+  status: RegionStatus
+  p99LatencyMs: number
+  replicationLagMs: number
+  lastHeartbeatAt: number
+  dataResidency: string
+}
+
+export interface ReplicationPolicy {
+  mode: ReplicationMode
+  criticalPathP99TargetMs: number
+  maxReplicationLagMs: number
+  heartbeatTimeoutMs: number
+  availabilityTarget: number
+  canaryErrorBudgetPercent: number
+  canaryLatencyBudgetMs: number
+}
+
+export interface ReplicationHealth {
+  regionId: string
+  status: DrillStatus
+  messages: string[]
+}
+
+export interface FailoverPlan {
+  decision: FailoverDecision
+  targetRegionId: string | null
+  reason: string
+  runbookSteps: string[]
+}
+
+export interface DisasterRecoveryDrillResult {
+  status: DrillStatus
+  rpoMs: number
+  rtoMs: number
+  availabilityPercent: number
+  canaryPassed: boolean
+  findings: string[]
+}


### PR DESCRIPTION
### Motivation
- Provide an opinionated frontend representation of multi-region replication and DR policy so operators can monitor failover posture and runbook guidance in one place.
- Encode deterministic decisioning for health evaluation, secondary promotion, and canary gating to reduce manual guesswork during incidents.
- Ship a lightweight way to exercise and record DR drills programmatically so RTO/RPO and canary outcomes are testable.

### Description
- Add typed models in `src/types/disasterRecovery.ts` describing regions, policies, health, failover plans, and drill results.
- Implement DR logic in `src/services/disasterRecoveryService.ts` including `evaluateReplicationHealth`, `createFailoverPlan`, and `runDisasterRecoveryDrill` with sensible defaults (100ms P99, 500ms RPO, 99.99% availability).
- Add a UI dashboard component at `src/components/disaster-recovery/DisasterRecoveryDashboard.tsx` and a route page at `app/network/dr/page.tsx` to visualize region health, failover decision, and canary analysis.
- Add documentation and an operational runbook at `docs/multi-region-disaster-recovery.md` and `docs/runbooks/disaster-recovery-failover.md` and unit tests in `src/services/tests/disasterRecoveryService.test.ts` covering health, failover, and drill scenarios.

### Testing
- Ran unit tests with `npm run test:unit -- --run src/services/tests/disasterRecoveryService.test.ts` and all tests in that file passed (8/8).
- Ran lint with `npm run lint` which completed but reported warnings only (no errors).
- Ran type-check with `npx tsc --noEmit` which failed due to unrelated pre-existing repository type errors (missing deps, target issues); failures are unrelated to the new files.
- Attempted `npm run build` which failed in this environment because `next/font` could not fetch Google Fonts, and attempted Playwright screenshot failed because browser binaries were not installed.

Closes #131