### PR TITLE
feat: Validator Exit Queue Position Tracker with Estimated Wait Time #103

### DIFF
--- a/app/validators/exit-queue/page.tsx
+++ b/app/validators/exit-queue/page.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { ExitQueueTracker } from '@/src/components/validators/ExitQueueTracker'
+
+const DEFAULT_VALIDATOR_INDEX = 100
+
+function ExitQueueRoute() {
+  const params = useSearchParams()
+  const raw = params.get('validator')
+  const parsed = Number(raw)
+  const validatorIndex =
+    Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_VALIDATOR_INDEX
+  const beaconNodeUrl = params.get('beacon') ?? undefined
+
+  return (
+    <main className="mx-auto min-h-screen max-w-4xl px-4 py-8">
+      <h1 className="mb-2 text-2xl font-bold text-white">Exit Queue Tracker</h1>
+      <p className="mb-6 text-sm text-slate-400">
+        Validator exit queue position, estimated wait time, and historical depth
+      </p>
+      <section className="rounded-3xl border border-white/10 bg-slate-900/80 p-6 text-white">
+        <ExitQueueTracker
+          validatorIndex={validatorIndex}
+          beaconNodeUrl={beaconNodeUrl}
+        />
+      </section>
+    </main>
+  )
+}
+
+export default function ValidatorExitQueuePage() {
+  return (
+    <div className="min-h-screen bg-slate-950">
+      <Suspense fallback={<div className="p-8 text-slate-400">Loading…</div>}>
+        <ExitQueueRoute />
+      </Suspense>
+    </div>
+  )
+}

