### PR TITLE
Service level objective

### DIFF
--- a/app/network/page.tsx
+++ b/app/network/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { LightClientSyncIndicator } from '@/src/components/network/LightClientSyncIndicator';
+import { SloMonitoringDashboard } from '@/src/components/slo/SloMonitoringDashboard';
 import dynamic from 'next/dynamic';
 import { ChartSkeleton } from '@/src/components/charts/ChartSkeleton';
 
@@ -60,6 +61,7 @@ export default function NetworkStatus() {
       <h1 className="text-3xl font-bold mb-8 text-zinc-900 dark:text-zinc-50">Network Status</h1>
 
       <div className="grid grid-cols-1 gap-8">
+        <SloMonitoringDashboard />
         <div className="bg-white dark:bg-zinc-900 rounded-xl p-6 shadow-sm border border-zinc-200 dark:border-zinc-800">
           <h2 className="mb-4 text-xl font-semibold text-zinc-900 dark:text-zinc-50">Validator topology</h2>
           <NetworkGraph />

--- a/docs/monitoring/slo-burn-rate-runbook.md
+++ b/docs/monitoring/slo-burn-rate-runbook.md
@@ -1,0 +1,39 @@
+# SLO monitoring and burn-rate alerting
+
+## Architecture
+
+VeriNode evaluates service-level indicators for critical user journeys in a lightweight frontend service so operators can see error-budget risk even when backend telemetry is partially degraded.
+
+- **Objectives:** 99.99% platform availability and P99 critical-path latency below 100ms.
+- **Inputs:** rolling request success counters, latency P99 samples, service identifier, and capture time.
+- **Core logic:** `evaluateSloWindow` normalizes availability, compares latency objectives, computes error-budget burn rate, and derives alert severity.
+- **Dashboard:** the network status page renders a burn-rate panel with current paging/ticket counts and per-window diagnostics.
+
+## Alert policy
+
+- **Critical/page:** burn rate at or above 14.4x.
+- **Warning/ticket:** burn rate at or above 6x.
+- **Healthy:** burn rate below ticket threshold.
+
+## Deployment strategy
+
+1. Ship instrumentation behind the existing dashboard route.
+2. Run a blue-green release by serving the new dashboard to the green environment first.
+3. Canary 5% of operators for 30 minutes and compare client errors, render latency, and alert volume.
+4. Promote to 100% only if P99 dashboard render path remains below 100ms and no false critical alert burst occurs.
+5. Roll back by disabling the SLO dashboard import on the network page if canary analysis fails.
+
+## Security review checklist
+
+- Do not include user identifiers in SLO samples.
+- Sanitize service names before wiring live backend data to UI rendering.
+- Confirm alert webhooks use least-privilege credentials and rotated secrets.
+- Verify runbook links do not expose internal incident channels to unauthenticated users.
+
+## Operator response
+
+1. Acknowledge the highest-severity burn-rate alert.
+2. Check the affected objective, window, burn rate, and time-to-exhaustion.
+3. Correlate with deployment, dependency, and Kafka lag dashboards.
+4. For critical alerts, start incident response and freeze non-emergency deploys.
+5. After mitigation, confirm burn rate returns below 6x on short and long windows.

--- a/src/components/slo/SloMonitoringDashboard.tsx
+++ b/src/components/slo/SloMonitoringDashboard.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useMemo } from 'react';
+import { generateDemoSloEvaluations } from '@/src/services/slo/sloMonitoringService';
+import type { SloEvaluation, SloSeverity } from '@/src/types/slo';
+
+const SEVERITY_STYLES: Record<SloSeverity, string> = {
+  healthy: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  warning: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  critical: 'border-rose-500/30 bg-rose-500/10 text-rose-300',
+};
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(3)}%`;
+}
+
+function formatTte(hours: number | null): string {
+  if (hours === null) return 'Budget stable';
+  if (hours < 1) return `${Math.round(hours * 60)}m`;
+  return `${hours.toFixed(1)}h`;
+}
+
+function EvaluationCard({ evaluation }: { evaluation: SloEvaluation }) {
+  return (
+    <article className="rounded-2xl border border-slate-800 bg-slate-950/70 p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-white">{evaluation.objective.name}</h3>
+          <p className="mt-1 text-xs text-slate-400">{evaluation.objective.description}</p>
+        </div>
+        <span className={`rounded-full border px-2.5 py-1 text-xs font-semibold capitalize ${SEVERITY_STYLES[evaluation.severity]}`}>
+          {evaluation.severity}
+        </span>
+      </div>
+
+      <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
+        <div className="rounded-xl bg-slate-900/80 p-3">
+          <dt className="text-slate-500">Window</dt>
+          <dd className="mt-1 font-semibold text-slate-100">{evaluation.sample.window}</dd>
+        </div>
+        <div className="rounded-xl bg-slate-900/80 p-3">
+          <dt className="text-slate-500">Observed SLI</dt>
+          <dd className="mt-1 font-semibold text-slate-100">{formatPercent(evaluation.observed)}</dd>
+        </div>
+        <div className="rounded-xl bg-slate-900/80 p-3">
+          <dt className="text-slate-500">Burn rate</dt>
+          <dd className="mt-1 font-semibold text-slate-100">{evaluation.burnRate.toFixed(1)}x</dd>
+        </div>
+        <div className="rounded-xl bg-slate-900/80 p-3">
+          <dt className="text-slate-500">Time to exhaust</dt>
+          <dd className="mt-1 font-semibold text-slate-100">{formatTte(evaluation.timeToExhaustionHours)}</dd>
+        </div>
+      </dl>
+
+      {evaluation.reasons.length > 0 && (
+        <ul className="mt-4 space-y-1 text-xs text-slate-300">
+          {evaluation.reasons.map((reason) => (
+            <li key={reason}>• {reason}</li>
+          ))}
+        </ul>
+      )}
+    </article>
+  );
+}
+
+export function SloMonitoringDashboard() {
+  const evaluations = useMemo(() => generateDemoSloEvaluations(), []);
+  const criticalCount = evaluations.filter((item) => item.severity === 'critical').length;
+  const warningCount = evaluations.filter((item) => item.severity === 'warning').length;
+
+  return (
+    <section className="space-y-6 rounded-3xl border border-slate-800 bg-slate-950 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold text-white">SLO burn-rate monitoring</h2>
+          <p className="mt-1 text-sm text-slate-400">
+            Tracks 99.99% availability and &lt;100ms P99 critical-path objectives with multi-window alert signals.
+          </p>
+        </div>
+        <div className="flex gap-2 text-xs font-semibold">
+          <span className="rounded-full border border-rose-500/30 bg-rose-500/10 px-3 py-1 text-rose-300">{criticalCount} paging</span>
+          <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-amber-300">{warningCount} ticket</span>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {evaluations.map((evaluation) => (
+          <EvaluationCard key={`${evaluation.objective.id}-${evaluation.sample.window}`} evaluation={evaluation} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/services/slo/sloMonitoringService.test.ts
+++ b/src/services/slo/sloMonitoringService.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_SLO_POLICY,
+  SYSTEM_SLO_OBJECTIVES,
+  calculateAvailability,
+  calculateBurnRate,
+  deriveSloSeverity,
+  evaluateSloWindow,
+  generateDemoSloEvaluations,
+} from './sloMonitoringService';
+
+describe('SLO monitoring service', () => {
+  it('calculates availability safely', () => {
+    expect(calculateAvailability(9999, 10000)).toBe(0.9999);
+    expect(calculateAvailability(1, 0)).toBe(1);
+  });
+
+  it('derives burn rate against the objective error budget', () => {
+    const objective = SYSTEM_SLO_OBJECTIVES[0];
+    const burnRate = calculateBurnRate(objective, {
+      window: '1h',
+      goodEvents: 999_800,
+      totalEvents: 1_000_000,
+      capturedAt: 1,
+    });
+    expect(burnRate).toBeCloseTo(2, 5);
+  });
+
+  it('gates latency burn rate on the 100ms P99 target', () => {
+    const objective = SYSTEM_SLO_OBJECTIVES[1];
+    expect(calculateBurnRate(objective, { window: '5m', goodEvents: 90, totalEvents: 100, p99LatencyMs: 99, capturedAt: 1 })).toBe(0);
+    expect(calculateBurnRate(objective, { window: '5m', goodEvents: 90, totalEvents: 100, p99LatencyMs: 101, capturedAt: 1 })).toBeGreaterThan(0);
+  });
+
+  it('maps burn rates to ticket and page severities', () => {
+    expect(deriveSloSeverity(1)).toBe('healthy');
+    expect(deriveSloSeverity(DEFAULT_SLO_POLICY.ticketBurnRate)).toBe('warning');
+    expect(deriveSloSeverity(DEFAULT_SLO_POLICY.pageBurnRate)).toBe('critical');
+  });
+
+  it('evaluates windows with reasons and time to exhaustion', () => {
+    const evaluation = evaluateSloWindow(SYSTEM_SLO_OBJECTIVES[0], {
+      window: '30m',
+      goodEvents: 99_000,
+      totalEvents: 100_000,
+      capturedAt: 1,
+    });
+    expect(evaluation.severity).toBe('critical');
+    expect(evaluation.reasons.length).toBeGreaterThan(0);
+    expect(evaluation.timeToExhaustionHours).toBeGreaterThan(0);
+  });
+
+  it('provides demo evaluations for the dashboard', () => {
+    const evaluations = generateDemoSloEvaluations(123);
+    expect(evaluations).toHaveLength(4);
+    expect(evaluations.some((item) => item.severity !== 'healthy')).toBe(true);
+  });
+
+  it('keeps critical-path evaluation under 100ms for 10 000 samples', () => {
+    const objective = SYSTEM_SLO_OBJECTIVES[0];
+    const start = performance.now();
+    for (let i = 0; i < 10_000; i++) {
+      evaluateSloWindow(objective, { window: '5m', goodEvents: 9990, totalEvents: 10000, capturedAt: i });
+    }
+    expect(performance.now() - start).toBeLessThan(100);
+  });
+});

--- a/src/services/slo/sloMonitoringService.ts
+++ b/src/services/slo/sloMonitoringService.ts
@@ -1,0 +1,133 @@
+import type {
+  BurnRateAlertPolicy,
+  SliWindowSample,
+  SloEvaluation,
+  SloObjective,
+  SloSeverity,
+} from '@/src/types/slo';
+
+export const DEFAULT_SLO_POLICY: BurnRateAlertPolicy = {
+  pageBurnRate: 14.4,
+  ticketBurnRate: 6,
+  latencyP99Ms: 100,
+};
+
+export const SYSTEM_SLO_OBJECTIVES: SloObjective[] = [
+  {
+    id: 'platform-availability',
+    name: 'Platform Availability',
+    service: 'verinode-platform',
+    sliType: 'availability',
+    target: 0.9999,
+    windowDays: 30,
+    description: '99.99% successful critical requests across frontend and API dependencies.',
+  },
+  {
+    id: 'critical-path-latency',
+    name: 'Critical Path Latency',
+    service: 'critical-user-flows',
+    sliType: 'latency',
+    target: 0.99,
+    windowDays: 30,
+    description: 'P99 latency for wallet, validator, and monitoring critical paths stays below 100ms.',
+  },
+];
+
+const WINDOW_HOURS: Record<SliWindowSample['window'], number> = {
+  '5m': 5 / 60,
+  '30m': 0.5,
+  '1h': 1,
+  '6h': 6,
+  '24h': 24,
+};
+
+function clamp(value: number, min = 0, max = Number.POSITIVE_INFINITY): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+export function calculateAvailability(goodEvents: number, totalEvents: number): number {
+  if (totalEvents <= 0) return 1;
+  return clamp(goodEvents / totalEvents, 0, 1);
+}
+
+export function calculateBurnRate(
+  objective: SloObjective,
+  sample: SliWindowSample,
+): number {
+  const errorBudgetRatio = 1 - objective.target;
+  if (errorBudgetRatio <= 0) return 0;
+
+  if (objective.sliType === 'latency') {
+    const latencyViolation = sample.p99LatencyMs !== undefined && sample.p99LatencyMs > DEFAULT_SLO_POLICY.latencyP99Ms;
+    if (!latencyViolation) return 0;
+  }
+
+  const observed = calculateAvailability(sample.goodEvents, sample.totalEvents);
+  const observedErrorRatio = 1 - observed;
+  return clamp(observedErrorRatio / errorBudgetRatio);
+}
+
+export function deriveSloSeverity(
+  burnRate: number,
+  policy: BurnRateAlertPolicy = DEFAULT_SLO_POLICY,
+): SloSeverity {
+  if (burnRate >= policy.pageBurnRate) return 'critical';
+  if (burnRate >= policy.ticketBurnRate) return 'warning';
+  return 'healthy';
+}
+
+export function estimateTimeToExhaustionHours(
+  objective: SloObjective,
+  burnRate: number,
+  consumedRatio: number,
+): number | null {
+  if (burnRate <= 0 || consumedRatio >= 1) return consumedRatio >= 1 ? 0 : null;
+  const remainingRatio = Math.max(0, 1 - consumedRatio);
+  return (remainingRatio * objective.windowDays * 24) / burnRate;
+}
+
+export function evaluateSloWindow(
+  objective: SloObjective,
+  sample: SliWindowSample,
+  policy: BurnRateAlertPolicy = DEFAULT_SLO_POLICY,
+): SloEvaluation {
+  const observed = calculateAvailability(sample.goodEvents, sample.totalEvents);
+  const burnRate = calculateBurnRate(objective, sample);
+  const windowHours = WINDOW_HOURS[sample.window];
+  const windowBudgetRatio = windowHours / (objective.windowDays * 24);
+  const consumedRatio = clamp(burnRate * windowBudgetRatio, 0, 1);
+  const severity = deriveSloSeverity(burnRate, policy);
+  const reasons: string[] = [];
+
+  if (objective.sliType === 'latency' && sample.p99LatencyMs !== undefined && sample.p99LatencyMs > policy.latencyP99Ms) {
+    reasons.push(`P99 latency ${sample.p99LatencyMs}ms exceeds ${policy.latencyP99Ms}ms target`);
+  }
+  if (observed < objective.target) {
+    reasons.push(`Observed SLI ${(observed * 100).toFixed(3)}% below ${(objective.target * 100).toFixed(2)}% objective`);
+  }
+  if (severity !== 'healthy') {
+    reasons.push(`${burnRate.toFixed(1)}x error-budget burn rate requires ${severity === 'critical' ? 'paging' : 'ticket'} response`);
+  }
+
+  return {
+    objective,
+    sample,
+    observed,
+    errorBudgetConsumedRatio: consumedRatio,
+    burnRate,
+    timeToExhaustionHours: estimateTimeToExhaustionHours(objective, burnRate, consumedRatio),
+    severity,
+    reasons,
+  };
+}
+
+export function generateDemoSloEvaluations(now = Date.now()): SloEvaluation[] {
+  const [availability, latency] = SYSTEM_SLO_OBJECTIVES;
+  return [
+    evaluateSloWindow(availability, { window: '1h', goodEvents: 999_920, totalEvents: 1_000_000, capturedAt: now }),
+    evaluateSloWindow(availability, { window: '6h', goodEvents: 5_999_300, totalEvents: 6_000_000, capturedAt: now }),
+    evaluateSloWindow(latency, { window: '30m', goodEvents: 46_000, totalEvents: 50_000, p99LatencyMs: 118, capturedAt: now }),
+    evaluateSloWindow(latency, { window: '24h', goodEvents: 2_399_850, totalEvents: 2_400_000, p99LatencyMs: 92, capturedAt: now }),
+  ];
+}

--- a/src/types/slo.ts
+++ b/src/types/slo.ts
@@ -1,0 +1,40 @@
+// Service Level Objective monitoring and burn-rate alert types.
+
+export type SloWindow = '5m' | '30m' | '1h' | '6h' | '24h';
+export type SloSeverity = 'healthy' | 'warning' | 'critical';
+export type SliType = 'availability' | 'latency';
+
+export interface SloObjective {
+  id: string;
+  name: string;
+  service: string;
+  sliType: SliType;
+  target: number;
+  windowDays: number;
+  description: string;
+}
+
+export interface SliWindowSample {
+  window: SloWindow;
+  goodEvents: number;
+  totalEvents: number;
+  p99LatencyMs?: number;
+  capturedAt: number;
+}
+
+export interface SloEvaluation {
+  objective: SloObjective;
+  sample: SliWindowSample;
+  observed: number;
+  errorBudgetConsumedRatio: number;
+  burnRate: number;
+  timeToExhaustionHours: number | null;
+  severity: SloSeverity;
+  reasons: string[];
+}
+
+export interface BurnRateAlertPolicy {
+  pageBurnRate: number;
+  ticketBurnRate: number;
+  latencyP99Ms: number;
+}


### PR DESCRIPTION
### Motivation
- Provide system-wide SLO evaluation and burn-rate alerting for critical objectives (99.99% availability and <100ms P99 latency) so operators can see error-budget risk from the frontend dashboard.
- Ship a lightweight, demo-first implementation that can be wired to real telemetry later and included in the existing network status UI.

### Description
- Add typed SLO models in `src/types/slo.ts` and implement core SLO logic (availability, burn-rate, severity, time-to-exhaustion, demo evaluations) in `src/services/slo/sloMonitoringService.ts`.
- Add unit and performance-guard tests in `src/services/slo/sloMonitoringService.test.ts` that validate correctness and ensure the critical-path evaluation stays under the 100ms P99 target.
- Add a client-side SLO burn-rate dashboard component `src/components/slo/SloMonitoringDashboard.tsx` and mount it on the existing network page (`app/network/page.tsx`).
- Add an operator-facing runbook and architecture notes at `docs/monitoring/slo-burn-rate-runbook.md` describing alert thresholds, rollout strategy, security checklist, and response steps.

### Testing
- Ran unit tests with `npm run test:unit -- src/services/slo/sloMonitoringService.test.ts`, all tests passed (7/7) after an initial demo-data tweak to ensure demo evaluations show non-healthy items.
- Ran linting with `npm run lint` on the new/modified files and it completed without errors.
- Attempted production build with `npm run build` but the build was blocked by the environment failing to fetch the Google Fonts resource (Next.js font fetch error), preventing a full production verification.
- Attempted to capture a screenshot via Playwright but `npx playwright install chromium` failed to download browsers from the CDN (403), so end-to-end screenshot capture was blocked.

Closes #129