### PR TITLE
Configuration management

### DIFF
--- a/docs/configuration-management.md
+++ b/docs/configuration-management.md
@@ -1,0 +1,18 @@
+# Configuration Management
+
+VeriNode uses a typed configuration manager for system-wide settings that need runtime validation and hot-reload. The manager loads a partial configuration from a source, merges schema defaults, validates every key, and atomically publishes only valid snapshots to subscribers.
+
+## Architecture
+
+1. **Config source**: implements `load()` and optional `revision()` for API, localStorage, feature-flag, or file-backed configuration.
+2. **Schema**: declares defaults, validators, and whether validation failures are critical.
+3. **Manager**: keeps the last known-good snapshot, exposes immutable reads, emits change events, and polls for hot-reload.
+4. **Metrics**: exposes reload attempts, successes, failures, validation failures, duration, timestamp, and revision for dashboards and alerts.
+
+Invalid critical updates are rejected and the previous snapshot remains active. Non-critical fields can fall back to defaults while still reporting validation errors.
+
+## Operating targets
+
+- Keep schema validation synchronous and lightweight so reloads do not affect critical paths; callers read in-memory snapshots.
+- Alert when `reloadFailures` or `validationFailures` increases in production.
+- Use canary release by wiring a canary config source or revision before enabling the same source globally.

--- a/docs/runbooks/configuration-hot-reload.md
+++ b/docs/runbooks/configuration-hot-reload.md
@@ -1,0 +1,16 @@
+# Configuration Hot-Reload Runbook
+
+## Deploying a config change
+
+1. Validate the change against the service schema in staging.
+2. Publish to the canary config source and watch reload metrics for at least one poll interval.
+3. Promote with blue-green deployment by switching the active source revision for the green environment.
+4. Roll back by restoring the previous revision; services keep the last known-good snapshot if validation fails.
+
+## Alerts
+
+Page the service owner when any of these occur:
+
+- `validationFailures` increases for a production service.
+- `reloadFailures` increases for three consecutive poll intervals.
+- `lastSuccessfulReloadAt` is older than two expected poll intervals.

--- a/src/lib/configManager.test.ts
+++ b/src/lib/configManager.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ConfigManager, ConfigValidationException, type ConfigSchema } from './configManager';
+
+type AppConfig = {
+  maxRequests: number;
+  maintenanceMode: boolean;
+  apiBaseUrl: string;
+};
+
+const schema: ConfigSchema<AppConfig> = {
+  maxRequests: {
+    defaultValue: 100,
+    validate: (value): value is number => typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= 10_000,
+    message: 'must be an integer between 1 and 10000',
+    critical: true,
+  },
+  maintenanceMode: {
+    defaultValue: false,
+    validate: (value): value is boolean => typeof value === 'boolean',
+    message: 'must be a boolean',
+    critical: false,
+  },
+  apiBaseUrl: {
+    defaultValue: 'https://api.verinode.example',
+    validate: (value): value is string => typeof value === 'string' && value.startsWith('https://'),
+    message: 'must be an HTTPS URL',
+    critical: true,
+  },
+};
+
+describe('ConfigManager', () => {
+  it('merges defaults with source configuration and exposes immutable snapshots', async () => {
+    const manager = new ConfigManager({
+      schema,
+      source: { load: () => ({ maxRequests: 250 }), revision: () => 'rev-1' },
+    });
+
+    const loaded = await manager.load();
+    loaded.maxRequests = 1;
+
+    expect(manager.getConfig()).toEqual({
+      maxRequests: 250,
+      maintenanceMode: false,
+      apiBaseUrl: 'https://api.verinode.example',
+    });
+    expect(manager.getMetrics()).toMatchObject({ reloadAttempts: 1, reloadSuccesses: 1, currentRevision: 'rev-1' });
+  });
+
+  it('rejects critical validation failures and keeps the previous known-good config', async () => {
+    let raw: Partial<AppConfig> = { maxRequests: 500 };
+    const manager = new ConfigManager({ schema, source: { load: () => raw } });
+    await manager.load();
+
+    raw = { maxRequests: -1, apiBaseUrl: 'http://insecure.example' };
+
+    await expect(manager.load()).rejects.toBeInstanceOf(ConfigValidationException);
+    expect(manager.getConfig().maxRequests).toBe(500);
+    expect(manager.getMetrics()).toMatchObject({ reloadAttempts: 2, reloadSuccesses: 1, reloadFailures: 1, validationFailures: 1 });
+  });
+
+  it('falls back to defaults for non-critical invalid fields and notifies subscribers of changed keys', async () => {
+    const listener = vi.fn();
+    const manager = new ConfigManager({
+      schema,
+      source: { load: () => ({ maxRequests: 300, maintenanceMode: 'yes' } as unknown as Partial<AppConfig>), revision: () => 7 },
+    });
+    manager.subscribe(listener);
+
+    await manager.load();
+
+    expect(manager.getConfig().maintenanceMode).toBe(false);
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ revision: 7, changedKeys: ['maxRequests'] }));
+  });
+
+  it('polls the source for hot-reload until stopped', async () => {
+    vi.useFakeTimers();
+    const source = { load: vi.fn(() => ({ maxRequests: 100 })), revision: vi.fn(() => source.load.mock.calls.length) };
+    const manager = new ConfigManager({ schema, source, pollIntervalMs: 50 });
+
+    const stop = manager.startHotReload();
+    await vi.advanceTimersByTimeAsync(125);
+    stop();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(source.load).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+});