--- a/src/components/validators/ChurnRateChart.tsx
+++ b/src/components/validators/ChurnRateChart.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { NetworkQueueSnapshot } from '@/src/types/exitQueue'
+import { EPOCH_MS } from '@/src/utils/epochTime'
+
+const VIEW_W = 600
+const VIEW_H = 100
+/** 7 days in milliseconds — window for the churn rate bar chart. */
+const WINDOW_MS = 7 * 24 * 60 * 60 * 1_000
+
+/**
+ * Bar chart of validators processed per epoch (min(queueDepth, churnLimit))
+ * over the last 7 days. Each bar represents one epoch; bars are grouped by day
+ * on the x-axis. Uses the same custom SVG approach as the rest of the codebase.
+ */
+export function ChurnRateChart({ samples }: { samples: NetworkQueueSnapshot[] }) {
+  const [hover, setHover] = useState<number | null>(null)
+
+  const { bars, maxChurn } = useMemo(() => {
+    const cutoff = Date.now() - WINDOW_MS
+    const recent = samples.filter((s) => s.timestamp >= cutoff)
+    if (recent.length === 0) return { bars: [], maxChurn: 0 }
+
+    const bars = recent.map((s) => ({
+      epoch: s.epoch,
+      timestamp: s.timestamp,
+      churn: Math.min(s.queueDepth, s.churnLimit),
+      churnLimit: s.churnLimit,
+    }))
+    const maxChurn = Math.max(...bars.map((b) => b.churn), 1)
+    return { bars, maxChurn }
+  }, [samples])
+
+  if (bars.length === 0) {
+    return (
+      <div className="flex h-28 items-center justify-center rounded-xl bg-slate-950/60 text-sm text-slate-400">
+        Building churn rate history…
+      </div>
+    )
+  }
+
+  const n = bars.length
+  const barW = VIEW_W / n
+
+  return (
+    <div className="relative space-y-1">
+      <p className="text-[11px] uppercase tracking-wide text-slate-500">
+        Churn rate · last 7 days
+      </p>
+      <div className="relative">
+        <svg
+          viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+          preserveAspectRatio="none"
+          className="h-28 w-full rounded-xl bg-slate-950/60"
+          onMouseMove={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect()
+            const frac = (e.clientX - rect.left) / rect.width
+            const idx = Math.floor(frac * n)
+            setHover(Math.max(0, Math.min(n - 1, idx)))
+          }}
+          onMouseLeave={() => setHover(null)}
+          role="img"
+          aria-label="Validator churn rate bar chart over last 7 days"
+        >
+          {bars.map((bar, i) => {
+            const barH = (bar.churn / maxChurn) * VIEW_H
+            return (
+              <rect
+                key={bar.epoch}
+                x={i * barW + 0.5}
+                y={VIEW_H - barH}
+                width={Math.max(1, barW - 1)}
+                height={barH}
+                fill="#a78bfa"
+                opacity={hover === null || hover === i ? 1 : 0.4}
+                vectorEffect="non-scaling-stroke"
+              />
+            )
+          })}
+        </svg>
+
+        {/* Tooltip */}
+        {hover !== null && bars[hover] && (
+          <div className="pointer-events-none absolute left-2 top-2 rounded-md border border-white/10 bg-slate-950/95 px-3 py-2 text-xs text-slate-100">
+            <div className="font-semibold">Epoch {bars[hover].epoch.toLocaleString()}</div>
+            <div className="text-violet-400">
+              Processed: {bars[hover].churn.toLocaleString()} validators
+            </div>
+            <div className="text-slate-400">
+              Churn limit: {bars[hover].churnLimit.toLocaleString()}/epoch
+            </div>
+            <div className="text-slate-500">
+              {new Date(bars[hover].timestamp).toLocaleString(undefined, {
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1.5 text-[11px] text-slate-600">
+        <span
+          className="inline-block h-2 w-2 rounded-sm"
+          style={{ backgroundColor: '#a78bfa' }}
+        />
+        Validators processed per epoch
+      </div>
+    </div>
+  )
+}

--- a/src/components/validators/ExitCompleteAlert.tsx
+++ b/src/components/validators/ExitCompleteAlert.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useState } from 'react'
+
+/**
+ * Congratulatory banner shown when a validator's exit is complete (position ≤ 0).
+ * Displays reactivation instructions and can be dismissed.
+ */
+export function ExitCompleteAlert({
+  validatorIndex,
+  exitEpoch,
+  onDismiss,
+}: {
+  validatorIndex: number
+  exitEpoch: number | null
+  onDismiss?: () => void
+}) {
+  const [dismissed, setDismissed] = useState(false)
+
+  if (dismissed) return null
+
+  const handleDismiss = () => {
+    setDismissed(true)
+    onDismiss?.()
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="rounded-2xl border border-emerald-500/30 bg-emerald-500/10 px-5 py-4 text-white"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 text-2xl" aria-hidden="true">
+            🎉
+          </span>
+          <div>
+            <h3 className="font-semibold text-emerald-300">
+              Validator #{validatorIndex} has exited
+            </h3>
+            {exitEpoch !== null && (
+              <p className="mt-0.5 text-sm text-emerald-200/80">
+                Exit completed at epoch {exitEpoch.toLocaleString()}
+              </p>
+            )}
+            <div className="mt-3 space-y-1.5 text-xs text-emerald-200/70">
+              <p className="font-semibold text-emerald-200">To reactivate this validator:</p>
+              <ol className="ml-4 list-decimal space-y-1">
+                <li>
+                  Wait for the full withdrawal to settle (withdrawable epoch must pass before
+                  the 32 ETH can be re-staked).
+                </li>
+                <li>
+                  Generate a new BLS key pair and obtain a new deposit data file via the{' '}
+                  <span className="font-mono text-emerald-300">ethereum/staking-deposit-cli</span>.
+                </li>
+                <li>
+                  Submit a new 32 ETH deposit transaction to the Ethereum deposit contract.
+                </li>
+                <li>
+                  Wait for the activation queue — your validator will receive a new index.
+                </li>
+              </ol>
+              <p className="mt-2">
+                For withdrawal credential changes (0x00 → 0x01), use the{' '}
+                <span className="font-mono text-emerald-300">BLSToExecutionChange</span> operation
+                before re-depositing.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss exit complete alert"
+          className="flex-shrink-0 rounded-lg p-1 text-emerald-400 hover:bg-emerald-500/20 hover:text-emerald-200"
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/validators/ExitNotification.tsx
+++ b/src/components/validators/ExitNotification.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+/**
+ * Toggle for push notification subscription when a validator is within 10
+ * positions of exit. Requests browser Notification permission on first enable.
+ * Renders nothing when the Notifications API is unavailable.
+ */
+export function ExitNotification({
+  validatorIndex,
+  enabled,
+  onToggle,
+}: {
+  validatorIndex: number
+  enabled: boolean
+  onToggle: () => void
+}) {
+  // Hide when the Notifications API is not supported (e.g., in SSR or Safari iOS).
+  if (typeof window !== 'undefined' && !('Notification' in window)) {
+    return null
+  }
+
+  const isBlocked =
+    typeof window !== 'undefined' &&
+    'Notification' in window &&
+    Notification.permission === 'denied'
+
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-white/10 bg-slate-950/60 px-4 py-3">
+      <div className="flex-1">
+        <p className="text-sm font-medium text-slate-200">
+          Exit notifications
+        </p>
+        <p className="text-xs text-slate-500">
+          {isBlocked
+            ? 'Notifications are blocked — allow them in browser settings'
+            : `Alert when validator #${validatorIndex} is within 10 positions of exit`}
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={isBlocked}
+        aria-pressed={enabled}
+        aria-label={
+          enabled
+            ? `Disable exit notifications for validator ${validatorIndex}`
+            : `Enable exit notifications for validator ${validatorIndex}`
+        }
+        className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50 ${
+          enabled ? 'bg-sky-500' : 'bg-slate-700'
+        }`}
+      >
+        <span
+          className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+            enabled ? 'translate-x-5' : 'translate-x-0'
+          }`}
+        />
+      </button>
+    </div>
+  )
+}

--- a/src/components/validators/ExitQueueTracker.tsx
+++ b/src/components/validators/ExitQueueTracker.tsx
@@ -1,0 +1,211 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useExitQueue } from '@/src/hooks/useExitQueue'
+import { QueuePosition } from '@/src/components/validators/QueuePosition'
+import { QueueDepthChart } from '@/src/components/validators/QueueDepthChart'
+import { ChurnRateChart } from '@/src/components/validators/ChurnRateChart'
+import { ExitNotification } from '@/src/components/validators/ExitNotification'
+import { ExitCompleteAlert } from '@/src/components/validators/ExitCompleteAlert'
+
+function formatDate(ms: number | null): string {
+  if (ms === null) return '—'
+  return new Date(ms).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function Stat({
+  label,
+  value,
+  tone = 'text-slate-100',
+}: {
+  label: string
+  value: string
+  tone?: string
+}) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
+      <p className="text-[11px] uppercase tracking-wide text-slate-500">{label}</p>
+      <p className={`mt-1 font-semibold ${tone}`}>{value}</p>
+    </div>
+  )
+}
+
+/**
+ * Full exit queue tracker for one validator. Wraps queue position gauge,
+ * historical queue depth area chart, 7-day churn rate bar chart, near-exit
+ * notification toggle, and exit-complete congratulatory alert.
+ *
+ * Poll interval: one epoch (≈6.4 min) aligned to epoch boundaries.
+ */
+export function ExitQueueTracker({
+  validatorIndex,
+  beaconNodeUrl,
+}: {
+  validatorIndex: number
+  beaconNodeUrl?: string
+}) {
+  const {
+    projection,
+    samples,
+    isLoading,
+    error,
+    isNearExit,
+    hasExited,
+    notificationsEnabled,
+    toggleNotifications,
+  } = useExitQueue(validatorIndex, { beaconNodeUrl })
+
+  const [exitDismissed, setExitDismissed] = useState(false)
+
+  const churnLimitDisplay = useMemo(() => {
+    if (!projection) return '—'
+    // Churn limit: max(4, active_validator_count / 1024)
+    return `${projection.churnLimit.toLocaleString()} / epoch`
+  }, [projection])
+
+  return (
+    <div className="space-y-5">
+      {/* Exit complete alert */}
+      {hasExited && !exitDismissed && (
+        <ExitCompleteAlert
+          validatorIndex={validatorIndex}
+          exitEpoch={projection?.projectedExitEpoch ?? null}
+          onDismiss={() => setExitDismissed(true)}
+        />
+      )}
+
+      {/* Near-exit alert strip */}
+      {isNearExit && !hasExited && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="flex items-center gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm"
+        >
+          <span className="h-2 w-2 animate-pulse rounded-full bg-amber-400" aria-hidden="true" />
+          <span className="text-amber-300">
+            Validator #{validatorIndex} is within {projection?.positionOffset ?? 0} positions of
+            exit — standby for withdrawal.
+          </span>
+        </div>
+      )}
+
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="font-mono text-sm font-semibold text-slate-200">
+            Validator #{validatorIndex}
+          </h3>
+          <p className="text-xs text-slate-500">Exit queue tracker</p>
+        </div>
+        {projection?.slashed && (
+          <span className="rounded-full bg-red-500/15 px-2.5 py-1 text-[10px] font-semibold text-red-400">
+            SLASHED · +4 EPOCH DELAY
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <p className="rounded-lg bg-red-500/10 px-4 py-2 text-sm text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+
+      {isLoading && samples.length === 0 ? (
+        <p className="py-10 text-center text-sm text-slate-400">Reading exit queue…</p>
+      ) : !projection ? (
+        <p className="py-10 text-center text-sm text-slate-400">No exit queue data available.</p>
+      ) : (
+        <div className="space-y-5">
+          {/* Gauge + metrics grid */}
+          <div className="grid gap-5 sm:grid-cols-[auto_1fr]">
+            {/* Queue position gauge */}
+            <div className="relative flex items-center justify-center">
+              <QueuePosition
+                position={projection.positionOffset}
+                queueDepth={projection.queueDepth}
+                epochsRemaining={projection.epochsRemaining}
+                projectedExitTimestamp={projection.projectedExitTimestamp}
+              />
+            </div>
+
+            {/* Key metrics */}
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <Stat
+                label="Position"
+                value={projection.positionOffset.toLocaleString()}
+                tone="text-sky-300"
+              />
+              <Stat
+                label="Queue depth"
+                value={projection.queueDepth.toLocaleString()}
+              />
+              <Stat
+                label="Churn limit"
+                value={churnLimitDisplay}
+              />
+              <Stat
+                label="Churn (EWMA)"
+                value={`${projection.ewmaChurn.toFixed(1)} / epoch`}
+              />
+              <Stat
+                label="Exit epoch"
+                value={projection.projectedExitEpoch?.toLocaleString() ?? '—'}
+                tone="text-sky-300"
+              />
+              <Stat
+                label="Estimated wait"
+                value={
+                  projection.epochsRemaining !== null
+                    ? (() => {
+                        const ms = projection.epochsRemaining * 384_000
+                        const days = ms / 86_400_000
+                        if (days < 1) {
+                          const hours = ms / 3_600_000
+                          return `${hours.toFixed(1)} h`
+                        }
+                        return `${days.toFixed(1)} d`
+                      })()
+                    : '—'
+                }
+              />
+            </div>
+          </div>
+
+          {/* Projected exit date */}
+          <div className="rounded-xl border border-white/10 bg-slate-950/60 px-4 py-3">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-slate-400">Projected exit</span>
+              <span className="font-semibold text-slate-100">
+                {formatDate(projection.projectedExitTimestamp)}
+              </span>
+            </div>
+            {projection.epochsRemaining !== null && (
+              <p className="mt-1 text-xs text-slate-500">
+                {projection.epochsRemaining.toLocaleString()} epochs remaining ·{' '}
+                current epoch {projection.currentEpoch?.toLocaleString() ?? '—'}
+              </p>
+            )}
+          </div>
+
+          {/* Historical queue depth chart */}
+          <QueueDepthChart samples={samples} />
+
+          {/* 7-day churn rate bar chart */}
+          <ChurnRateChart samples={samples} />
+
+          {/* Notification toggle */}
+          <ExitNotification
+            validatorIndex={validatorIndex}
+            enabled={notificationsEnabled}
+            onToggle={toggleNotifications}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/validators/QueueDepthChart.tsx
+++ b/src/components/validators/QueueDepthChart.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { NetworkQueueSnapshot } from '@/src/types/exitQueue'
+
+const VIEW_W = 600
+const VIEW_H = 140
+
+/**
+ * Area chart showing historical queue depth over time. Uses the same custom
+ * SVG approach as the rest of the codebase (no external charting library).
+ * Hover crosshair shows the epoch + depth at each data point.
+ */
+export function QueueDepthChart({ samples }: { samples: NetworkQueueSnapshot[] }) {
+  const [hover, setHover] = useState<number | null>(null)
+
+  const { area, line, minDepth, maxDepth } = useMemo(() => {
+    if (samples.length < 2) return { area: '', line: '', minDepth: 0, maxDepth: 0 }
+
+    const depths = samples.map((s) => s.queueDepth)
+    const minDepth = Math.min(...depths)
+    const maxDepth = Math.max(...depths)
+    const span = maxDepth - minDepth || 1
+    const n = samples.length
+
+    const pts = samples.map((s, i) => ({
+      x: (i / (n - 1)) * VIEW_W,
+      y: VIEW_H - ((s.queueDepth - minDepth) / span) * VIEW_H,
+    }))
+
+    const topLine = pts.map((p) => `${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(' ')
+    const area = `${topLine} ${VIEW_W.toFixed(2)},${VIEW_H} 0,${VIEW_H}`
+    const line = pts
+      .map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x.toFixed(2)},${p.y.toFixed(2)}`)
+      .join(' ')
+
+    return { area, line, minDepth, maxDepth }
+  }, [samples])
+
+  const toX = (i: number) => (samples.length < 2 ? 0 : (i / (samples.length - 1)) * VIEW_W)
+  const toY = (depth: number) => {
+    const span = maxDepth - minDepth || 1
+    return VIEW_H - ((depth - minDepth) / span) * VIEW_H
+  }
+
+  if (samples.length < 2) {
+    return (
+      <div className="flex h-36 items-center justify-center rounded-xl bg-slate-950/60 text-sm text-slate-400">
+        Building queue depth history…
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative space-y-1">
+      <p className="text-[11px] uppercase tracking-wide text-slate-500">Queue depth history</p>
+      <div className="relative">
+        <svg
+          viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+          preserveAspectRatio="none"
+          className="h-36 w-full rounded-xl bg-slate-950/60"
+          onMouseMove={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect()
+            const frac = (e.clientX - rect.left) / rect.width
+            const idx = Math.round(frac * (samples.length - 1))
+            setHover(Math.max(0, Math.min(samples.length - 1, idx)))
+          }}
+          onMouseLeave={() => setHover(null)}
+          role="img"
+          aria-label="Exit queue depth area chart"
+        >
+          {/* Filled area */}
+          {area && (
+            <polygon points={area} fill="rgba(245,158,11,0.12)" stroke="none" />
+          )}
+          {/* Line */}
+          {line && (
+            <path
+              d={line}
+              fill="none"
+              stroke="#f59e0b"
+              strokeWidth={2}
+              strokeLinejoin="round"
+              vectorEffect="non-scaling-stroke"
+            />
+          )}
+          {/* Crosshair */}
+          {hover !== null && samples[hover] && (
+            <>
+              <line
+                x1={toX(hover).toFixed(2)}
+                y1={0}
+                x2={toX(hover).toFixed(2)}
+                y2={VIEW_H}
+                stroke="rgba(248,250,252,0.4)"
+                strokeWidth={1}
+                strokeDasharray="3 3"
+                vectorEffect="non-scaling-stroke"
+              />
+              <circle
+                cx={toX(hover).toFixed(2)}
+                cy={toY(samples[hover].queueDepth).toFixed(2)}
+                r={4}
+                fill="#f59e0b"
+                vectorEffect="non-scaling-stroke"
+              />
+            </>
+          )}
+        </svg>
+
+        {/* Tooltip */}
+        {hover !== null && samples[hover] && (
+          <div className="pointer-events-none absolute left-2 top-2 rounded-md border border-white/10 bg-slate-950/95 px-3 py-2 text-xs text-slate-100">
+            <div className="font-semibold">Epoch {samples[hover].epoch.toLocaleString()}</div>
+            <div className="text-amber-400">
+              Depth: {samples[hover].queueDepth.toLocaleString()}
+            </div>
+            <div className="text-slate-400">
+              Churn: {samples[hover].churnLimit}/epoch
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-between text-[11px] text-slate-600">
+        <span>{minDepth.toLocaleString()}</span>
+        <span>{maxDepth.toLocaleString()}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/validators/QueuePosition.tsx
+++ b/src/components/validators/QueuePosition.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useMemo } from 'react'
+
+const GAUGE_R = 46
+const GAUGE_CIRCUMFERENCE = 2 * Math.PI * GAUGE_R
+
+/**
+ * SVG arc gauge: shows the validator's position within the total queue depth.
+ * Arc fill represents the fraction of the queue still ahead of this validator —
+ * the smaller the arc, the closer to the front.
+ */
+export function QueuePosition({
+  position,
+  queueDepth,
+  epochsRemaining,
+  projectedExitTimestamp,
+}: {
+  position: number
+  queueDepth: number
+  epochsRemaining: number | null
+  projectedExitTimestamp: number | null
+}) {
+  const ratio = useMemo(() => {
+    if (queueDepth <= 0) return 0
+    return Math.min(1, position / queueDepth)
+  }, [position, queueDepth])
+
+  const dashOffset = GAUGE_CIRCUMFERENCE - ratio * GAUGE_CIRCUMFERENCE
+
+  const eta = useMemo(() => {
+    if (projectedExitTimestamp === null) return null
+    const ms = projectedExitTimestamp - Date.now()
+    if (ms <= 0) return 'imminent'
+    const minutes = ms / 60_000
+    if (minutes < 60) return `${Math.round(minutes)} min`
+    const hours = minutes / 60
+    if (hours < 48) return `${hours.toFixed(1)} h`
+    const days = hours / 24
+    return `${days.toFixed(1)} d`
+  }, [projectedExitTimestamp])
+
+  // Color: green when near front, amber mid-queue, red at the back.
+  const color = ratio < 0.2 ? '#22c55e' : ratio < 0.6 ? '#f59e0b' : '#ef4444'
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <svg
+        viewBox="0 0 120 120"
+        className="h-36 w-36 -rotate-90"
+        aria-label={`Queue position gauge: ${position.toLocaleString()} of ${queueDepth.toLocaleString()}`}
+        role="img"
+      >
+        {/* Track */}
+        <circle
+          cx="60"
+          cy="60"
+          r={GAUGE_R}
+          fill="none"
+          stroke="#1e293b"
+          strokeWidth="12"
+        />
+        {/* Fill */}
+        <circle
+          cx="60"
+          cy="60"
+          r={GAUGE_R}
+          fill="none"
+          stroke={color}
+          strokeWidth="12"
+          strokeLinecap="round"
+          strokeDasharray={GAUGE_CIRCUMFERENCE}
+          strokeDashoffset={dashOffset}
+          className="transition-all duration-500 ease-out"
+        />
+      </svg>
+
+      {/* Centre label overlay */}
+      <div className="absolute flex flex-col items-center justify-center" style={{ lineHeight: 1 }}>
+        <span className="text-2xl font-bold text-white">
+          {position.toLocaleString()}
+        </span>
+        <span className="text-[11px] text-slate-400">in queue</span>
+      </div>
+
+      <div className="mt-1 text-center">
+        <p className="text-sm font-semibold text-slate-200">
+          {position.toLocaleString()} / {queueDepth.toLocaleString()}
+        </p>
+        <p className="text-xs text-slate-500">
+          position · total depth
+        </p>
+        {eta !== null && (
+          <p className="mt-1 text-xs font-medium" style={{ color }}>
+            ETA: {eta}
+            {epochsRemaining !== null && ` · ${epochsRemaining.toLocaleString()} epochs`}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/tests/useExitQueue.test.ts
+++ b/src/hooks/tests/useExitQueue.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useExitQueue } from '../useExitQueue'
+
+// ---------------------------------------------------------------------------
+// Mock epoch time utilities so tests don't depend on wall-clock time
+// ---------------------------------------------------------------------------
+
+vi.mock('@/src/utils/epochTime', () => ({
+  EPOCH_MS: 384_000,
+  currentEpoch: vi.fn(() => 5),
+  epochStartMs: vi.fn((epoch: number) => epoch * 384_000),
+  msUntilNextEpoch: vi.fn(() => 999_999_999),
+  epochsToMs: vi.fn((n: number) => n * 384_000),
+}))
+
+// ---------------------------------------------------------------------------
+// Mock useBeaconRPC to return controlled demo data
+// ---------------------------------------------------------------------------
+
+const mockGetValidatorQueue = vi.fn()
+
+vi.mock('@/src/hooks/useBeaconRPC', () => ({
+  useBeaconRPC: () => ({ getValidatorQueue: mockGetValidatorQueue }),
+}))
+
+// ---------------------------------------------------------------------------
+// Mock zustand beacon store — controlled values updated per test
+// ---------------------------------------------------------------------------
+
+const mockIngest = vi.fn()
+let mockSamplesRef: { current: unknown[] } = { current: [] }
+let mockEwmaChurnRef: { current: number } = { current: 13 }
+
+vi.mock('@/src/store/beaconSlice', () => ({
+  useBeaconStore: (selector: (s: unknown) => unknown) => {
+    const fakeState = {
+      ingest: mockIngest,
+      get samples() {
+        return mockSamplesRef.current
+      },
+      ewmaSeries: [13],
+      get ewmaChurn() {
+        return mockEwmaChurnRef.current
+      },
+      get latest() {
+        const s = mockSamplesRef.current
+        return s.length ? s[s.length - 1] : null
+      },
+    }
+    return selector(fakeState)
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeNetwork(overrides: Partial<{ queueDepth: number; churnLimit: number }> = {}) {
+  return {
+    epoch: 5,
+    timestamp: 5 * 384_000,
+    queueDepth: overrides.queueDepth ?? 5000,
+    churnLimit: overrides.churnLimit ?? 13,
+    voluntaryExits: 2,
+    slashedExits: 0,
+  }
+}
+
+function makeQueueReading(overrides: Partial<{ positionOffset: number; slashed: boolean }> = {}) {
+  const { positionOffset = 500, slashed = false } = overrides
+  return {
+    network: makeNetwork(),
+    position: {
+      validatorIndex: 42,
+      epoch: 5,
+      positionOffset,
+      slashed,
+    },
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSamplesRef = { current: [makeNetwork()] }
+  mockEwmaChurnRef = { current: 13 }
+  mockGetValidatorQueue.mockResolvedValue(makeQueueReading())
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// SEED_EPOCHS is set to 40 in the hook, but currentEpoch() returns 5 in tests,
+// so the seed loop only runs 5 iterations (epochs 0–5).
+// ---------------------------------------------------------------------------
+
+describe('useExitQueue', () => {
+  it('starts loading and resolves projection after seed completes', async () => {
+    const { result } = renderHook(() => useExitQueue(42))
+
+    expect(result.current.isLoading).toBe(true)
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 10_000 })
+
+    expect(result.current.projection).not.toBeNull()
+    expect(result.current.projection?.positionOffset).toBe(500)
+    expect(result.current.projection?.churnLimit).toBe(13)
+  }, 15_000)
+
+  it('returns null projection for null validatorIndex', () => {
+    const { result } = renderHook(() => useExitQueue(null))
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.projection).toBeNull()
+    expect(mockGetValidatorQueue).not.toHaveBeenCalled()
+  })
+
+  it('isNearExit is true when positionOffset <= 10', async () => {
+    mockGetValidatorQueue.mockResolvedValue(makeQueueReading({ positionOffset: 7 }))
+    const { result } = renderHook(() => useExitQueue(42))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 10_000 })
+    expect(result.current.isNearExit).toBe(true)
+    expect(result.current.hasExited).toBe(false)
+  }, 15_000)
+
+  it('hasExited is true when positionOffset is 0', async () => {
+    mockGetValidatorQueue.mockResolvedValue(makeQueueReading({ positionOffset: 0 }))
+    const { result } = renderHook(() => useExitQueue(42))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 10_000 })
+    expect(result.current.hasExited).toBe(true)
+    expect(result.current.isNearExit).toBe(false)
+  }, 15_000)
+
+  it('isNearExit is false for position > 10', async () => {
+    mockGetValidatorQueue.mockResolvedValue(makeQueueReading({ positionOffset: 100 }))
+    const { result } = renderHook(() => useExitQueue(42))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 10_000 })
+    expect(result.current.isNearExit).toBe(false)
+  }, 15_000)
+
+  it('computes epochsRemaining from positionOffset and ewmaChurn', async () => {
+    // positionOffset=500, ewmaChurn=13 → ceil(500/13) = 39 epochs
+    const { result } = renderHook(() => useExitQueue(42))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 10_000 })
+    expect(result.current.projection?.epochsRemaining).toBe(39)
+  }, 15_000)
+
+  it('adds 4-epoch slashing delay when validator is slashed', async () => {
+    mockGetValidatorQueue.mockResolvedValue(makeQueueReading({ positionOffset: 500, slashed: true }))
+    const { result } = renderHook(() => useExitQueue(42))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 10_000 })
+    // ceil(500/13) + 4 = 39 + 4 = 43
+    expect(result.current.projection?.epochsRemaining).toBe(43)
+    expect(result.current.projection?.slashed).toBe(true)
+  }, 15_000)
+
+  it('surfaces error string on fetch failure', async () => {
+    mockGetValidatorQueue.mockRejectedValue(new Error('beacon node offline'))
+    const { result } = renderHook(() => useExitQueue(42))
+
+    await waitFor(() => expect(result.current.error).not.toBeNull(), { timeout: 10_000 })
+    expect(result.current.error).toContain('beacon node offline')
+  }, 15_000)
+
+  it('notificationsEnabled starts as false', () => {
+    const { result } = renderHook(() => useExitQueue(42))
+    expect(result.current.notificationsEnabled).toBe(false)
+  })
+
+  it('toggleNotifications enables notifications when Notification API is granted', async () => {
+    // Simulate Notification API available and already granted — no async requestPermission needed
+    Object.defineProperty(window, 'Notification', {
+      value: { permission: 'granted' },
+      configurable: true,
+      writable: true,
+    })
+
+    const { result } = renderHook(() => useExitQueue(42))
+
+    // Wait for loading to complete before calling toggleNotifications
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 10_000 })
+
+    expect(result.current.notificationsEnabled).toBe(false)
+
+    act(() => {
+      result.current.toggleNotifications()
+    })
+
+    await waitFor(() => expect(result.current.notificationsEnabled).toBe(true), { timeout: 5_000 })
+  }, 20_000)
+
+  it('clears projection when validatorIndex changes', async () => {
+    const { result, rerender } = renderHook(
+      ({ idx }: { idx: number | null }) => useExitQueue(idx),
+      { initialProps: { idx: 42 } },
+    )
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 10_000 })
+    expect(result.current.projection).not.toBeNull()
+
+    act(() => {
+      rerender({ idx: 99 })
+    })
+
+    // After rerender the position should be cleared (null projection while loading).
+    expect(result.current.projection).toBeNull()
+  }, 15_000)
+
+  it('ingests network snapshots into the beacon store', async () => {
+    renderHook(() => useExitQueue(42))
+
+    await waitFor(() => expect(mockIngest).toHaveBeenCalled(), { timeout: 10_000 })
+    expect(mockIngest).toHaveBeenCalledWith(
+      expect.objectContaining({ epoch: 5, queueDepth: 5000 }),
+    )
+  }, 15_000)
+})

--- a/src/hooks/useExitQueue.ts
+++ b/src/hooks/useExitQueue.ts
@@ -1,0 +1,212 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type {
+  ExitQueueProjection,
+  NetworkQueueSnapshot,
+  ValidatorQueuePosition,
+} from '@/src/types/exitQueue'
+import { useBeaconRPC } from '@/src/hooks/useBeaconRPC'
+import { useBeaconStore } from '@/src/store/beaconSlice'
+import { EPOCH_MS, currentEpoch, epochStartMs, msUntilNextEpoch } from '@/src/utils/epochTime'
+
+const SLASHING_DELAY_EPOCHS = 4
+const SEED_EPOCHS = 40
+const NEAR_EXIT_THRESHOLD = 10
+
+interface UseExitQueueOptions {
+  beaconNodeUrl?: string
+  /** Enable near-exit notifications (default: false). */
+  notificationsEnabled?: boolean
+}
+
+export interface ExitQueueState {
+  projection: ExitQueueProjection | null
+  position: ValidatorQueuePosition | null
+  samples: NetworkQueueSnapshot[]
+  ewmaSeries: number[]
+  ewmaChurn: number
+  isLoading: boolean
+  error: string | null
+  /** Whether validator is within 10 positions of exit. */
+  isNearExit: boolean
+  /** Whether validator has exited (position <= 0). */
+  hasExited: boolean
+  notificationsEnabled: boolean
+  toggleNotifications: () => void
+}
+
+/**
+ * Unified exit queue hook: polls at epoch boundaries, feeds shared beacon
+ * store, projects exit ETA, and surfaces near-exit + completion state for
+ * alerting. Wraps `useExitQueuePosition` with notification toggle state.
+ */
+export function useExitQueue(
+  validatorIndex: number | null,
+  options: UseExitQueueOptions = {},
+): ExitQueueState {
+  const { beaconNodeUrl, notificationsEnabled: initialNotifications = false } = options
+
+  const rpc = useBeaconRPC(beaconNodeUrl)
+  const ingest = useBeaconStore((s) => s.ingest)
+  const samples = useBeaconStore((s) => s.samples)
+  const ewmaSeries = useBeaconStore((s) => s.ewmaSeries)
+  const ewmaChurn = useBeaconStore((s) => s.ewmaChurn)
+  const latest = useBeaconStore((s) => s.latest)
+
+  const [position, setPosition] = useState<ValidatorQueuePosition | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notificationsEnabled, setNotificationsEnabled] = useState(initialNotifications)
+  const [lastNotifiedPosition, setLastNotifiedPosition] = useState<number | null>(null)
+
+  // Clear stale position when validator changes (during render).
+  const [tracked, setTracked] = useState<number | null | undefined>(undefined)
+  if (tracked !== validatorIndex) {
+    setTracked(validatorIndex)
+    setPosition(null)
+    setLastNotifiedPosition(null)
+  }
+
+  const isNearExit = useMemo(
+    () => position !== null && position.positionOffset <= NEAR_EXIT_THRESHOLD && position.positionOffset > 0,
+    [position],
+  )
+
+  const hasExited = useMemo(
+    () => position !== null && position.positionOffset <= 0,
+    [position],
+  )
+
+  // Send notification when near exit (once per crossing of threshold).
+  useEffect(() => {
+    if (!notificationsEnabled || !isNearExit || !position) return
+    if (lastNotifiedPosition !== null && lastNotifiedPosition <= NEAR_EXIT_THRESHOLD) return
+
+    if ('Notification' in window && Notification.permission === 'granted') {
+      new Notification('Validator Near Exit', {
+        body: `Validator #${validatorIndex} is within ${position.positionOffset} positions of exit`,
+        icon: '/icons/icon-192x192.svg',
+        tag: `exit-near-${validatorIndex}`,
+      })
+    }
+    setLastNotifiedPosition(position.positionOffset)
+  }, [isNearExit, notificationsEnabled, position, lastNotifiedPosition, validatorIndex])
+
+  // Send notification when exit complete (once).
+  useEffect(() => {
+    if (!notificationsEnabled || !hasExited || !position) return
+    if (lastNotifiedPosition !== null && lastNotifiedPosition <= 0) return
+
+    if ('Notification' in window && Notification.permission === 'granted') {
+      new Notification('Validator Exit Complete', {
+        body: `Validator #${validatorIndex} has successfully exited`,
+        icon: '/icons/icon-192x192.svg',
+        tag: `exit-complete-${validatorIndex}`,
+      })
+    }
+    setLastNotifiedPosition(0)
+  }, [hasExited, notificationsEnabled, position, lastNotifiedPosition, validatorIndex])
+
+  const toggleNotifications = useCallback(async () => {
+    if (!notificationsEnabled && 'Notification' in window) {
+      // Request permission if not yet granted.
+      if (Notification.permission === 'default') {
+        const permission = await Notification.requestPermission()
+        if (permission === 'granted') {
+          setNotificationsEnabled(true)
+        }
+      } else if (Notification.permission === 'granted') {
+        setNotificationsEnabled(true)
+      }
+    } else {
+      setNotificationsEnabled(false)
+    }
+  }, [notificationsEnabled])
+
+  useEffect(() => {
+    if (validatorIndex === null) return
+
+    let cancelled = false
+    let interval: number | undefined
+
+    const poll = async (epoch: number) => {
+      try {
+        const reading = await rpc.getValidatorQueue(validatorIndex, epoch)
+        if (cancelled) return
+        ingest(reading.network)
+        setPosition(reading.position)
+        setError(null)
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to read exit queue')
+      }
+    }
+
+    const run = async () => {
+      setIsLoading(true)
+      setError(null)
+      const cur = currentEpoch(Date.now())
+      for (let epoch = Math.max(0, cur - SEED_EPOCHS + 1); epoch <= cur; epoch++) {
+        if (cancelled) return
+        await poll(epoch)
+      }
+      if (!cancelled) setIsLoading(false)
+    }
+
+    run()
+
+    // Poll at epoch boundaries (≈6.4 min).
+    const timeout = window.setTimeout(() => {
+      poll(currentEpoch(Date.now()))
+      interval = window.setInterval(() => poll(currentEpoch(Date.now())), EPOCH_MS)
+    }, msUntilNextEpoch(Date.now()))
+
+    return () => {
+      cancelled = true
+      window.clearTimeout(timeout)
+      if (interval !== undefined) window.clearInterval(interval)
+    }
+  }, [validatorIndex, rpc, ingest])
+
+  const projection = useMemo<ExitQueueProjection | null>(() => {
+    if (!position) return null
+
+    let epochsRemaining: number | null = null
+    let projectedExitEpoch: number | null = null
+    let projectedExitTimestamp: number | null = null
+
+    if (ewmaChurn > 0) {
+      epochsRemaining =
+        Math.ceil(position.positionOffset / ewmaChurn) +
+        (position.slashed ? SLASHING_DELAY_EPOCHS : 0)
+      projectedExitEpoch = position.epoch + epochsRemaining
+      projectedExitTimestamp = epochStartMs(projectedExitEpoch)
+    }
+
+    return {
+      currentEpoch: position.epoch,
+      positionOffset: position.positionOffset,
+      queueDepth: latest?.queueDepth ?? 0,
+      churnLimit: latest?.churnLimit ?? 0,
+      ewmaChurn,
+      slashed: position.slashed,
+      epochsRemaining,
+      projectedExitEpoch,
+      projectedExitTimestamp,
+    }
+  }, [position, latest, ewmaChurn])
+
+  return {
+    projection,
+    position,
+    samples,
+    ewmaSeries,
+    ewmaChurn,
+    isLoading,
+    error,
+    isNearExit,
+    hasExited,
+    notificationsEnabled,
+    toggleNotifications,
+  }
+}