--- a/src/lib/configManager.ts
+++ b/src/lib/configManager.ts
@@ -1,0 +1,182 @@
+export type ConfigValue = string | number | boolean | null | ConfigValue[] | { [key: string]: ConfigValue };
+export type ConfigRecord = Record<string, ConfigValue>;
+
+export type SchemaRule<T> = {
+  validate: (value: unknown, config: Partial<T>) => value is T[keyof T];
+  message: string;
+  critical?: boolean;
+};
+
+export type ConfigSchema<T extends ConfigRecord> = {
+  [K in keyof T]: {
+    defaultValue: T[K];
+    validate: (value: unknown, config: Partial<T>) => value is T[K];
+    message: string;
+    critical?: boolean;
+  };
+};
+
+export type ConfigValidationError<T extends ConfigRecord> = {
+  key: keyof T;
+  message: string;
+  value: unknown;
+  critical: boolean;
+};
+
+export type ConfigValidationResult<T extends ConfigRecord> =
+  | { ok: true; config: T; errors: [] }
+  | { ok: false; config: T; errors: ConfigValidationError<T>[] };
+
+export interface ConfigSource<T extends ConfigRecord> {
+  load(): Promise<Partial<T>> | Partial<T>;
+  revision?(): Promise<string | number> | string | number;
+}
+
+export type ConfigChange<T extends ConfigRecord> = {
+  previous: T;
+  current: T;
+  revision: string | number;
+  changedKeys: Array<keyof T>;
+  loadedAt: number;
+};
+
+export type ConfigMetrics = {
+  reloadAttempts: number;
+  reloadSuccesses: number;
+  reloadFailures: number;
+  validationFailures: number;
+  lastReloadDurationMs: number;
+  lastSuccessfulReloadAt: number | null;
+  currentRevision: string | number;
+};
+
+export type ConfigManagerOptions<T extends ConfigRecord> = {
+  schema: ConfigSchema<T>;
+  source: ConfigSource<T>;
+  pollIntervalMs?: number;
+  now?: () => number;
+};
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+
+export class ConfigValidationException<T extends ConfigRecord> extends Error {
+  constructor(public readonly errors: ConfigValidationError<T>[]) {
+    super(errors.map((error) => `${String(error.key)}: ${error.message}`).join('; '));
+    this.name = 'ConfigValidationException';
+  }
+}
+
+export class ConfigManager<T extends ConfigRecord> {
+  private current: T;
+  private revision: string | number = 0;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private listeners = new Set<(change: ConfigChange<T>) => void>();
+  private readonly metrics: ConfigMetrics = {
+    reloadAttempts: 0,
+    reloadSuccesses: 0,
+    reloadFailures: 0,
+    validationFailures: 0,
+    lastReloadDurationMs: 0,
+    lastSuccessfulReloadAt: null,
+    currentRevision: 0,
+  };
+
+  constructor(private readonly options: ConfigManagerOptions<T>) {
+    this.current = defaultsFromSchema(options.schema);
+  }
+
+  getConfig(): T {
+    return structuredCloneSafe(this.current);
+  }
+
+  getMetrics(): ConfigMetrics {
+    return { ...this.metrics };
+  }
+
+  validate(raw: Partial<T>): ConfigValidationResult<T> {
+    const merged = { ...defaultsFromSchema(this.options.schema), ...raw } as T;
+    const errors: ConfigValidationError<T>[] = [];
+
+    for (const key of Object.keys(this.options.schema) as Array<keyof T>) {
+      const rule = this.options.schema[key];
+      if (!rule.validate(merged[key], merged)) {
+        errors.push({ key, message: rule.message, value: merged[key], critical: rule.critical ?? true });
+        merged[key] = rule.defaultValue;
+      }
+    }
+
+    return errors.length > 0 ? { ok: false, config: merged, errors } : { ok: true, config: merged, errors: [] };
+  }
+
+  async load(): Promise<T> {
+    const startedAt = this.now();
+    this.metrics.reloadAttempts += 1;
+    try {
+      const raw = await this.options.source.load();
+      const result = this.validate(raw);
+      if (!result.ok && result.errors.some((error) => error.critical)) {
+        this.metrics.validationFailures += 1;
+        throw new ConfigValidationException(result.errors);
+      }
+
+      const nextRevision = this.options.source.revision ? await this.options.source.revision() : this.nextNumericRevision();
+      this.applyConfig(result.config, nextRevision, startedAt);
+      this.metrics.reloadSuccesses += 1;
+      this.metrics.lastSuccessfulReloadAt = this.now();
+      return this.getConfig();
+    } catch (error) {
+      this.metrics.reloadFailures += 1;
+      throw error;
+    } finally {
+      this.metrics.lastReloadDurationMs = this.now() - startedAt;
+    }
+  }
+
+  startHotReload(): () => void {
+    if (this.timer) return () => this.stopHotReload();
+    this.timer = setInterval(() => {
+      void this.load().catch(() => undefined);
+    }, this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+    return () => this.stopHotReload();
+  }
+
+  stopHotReload(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  subscribe(listener: (change: ConfigChange<T>) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private applyConfig(next: T, nextRevision: string | number, loadedAt: number): void {
+    const previous = this.current;
+    const changedKeys = Object.keys(next).filter((key) => previous[key] !== next[key]) as Array<keyof T>;
+    this.current = structuredCloneSafe(next);
+    this.revision = nextRevision;
+    this.metrics.currentRevision = nextRevision;
+    if (changedKeys.length === 0) return;
+    const change = { previous, current: this.getConfig(), revision: nextRevision, changedKeys, loadedAt };
+    this.listeners.forEach((listener) => listener(change));
+  }
+
+  private nextNumericRevision(): number {
+    return typeof this.revision === 'number' ? this.revision + 1 : 1;
+  }
+
+  private now(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+}
+
+export function defaultsFromSchema<T extends ConfigRecord>(schema: ConfigSchema<T>): T {
+  return Object.fromEntries(
+    Object.entries(schema).map(([key, rule]) => [key, structuredCloneSafe(rule.defaultValue)]),
+  ) as T;
+}
+
+function structuredCloneSafe<T>(value: T): T {
+  if (typeof structuredClone === 'function') return structuredClone(value);
+  return JSON.parse(JSON.stringify(value)) as T;
+}


### PR DESCRIPTION
### Motivation
- Provide a system-wide, typed configuration manager that can load partial configs, merge schema defaults, validate fields, and publish only known-good snapshots to services.
- Support runtime hot-reload with polling, revision tracking and subscriber notifications so services can react to safe config changes without restart.
- Surface reload/validation metrics and runbook guidance to enable monitoring, canary promotion and safe rollbacks.

### Description
- Add `src/lib/configManager.ts` which implements `ConfigManager<T>`, schema-driven defaults, `validate()`, `load()` with `ConfigValidationException`, metrics, subscriber notifications, and `startHotReload()`/`stopHotReload()` polling logic.
- Add `src/lib/configManager.test.ts` with unit tests covering default merging, immutable snapshots, critical validation rejection, non-critical fallback behavior, subscriber notification, and polling hot-reload behavior.
- Add docs: `docs/configuration-management.md` (architecture, schema, metrics, operating targets) and `docs/runbooks/configuration-hot-reload.md` (deploy, canary, rollback, alerts).
- Include utility helpers `defaultsFromSchema()` and `structuredCloneSafe()` and numeric revision fallback when a source does not provide a revision.

### Testing
- Ran the focused unit tests with `npm run test:unit -- --run src/lib/configManager.test.ts` and the new test file passed (4 tests, all green).
- Ran the full unit suite with `npm run test:unit`; the targeted config tests passed but there are pre-existing unrelated failures in `src/utils/tests/treeFlattener.test.ts` and `src/hooks/tests/useSlashingStream.test.ts` (these are not caused by this change).
- Ran linters and TypeScript checks for the modified files with `npm run lint -- src/lib/configManager.ts src/lib/configManager.test.ts` and `npx tsc --noEmit --target ES2020 --moduleResolution bundler --module esnext --strict src/lib/configManager.ts src/lib/configManager.test.ts`, which succeeded for the scoped files; full-project `eslint`/`tsc --noEmit` still report pre-existing errors outside this change.

Closes #117