### PR DESCRIPTION
## Summary

Implements the validator exit queue tracker as specified in issue #103.

closes #103

## Changes

### New hook
- **src/hooks/useExitQueue.ts** — Unified exit queue hook. Polls at epoch boundaries (~6.4 min), feeds the shared \eaconSlice\ store, derives an \ExitQueueProjection\ from position + EWMA churn, and exposes \isNearExit\ (position ≤ 10), \hasExited\ (position = 0), and a \	oggleNotifications\ callback that requests \Notification\ permission and sends browser push alerts.

### New components
- **\QueuePosition\** — SVG arc gauge (r=46, consistent with \FinalityHealthGauge\ and \DVTClusterGauge\) showing validator position vs total queue depth; color-coded green/amber/red based on proximity to front.
- **\QueueDepthChart\** — Custom SVG area chart for historical queue depth over time; hover crosshair tooltip with epoch + depth.
- **\ChurnRateChart\** — Custom SVG bar chart of validators processed per epoch (\min(queueDepth, churnLimit)\) over the last 7 days.
- **\ExitNotification\** — Accessible toggle switch to subscribe to browser push notifications when validator is within 10 positions of exit.
- **\ExitCompleteAlert\** — Dismissible congratulatory banner when validator exits, with step-by-step reactivation instructions.
- **\ExitQueueTracker\** — Orchestrator component wiring all the above, with near-exit alert strip and slashing delay badge.

### New page
- **\pp/validators/exit-queue/page.tsx\** — Route at \/validators/exit-queue?validator=N&beacon=URL\, consistent with existing validator page conventions.

### Tests
- **\src/hooks/tests/useExitQueue.test.ts\** — 12 unit tests: loading lifecycle, projection math (position/churn/slashing delay), near-exit and exit detection, error surfacing, notification toggle, and validator index change behaviour.

### Build tooling
- **\itest.config.ts\** — Added \@/src\ alias so hook imports using the \@/src/...\ path convention resolve correctly in the Vite test environment.

## Testing / Validation
- \
px tsc --noEmit --skipLibCheck\ → ✅ zero errors
- \
px vitest run src/hooks/tests/useExitQueue.test.ts\ → ✅ 12/12 tests pass
- \
px next build\ → ✅ all 14 routes compiled, \/validators/exit-queue\ route generated

## Linked issue
https://github.com/VeriNode-Labs/VeriNode-Frontend/issues/103