### PR TITLE
feat: Node Operator Dashboard with real-time validator performance metrics

### DIFF
--- a/app/operator/page.tsx
+++ b/app/operator/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { OperatorDashboard } from '@/src/components/operator/OperatorDashboard';
+
+export default function OperatorPage() {
+  return (
+    <main className="min-h-screen bg-white dark:bg-zinc-950">
+      <OperatorDashboard />
+    </main>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "chartjs-adapter-date-fns": "^3.0.0",
         "date-fns": "^4.4.0",
         "isomorphic-dompurify": "^2.36.0",
+        "lightweight-charts": "^5.2.1",
         "next": "16.1.6",
         "qrcode": "^1.5.4",
         "react": "19.2.3",
@@ -61,6 +62,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -382,6 +397,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -1786,6 +1811,112 @@
         }
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2127,6 +2258,17 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@playwright/test": {
       "version": "1.61.0",
@@ -3627,16 +3769,50 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+      "integrity": "sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.7",
+        "vitest": "3.2.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
-      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -3645,13 +3821,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
-      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.6",
+        "@vitest/spy": "3.2.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -3672,9 +3848,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
-      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3685,13 +3861,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
-      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.6",
+        "@vitest/utils": "3.2.7",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -3700,13 +3876,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
-      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
+        "@vitest/pretty-format": "3.2.7",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -3715,9 +3891,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
-      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3728,13 +3904,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
-      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
+        "@vitest/pretty-format": "3.2.7",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -4022,6 +4198,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4807,6 +5002,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
@@ -5558,6 +5760,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
@@ -5778,6 +5986,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -5945,6 +6170,28 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5956,6 +6203,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -7113,6 +7386,60 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -7129,6 +7456,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -7594,6 +7937,15 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lightweight-charts": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.2.1.tgz",
+      "integrity": "sha512-IVwoK1RLFiLPubaKIjNbtjWLnpPMqiABSrTay6whmNa8L1+19292VtHJ+BWyPUuLCwF0tcQlhEWd1CLB2a1nsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7665,6 +8017,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7748,6 +8141,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mrmime": {
@@ -8279,6 +8682,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8330,6 +8740,30 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -9256,6 +9690,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -9379,6 +9836,20 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9517,6 +9988,60 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tinybench": {
@@ -10666,20 +11191,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
-      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.6",
-        "@vitest/mocker": "3.2.6",
-        "@vitest/pretty-format": "^3.2.6",
-        "@vitest/runner": "3.2.6",
-        "@vitest/snapshot": "3.2.6",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -10709,8 +11234,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.6",
-        "@vitest/ui": "3.2.6",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -11021,6 +11546,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chartjs-adapter-date-fns": "^3.0.0",
     "date-fns": "^4.4.0",
     "isomorphic-dompurify": "^2.36.0",
+    "lightweight-charts": "^5.2.1",
     "next": "16.1.6",
     "qrcode": "^1.5.4",
     "react": "19.2.3",

--- a/src/components/operator/AlertConfigPanel.tsx
+++ b/src/components/operator/AlertConfigPanel.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export interface AlertConfig {
+  /** Alert when missed attestations in the recent window exceed this count. */
+  missedAttestationsThreshold: number;
+  /** Alert when validator balance drops by more than this percent. */
+  balanceDropPct: number;
+  /** Alert when attestation effectiveness falls below this percent. */
+  effectivenessFloorPct: number;
+  channels: { push: boolean; email: boolean };
+}
+
+export const DEFAULT_ALERT_CONFIG: AlertConfig = {
+  missedAttestationsThreshold: 3,
+  balanceDropPct: 5,
+  effectivenessFloorPct: 90,
+  channels: { push: true, email: false },
+};
+
+const STORAGE_KEY = 'operator-alert-config';
+
+function loadConfig(): AlertConfig {
+  if (typeof window === 'undefined') return DEFAULT_ALERT_CONFIG;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_ALERT_CONFIG;
+    const parsed = JSON.parse(raw) as Partial<AlertConfig>;
+    return {
+      ...DEFAULT_ALERT_CONFIG,
+      ...parsed,
+      channels: { ...DEFAULT_ALERT_CONFIG.channels, ...parsed.channels },
+    };
+  } catch {
+    return DEFAULT_ALERT_CONFIG;
+  }
+}
+
+function Slider({
+  id,
+  label,
+  min,
+  max,
+  step,
+  value,
+  suffix,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  suffix: string;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <label htmlFor={id} className="text-sm text-zinc-600 dark:text-zinc-300">
+          {label}
+        </label>
+        <span className="text-sm font-medium tabular-nums text-zinc-900 dark:text-zinc-50">
+          {value}
+          {suffix}
+        </span>
+      </div>
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="mt-1 w-full accent-blue-600"
+      />
+    </div>
+  );
+}
+
+export interface AlertConfigPanelProps {
+  initialConfig?: AlertConfig;
+  onChange?: (config: AlertConfig) => void;
+}
+
+/** User-configurable alert thresholds + notification channels (persisted). */
+export function AlertConfigPanel({ initialConfig, onChange }: AlertConfigPanelProps) {
+  const [config, setConfig] = useState<AlertConfig>(initialConfig ?? DEFAULT_ALERT_CONFIG);
+
+  // Hydrate from storage on mount. Reading localStorage during render would
+  // cause an SSR/client hydration mismatch, so it is deferred to an effect.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing from an external source (localStorage), not deriving from props/state
+    if (!initialConfig) setConfig(loadConfig());
+  }, [initialConfig]);
+
+  const update = useCallback(
+    (patch: Partial<AlertConfig>) => {
+      setConfig((prev) => {
+        const next: AlertConfig = {
+          ...prev,
+          ...patch,
+          channels: { ...prev.channels, ...patch.channels },
+        };
+        if (typeof window !== 'undefined') {
+          window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        }
+        onChange?.(next);
+        return next;
+      });
+    },
+    [onChange],
+  );
+
+  return (
+    <section
+      aria-label="Alert configuration"
+      className="rounded-xl border bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900"
+    >
+      <h3 className="mb-3 text-sm font-medium text-zinc-700 dark:text-zinc-200">Alert Thresholds</h3>
+      <div className="space-y-4">
+        <Slider
+          id="alert-missed-attestations"
+          label="Missed attestations"
+          min={1}
+          max={20}
+          step={1}
+          value={config.missedAttestationsThreshold}
+          suffix=""
+          onChange={(v) => update({ missedAttestationsThreshold: v })}
+        />
+        <Slider
+          id="alert-balance-drop"
+          label="Balance drop"
+          min={1}
+          max={50}
+          step={1}
+          value={config.balanceDropPct}
+          suffix="%"
+          onChange={(v) => update({ balanceDropPct: v })}
+        />
+        <Slider
+          id="alert-effectiveness-floor"
+          label="Effectiveness floor"
+          min={50}
+          max={100}
+          step={1}
+          value={config.effectivenessFloorPct}
+          suffix="%"
+          onChange={(v) => update({ effectivenessFloorPct: v })}
+        />
+      </div>
+
+      <fieldset className="mt-4">
+        <legend className="text-sm text-zinc-600 dark:text-zinc-300">Notification channels</legend>
+        <div className="mt-2 flex gap-4">
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={config.channels.push}
+              onChange={(e) => update({ channels: { ...config.channels, push: e.target.checked } })}
+              className="accent-blue-600"
+            />
+            Push
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={config.channels.email}
+              onChange={(e) => update({ channels: { ...config.channels, email: e.target.checked } })}
+              className="accent-blue-600"
+            />
+            Email
+          </label>
+        </div>
+      </fieldset>
+    </section>
+  );
+}

--- a/src/components/operator/ExportButton.tsx
+++ b/src/components/operator/ExportButton.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { OperatorHistory, TimeRange } from '@/src/types/operator';
+import { buildMetricsCsv, exportFilename } from '@/src/lib/operatorExport';
+
+export interface ExportButtonProps {
+  history: OperatorHistory;
+  timeRange: TimeRange;
+  disabled?: boolean;
+}
+
+/** Downloads a CSV of performance metrics for the currently-selected range. */
+export function ExportButton({ history, timeRange, disabled }: ExportButtonProps) {
+  const [busy, setBusy] = useState(false);
+
+  const handleExport = useCallback(() => {
+    setBusy(true);
+    try {
+      const csv = buildMetricsCsv(history, timeRange);
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = exportFilename();
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } finally {
+      setBusy(false);
+    }
+  }, [history, timeRange]);
+
+  const noData =
+    history.balances.length === 0 && history.attestationEffectiveness.length === 0;
+
+  return (
+    <button
+      type="button"
+      onClick={handleExport}
+      disabled={disabled || busy || noData}
+      className="inline-flex items-center gap-2 rounded-lg border bg-white px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
+      aria-label="Export performance metrics as CSV"
+      title={noData ? 'No data to export in the selected range' : 'Export CSV'}
+    >
+      {busy ? 'Exporting…' : 'Export CSV'}
+    </button>
+  );
+}

--- a/src/components/operator/OperatorDashboard.tsx
+++ b/src/components/operator/OperatorDashboard.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState } from 'react';
+import dynamic from 'next/dynamic';
+import type { TimeRange } from '@/src/types/operator';
+import { useOperatorMetrics } from '@/src/hooks/useOperatorMetrics';
+import { OperatorOverview } from '@/src/components/operator/OperatorOverview';
+import { TimeRangeSelector } from '@/src/components/operator/TimeRangeSelector';
+import { AlertConfigPanel } from '@/src/components/operator/AlertConfigPanel';
+import { ExportButton } from '@/src/components/operator/ExportButton';
+
+// Lightweight Charts needs the DOM; load the charts client-only.
+const PerformanceCharts = dynamic(
+  () => import('@/src/components/operator/PerformanceCharts').then((m) => m.PerformanceCharts),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[260px] animate-pulse rounded-xl border bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900" />
+    ),
+  },
+);
+
+export interface OperatorDashboardProps {
+  /** Live metrics WebSocket URL (defaults to NEXT_PUBLIC_OPERATOR_METRICS_WS). */
+  metricsUrl?: string;
+}
+
+/**
+ * Node Operator Dashboard: live validator performance metrics, health scoring,
+ * historical charts, alert configuration, and CSV export.
+ */
+export function OperatorDashboard({ metricsUrl }: OperatorDashboardProps) {
+  const [timeRange, setTimeRange] = useState<TimeRange>({ kind: 'preset', preset: '7d' });
+
+  const { metrics, health, history, isConnected } = useOperatorMetrics({ url: metricsUrl });
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 p-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">Operator Dashboard</h1>
+          <p className="text-sm text-zinc-500">Real-time validator performance</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          <ExportButton history={history} timeRange={timeRange} />
+        </div>
+      </header>
+
+      <OperatorOverview metrics={metrics} health={health} isConnected={isConnected} />
+
+      <PerformanceCharts history={history} timeRange={timeRange} />
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <AlertConfigPanel />
+      </div>
+    </div>
+  );
+}

--- a/src/components/operator/OperatorOverview.tsx
+++ b/src/components/operator/OperatorOverview.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { HealthScore, LiveOperatorMetrics } from '@/src/types/operator';
+
+/** Gwei (bigint) -> ETH string with fixed precision. */
+export function formatGweiAsEth(gwei: bigint, decimals = 4): string {
+  const GWEI_PER_ETH = BigInt(1_000_000_000);
+  const whole = gwei / GWEI_PER_ETH;
+  const frac = gwei % GWEI_PER_ETH;
+  const fracStr = frac.toString().padStart(9, '0').slice(0, decimals);
+  return `${whole.toString()}.${fracStr}`;
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded-xl border bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-semibold tabular-nums text-zinc-900 dark:text-zinc-50">
+        {value}
+      </div>
+      {sub ? <div className="mt-0.5 text-xs text-zinc-400">{sub}</div> : null}
+    </div>
+  );
+}
+
+function gradeColor(grade: HealthScore['grade']): string {
+  switch (grade) {
+    case 'excellent':
+      return 'text-green-600 dark:text-green-400';
+    case 'good':
+      return 'text-emerald-600 dark:text-emerald-400';
+    case 'fair':
+      return 'text-amber-600 dark:text-amber-400';
+    case 'poor':
+      return 'text-red-600 dark:text-red-400';
+  }
+}
+
+function gaugeStroke(grade: HealthScore['grade']): string {
+  switch (grade) {
+    case 'excellent':
+      return '#16a34a';
+    case 'good':
+      return '#059669';
+    case 'fair':
+      return '#d97706';
+    case 'poor':
+      return '#dc2626';
+  }
+}
+
+/** Circular health-score gauge (SVG, no external deps). */
+function HealthGauge({ health }: { health: HealthScore }) {
+  const radius = 52;
+  const circumference = 2 * Math.PI * radius;
+  const pct = Math.max(0, Math.min(100, health.score));
+  const offset = circumference * (1 - pct / 100);
+
+  return (
+    <div
+      className="flex flex-col items-center rounded-xl border bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900"
+      role="group"
+      aria-label={`Node health score ${health.score} out of 100, ${health.grade}`}
+    >
+      <div className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+        Node Health
+      </div>
+      <div className="relative mt-2 h-32 w-32">
+        <svg viewBox="0 0 128 128" className="h-full w-full -rotate-90">
+          <circle
+            cx="64"
+            cy="64"
+            r={radius}
+            fill="none"
+            strokeWidth="10"
+            className="stroke-zinc-200 dark:stroke-zinc-700"
+          />
+          <circle
+            cx="64"
+            cy="64"
+            r={radius}
+            fill="none"
+            strokeWidth="10"
+            strokeLinecap="round"
+            stroke={gaugeStroke(health.grade)}
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            style={{ transition: 'stroke-dashoffset 400ms ease' }}
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-3xl font-bold tabular-nums text-zinc-900 dark:text-zinc-50">
+            {health.score.toFixed(0)}
+          </span>
+          <span className={`text-xs font-medium capitalize ${gradeColor(health.grade)}`}>
+            {health.grade}
+          </span>
+        </div>
+      </div>
+      <dl className="mt-3 grid w-full grid-cols-2 gap-x-4 gap-y-1 text-xs">
+        <div className="flex justify-between">
+          <dt className="text-zinc-500">Attestation</dt>
+          <dd className="tabular-nums">{health.components.attestationEffectiveness.toFixed(0)}/40</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-zinc-500">Proposal</dt>
+          <dd className="tabular-nums">{health.components.proposalTimeliness.toFixed(0)}/30</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-zinc-500">Uptime</dt>
+          <dd className="tabular-nums">{health.components.uptime.toFixed(0)}/20</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-zinc-500">Peers</dt>
+          <dd className="tabular-nums">{health.components.peerCount.toFixed(0)}/10</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function EffectivenessBadge({ pct }: { pct: number }) {
+  const tone =
+    pct >= 95
+      ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+      : pct >= 85
+        ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200'
+        : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
+  return (
+    <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium tabular-nums ${tone}`}>
+      {pct.toFixed(1)}% effective
+    </span>
+  );
+}
+
+export interface OperatorOverviewProps {
+  metrics: LiveOperatorMetrics | null;
+  health: HealthScore | null;
+  isConnected: boolean;
+}
+
+/**
+ * Top section of the operator dashboard: live balance / epoch / slot /
+ * finalized-block cards, the composite health gauge, effectiveness badge, and
+ * queue position.
+ */
+export function OperatorOverview({ metrics, health, isConnected }: OperatorOverviewProps) {
+  const balanceEth = useMemo(
+    () => (metrics ? formatGweiAsEth(metrics.validatorBalanceGwei) : '—'),
+    [metrics],
+  );
+
+  if (!metrics) {
+    return (
+      <div className="rounded-xl border border-dashed p-8 text-center text-sm text-zinc-500 dark:border-zinc-700">
+        {isConnected ? 'Waiting for validator metrics…' : 'Connecting to metrics stream…'}
+      </div>
+    );
+  }
+
+  return (
+    <section aria-label="Operator overview" className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-50">Overview</h2>
+        <div className="flex items-center gap-2">
+          <EffectivenessBadge pct={metrics.effectivenessPct} />
+          <span className="flex items-center gap-1.5 text-xs text-zinc-500">
+            <span
+              className={`inline-block h-2 w-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-zinc-400'}`}
+              aria-hidden
+            />
+            {isConnected ? 'Live' : 'Reconnecting'}
+          </span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard label="Validator Balance" value={`${balanceEth} ETH`} />
+        <StatCard label="Current Epoch" value={metrics.currentEpoch.toLocaleString()} />
+        <StatCard label="Current Slot" value={metrics.currentSlot.toLocaleString()} />
+        <StatCard label="Finalized Block" value={metrics.finalizedBlock.toLocaleString()} />
+        <StatCard
+          label="Queue Position"
+          value={metrics.queuePosition == null ? 'Active' : `#${metrics.queuePosition.toLocaleString()}`}
+          sub={metrics.queuePosition == null ? 'Validator is active' : 'In activation queue'}
+        />
+        <StatCard label="Peers" value={metrics.peerCount.toLocaleString()} />
+        <StatCard label="Uptime" value={`${metrics.uptimePct.toFixed(2)}%`} />
+      </div>
+
+      {health ? (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+          <HealthGauge health={health} />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/operator/PerformanceCharts.tsx
+++ b/src/components/operator/PerformanceCharts.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useEffect, useMemo, useRef } from 'react';
+import {
+  AreaSeries,
+  ColorType,
+  createChart,
+  HistogramSeries,
+  type IChartApi,
+  type ISeriesApi,
+  type UTCTimestamp,
+} from 'lightweight-charts';
+import type { OperatorHistory, TimeRange } from '@/src/types/operator';
+import {
+  epochToUnixSeconds,
+  filterEpochPointsByRange,
+  filterTimestampPointsByRange,
+} from '@/src/lib/operatorTime';
+
+interface Point {
+  time: UTCTimestamp;
+  value: number;
+  color?: string;
+}
+
+/** Sort ascending by time and drop duplicate timestamps (lightweight-charts requires this). */
+function normalize(points: Point[]): Point[] {
+  const sorted = [...points].sort((a, b) => a.time - b.time);
+  const out: Point[] = [];
+  let lastTime = -1;
+  for (const p of sorted) {
+    if (p.time === lastTime) out[out.length - 1] = p;
+    else out.push(p);
+    lastTime = p.time;
+  }
+  return out;
+}
+
+function LwChart({
+  data,
+  kind,
+  height = 220,
+}: {
+  data: Point[];
+  kind: 'area' | 'histogram';
+  height?: number;
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const seriesRef = useRef<ISeriesApi<'Area'> | ISeriesApi<'Histogram'> | null>(null);
+
+  // Create the chart once.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const chart = createChart(el, {
+      height,
+      layout: {
+        background: { type: ColorType.Solid, color: 'transparent' },
+        textColor: '#71717a',
+        attributionLogo: false,
+      },
+      grid: {
+        vertLines: { color: 'rgba(113,113,122,0.1)' },
+        horzLines: { color: 'rgba(113,113,122,0.1)' },
+      },
+      rightPriceScale: { borderVisible: false },
+      timeScale: { borderVisible: false, timeVisible: true },
+      handleScroll: false,
+      handleScale: false,
+    });
+    chartRef.current = chart;
+
+    seriesRef.current =
+      kind === 'area'
+        ? chart.addSeries(AreaSeries, {
+            lineColor: '#3b82f6',
+            topColor: 'rgba(59,130,246,0.35)',
+            bottomColor: 'rgba(59,130,246,0.02)',
+            lineWidth: 2,
+          })
+        : chart.addSeries(HistogramSeries, { color: '#3b82f6' });
+
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (w) chart.applyOptions({ width: Math.floor(w) });
+    });
+    ro.observe(el);
+    chart.applyOptions({ width: el.clientWidth });
+
+    return () => {
+      ro.disconnect();
+      chart.remove();
+      chartRef.current = null;
+      seriesRef.current = null;
+    };
+  }, [kind, height]);
+
+  // Update data when it changes.
+  useEffect(() => {
+    const series = seriesRef.current;
+    if (!series) return;
+    series.setData(normalize(data));
+    chartRef.current?.timeScale().fitContent();
+  }, [data]);
+
+  return <div ref={containerRef} className="w-full" style={{ height }} />;
+}
+
+function ChartCard({
+  title,
+  empty,
+  children,
+}: {
+  title: string;
+  empty: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <h3 className="mb-2 text-sm font-medium text-zinc-700 dark:text-zinc-200">{title}</h3>
+      {empty ? (
+        <div className="flex h-[220px] items-center justify-center text-sm text-zinc-400">
+          No data in the selected range
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}
+
+const PROPOSAL_COLORS: Record<string, string> = {
+  included: '#16a34a',
+  missed: '#dc2626',
+  orphaned: '#d97706',
+};
+
+export interface PerformanceChartsProps {
+  history: OperatorHistory;
+  timeRange: TimeRange;
+}
+
+/**
+ * Historical performance charts (Lightweight Charts): validator balance (area),
+ * attestation effectiveness (bar), and a proposal timeline (colored bars by
+ * status). All three respect the shared time range.
+ */
+export function PerformanceCharts({ history, timeRange }: PerformanceChartsProps) {
+  const balancePoints = useMemo<Point[]>(() => {
+    return filterEpochPointsByRange(history.balances, timeRange).map((p) => ({
+      time: epochToUnixSeconds(p.epoch) as UTCTimestamp,
+      value: Number(p.balanceGwei) / 1e9,
+    }));
+  }, [history.balances, timeRange]);
+
+  const effectivenessPoints = useMemo<Point[]>(() => {
+    return filterEpochPointsByRange(history.attestationEffectiveness, timeRange).map((p) => ({
+      time: epochToUnixSeconds(p.epoch) as UTCTimestamp,
+      value: p.effectivenessPct,
+    }));
+  }, [history.attestationEffectiveness, timeRange]);
+
+  const proposalPoints = useMemo<Point[]>(() => {
+    return filterTimestampPointsByRange(history.proposals, timeRange).map((p) => ({
+      time: Math.floor(p.timestamp / 1000) as UTCTimestamp,
+      value: 1,
+      color: PROPOSAL_COLORS[p.status] ?? '#3b82f6',
+    }));
+  }, [history.proposals, timeRange]);
+
+  return (
+    <section aria-label="Performance charts" className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      <ChartCard title="Balance History (ETH)" empty={balancePoints.length === 0}>
+        <LwChart data={balancePoints} kind="area" />
+      </ChartCard>
+      <ChartCard title="Attestation Effectiveness (%)" empty={effectivenessPoints.length === 0}>
+        <LwChart data={effectivenessPoints} kind="histogram" />
+      </ChartCard>
+      <ChartCard title="Proposal Timeline" empty={proposalPoints.length === 0}>
+        <LwChart data={proposalPoints} kind="histogram" />
+      </ChartCard>
+    </section>
+  );
+}

--- a/src/components/operator/TimeRangeSelector.tsx
+++ b/src/components/operator/TimeRangeSelector.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState } from 'react';
+import type { TimeRange, TimeRangePreset } from '@/src/types/operator';
+
+const PRESETS: { key: TimeRangePreset; label: string }[] = [
+  { key: '24h', label: '24h' },
+  { key: '7d', label: '7d' },
+  { key: '30d', label: '30d' },
+];
+
+function toDateInput(ms: number): string {
+  // yyyy-mm-dd for <input type="date">
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+export interface TimeRangeSelectorProps {
+  value: TimeRange;
+  onChange: (range: TimeRange) => void;
+}
+
+/** Shared 24h / 7d / 30d / custom range control driving charts and export. */
+export function TimeRangeSelector({ value, onChange }: TimeRangeSelectorProps) {
+  const isPreset = value.kind === 'preset';
+  // Captured once on mount (lazy initializer) so render stays pure.
+  const [now] = useState(() => Date.now());
+  const customFrom = value.kind === 'custom' ? value.fromMs : now - 7 * 24 * 60 * 60 * 1000;
+  const customTo = value.kind === 'custom' ? value.toMs : now;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2" role="group" aria-label="Time range">
+      <div className="inline-flex overflow-hidden rounded-lg border dark:border-zinc-700">
+        {PRESETS.map((p) => {
+          const active = isPreset && value.preset === p.key;
+          return (
+            <button
+              key={p.key}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onChange({ kind: 'preset', preset: p.key })}
+              className={`px-3 py-1.5 text-sm font-medium transition-colors ${
+                active
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white text-zinc-600 hover:bg-zinc-50 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800'
+              }`}
+            >
+              {p.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        <label className="text-xs text-zinc-500" htmlFor="range-from">
+          From
+        </label>
+        <input
+          id="range-from"
+          type="date"
+          value={toDateInput(customFrom)}
+          max={toDateInput(customTo)}
+          onChange={(e) =>
+            onChange({ kind: 'custom', fromMs: new Date(e.target.value).getTime(), toMs: customTo })
+          }
+          className="rounded-md border px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+        />
+        <label className="text-xs text-zinc-500" htmlFor="range-to">
+          To
+        </label>
+        <input
+          id="range-to"
+          type="date"
+          value={toDateInput(customTo)}
+          min={toDateInput(customFrom)}
+          onChange={(e) =>
+            onChange({ kind: 'custom', fromMs: customFrom, toMs: new Date(e.target.value).getTime() })
+          }
+          className="rounded-md border px-2 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useOperatorMetrics.ts
+++ b/src/hooks/useOperatorMetrics.ts
@@ -1,0 +1,141 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { HealthScore, LiveOperatorMetrics } from '@/src/types/operator';
+import { computeHealthScore } from '@/src/lib/operatorHealth';
+
+/**
+ * Wire-format of a live metrics message. Numeric fields arrive as JSON numbers;
+ * the validator balance arrives as a string because JSON has no bigint.
+ */
+interface OperatorMetricsWireEvent {
+  type: 'operator-metrics';
+  metrics: Omit<LiveOperatorMetrics, 'validatorBalanceGwei' | 'updatedAt'> & {
+    validatorBalanceGwei: string;
+    updatedAt?: number;
+  };
+}
+
+function parseWireMetrics(evt: OperatorMetricsWireEvent): LiveOperatorMetrics {
+  const m = evt.metrics;
+  return {
+    currentEpoch: m.currentEpoch,
+    currentSlot: m.currentSlot,
+    finalizedBlock: m.finalizedBlock,
+    validatorBalanceGwei: BigInt(m.validatorBalanceGwei),
+    effectivenessPct: m.effectivenessPct,
+    queuePosition: m.queuePosition ?? null,
+    attestationEffectivenessPct: m.attestationEffectivenessPct,
+    proposalTimelinessPct: m.proposalTimelinessPct,
+    uptimePct: m.uptimePct,
+    peerCount: m.peerCount,
+    updatedAt: m.updatedAt ?? Date.now(),
+  };
+}
+
+export interface UseOperatorMetricsOptions {
+  /** WebSocket URL for live metrics. Defaults to NEXT_PUBLIC_OPERATOR_METRICS_WS. */
+  url?: string;
+  enabled?: boolean;
+  /** Healthy peer-count target for the health score. */
+  peerTarget?: number;
+}
+
+export interface UseOperatorMetricsResult {
+  metrics: LiveOperatorMetrics | null;
+  health: HealthScore | null;
+  isConnected: boolean;
+  error: string | null;
+}
+
+/**
+ * Live validator performance metrics over WebSocket, with the composite health
+ * score derived on each update. Auto-reconnects (5s) like the other stream
+ * hooks in this repo. Historical series for the charts are composed separately
+ * (see useOperatorHistory); this hook owns the real-time leg.
+ */
+export function useOperatorMetrics(
+  options: UseOperatorMetricsOptions = {},
+): UseOperatorMetricsResult {
+  const {
+    url = process.env.NEXT_PUBLIC_OPERATOR_METRICS_WS ?? '',
+    enabled = true,
+    peerTarget,
+  } = options;
+
+  const [metrics, setMetrics] = useState<LiveOperatorMetrics | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    if (!enabled || !url) return;
+    mountedRef.current = true;
+
+    function connect() {
+      if (!mountedRef.current) return;
+      let ws: WebSocket;
+      try {
+        ws = new WebSocket(url);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'WebSocket construction failed');
+        return;
+      }
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        if (!mountedRef.current) return;
+        setIsConnected(true);
+        setError(null);
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data) as OperatorMetricsWireEvent;
+          if (data.type === 'operator-metrics') {
+            setMetrics(parseWireMetrics(data));
+          }
+        } catch (err) {
+          console.error('[useOperatorMetrics] failed to parse message:', err);
+        }
+      };
+
+      ws.onerror = () => {
+        if (!mountedRef.current) return;
+        setError('WebSocket error');
+      };
+
+      ws.onclose = () => {
+        wsRef.current = null;
+        if (!mountedRef.current) return;
+        setIsConnected(false);
+        reconnectRef.current = setTimeout(connect, 5000);
+      };
+    }
+
+    connect();
+
+    return () => {
+      mountedRef.current = false;
+      if (reconnectRef.current) clearTimeout(reconnectRef.current);
+      wsRef.current?.close();
+      wsRef.current = null;
+    };
+  }, [url, enabled]);
+
+  const health = useMemo<HealthScore | null>(() => {
+    if (!metrics) return null;
+    return computeHealthScore({
+      attestationEffectivenessPct: metrics.attestationEffectivenessPct,
+      proposalTimelinessPct: metrics.proposalTimelinessPct,
+      uptimePct: metrics.uptimePct,
+      peerCount: metrics.peerCount,
+      peerTarget,
+    });
+  }, [metrics, peerTarget]);
+
+  return { metrics, health, isConnected, error };
+}

--- a/src/hooks/useOperatorMetrics.ts
+++ b/src/hooks/useOperatorMetrics.ts
@@ -1,7 +1,14 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { HealthScore, LiveOperatorMetrics } from '@/src/types/operator';
+import type {
+  AttestationEffectivenessPoint,
+  BalanceHistoryPoint,
+  HealthScore,
+  LiveOperatorMetrics,
+  OperatorHistory,
+  ProposalPoint,
+} from '@/src/types/operator';
 import { computeHealthScore } from '@/src/lib/operatorHealth';
 
 /**
@@ -33,26 +40,46 @@ function parseWireMetrics(evt: OperatorMetricsWireEvent): LiveOperatorMetrics {
   };
 }
 
+/** Insert/replace a point keyed by epoch, keeping ascending order and a cap. */
+function upsertByEpoch<T extends { epoch: number }>(prev: T[], next: T, max: number): T[] {
+  const idx = prev.findIndex((p) => p.epoch === next.epoch);
+  let out: T[];
+  if (idx >= 0) {
+    out = prev.slice();
+    out[idx] = next;
+  } else {
+    out = [...prev, next].sort((a, b) => a.epoch - b.epoch);
+  }
+  return out.length > max ? out.slice(out.length - max) : out;
+}
+
 export interface UseOperatorMetricsOptions {
   /** WebSocket URL for live metrics. Defaults to NEXT_PUBLIC_OPERATOR_METRICS_WS. */
   url?: string;
   enabled?: boolean;
   /** Healthy peer-count target for the health score. */
   peerTarget?: number;
+  /** Max points retained per historical series. */
+  maxHistory?: number;
+  /** Seed proposals (e.g. from a REST backfill); the live stream carries none. */
+  seedProposals?: ProposalPoint[];
 }
 
 export interface UseOperatorMetricsResult {
   metrics: LiveOperatorMetrics | null;
   health: HealthScore | null;
+  history: OperatorHistory;
   isConnected: boolean;
   error: string | null;
 }
 
 /**
  * Live validator performance metrics over WebSocket, with the composite health
- * score derived on each update. Auto-reconnects (5s) like the other stream
- * hooks in this repo. Historical series for the charts are composed separately
- * (see useOperatorHistory); this hook owns the real-time leg.
+ * score derived on each update and a rolling historical buffer accumulated for
+ * the charts. Auto-reconnects (5s) like the other stream hooks in this repo.
+ *
+ * History is accumulated inside the message handler (not a reactive effect) so
+ * updates stay a single render per message.
  */
 export function useOperatorMetrics(
   options: UseOperatorMetricsOptions = {},
@@ -61,9 +88,15 @@ export function useOperatorMetrics(
     url = process.env.NEXT_PUBLIC_OPERATOR_METRICS_WS ?? '',
     enabled = true,
     peerTarget,
+    maxHistory = 5000,
+    seedProposals,
   } = options;
 
   const [metrics, setMetrics] = useState<LiveOperatorMetrics | null>(null);
+  const [balances, setBalances] = useState<BalanceHistoryPoint[]>([]);
+  const [attestationEffectiveness, setAttestationEffectiveness] = useState<
+    AttestationEffectivenessPoint[]
+  >([]);
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -95,9 +128,24 @@ export function useOperatorMetrics(
       ws.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data) as OperatorMetricsWireEvent;
-          if (data.type === 'operator-metrics') {
-            setMetrics(parseWireMetrics(data));
-          }
+          if (data.type !== 'operator-metrics') return;
+          const parsed = parseWireMetrics(data);
+          setMetrics(parsed);
+          // Accumulate history here (event callback), not in a reactive effect.
+          setBalances((prev) =>
+            upsertByEpoch(
+              prev,
+              { epoch: parsed.currentEpoch, balanceGwei: parsed.validatorBalanceGwei },
+              maxHistory,
+            ),
+          );
+          setAttestationEffectiveness((prev) =>
+            upsertByEpoch(
+              prev,
+              { epoch: parsed.currentEpoch, effectivenessPct: parsed.attestationEffectivenessPct },
+              maxHistory,
+            ),
+          );
         } catch (err) {
           console.error('[useOperatorMetrics] failed to parse message:', err);
         }
@@ -124,7 +172,7 @@ export function useOperatorMetrics(
       wsRef.current?.close();
       wsRef.current = null;
     };
-  }, [url, enabled]);
+  }, [url, enabled, maxHistory]);
 
   const health = useMemo<HealthScore | null>(() => {
     if (!metrics) return null;
@@ -137,5 +185,10 @@ export function useOperatorMetrics(
     });
   }, [metrics, peerTarget]);
 
-  return { metrics, health, isConnected, error };
+  const history = useMemo<OperatorHistory>(
+    () => ({ balances, attestationEffectiveness, proposals: seedProposals ?? [] }),
+    [balances, attestationEffectiveness, seedProposals],
+  );
+
+  return { metrics, health, history, isConnected, error };
 }

--- a/src/lib/operatorExport.test.ts
+++ b/src/lib/operatorExport.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { buildMetricsCsv, exportFilename } from './operatorExport';
+import { epochToUnixMs } from './operatorTime';
+import type { OperatorHistory, TimeRange } from '@/src/types/operator';
+
+const NOW = epochToUnixMs(1000); // anchor "now" to epoch 1000's time
+
+const history: OperatorHistory = {
+  balances: [
+    { epoch: 998, balanceGwei: BigInt(32_000_000_000) },
+    { epoch: 999, balanceGwei: BigInt(32_100_000_000) },
+  ],
+  attestationEffectiveness: [
+    { epoch: 999, effectivenessPct: 98.5 },
+    { epoch: 1000, effectivenessPct: 97 },
+  ],
+  proposals: [],
+};
+
+const range: TimeRange = { kind: 'preset', preset: '30d' };
+
+describe('operatorExport', () => {
+  it('emits a header and one row per epoch present in either series', () => {
+    const csv = buildMetricsCsv(history, range, NOW);
+    const lines = csv.split('\n');
+    expect(lines[0]).toBe('epoch,datetime_utc,balance_eth,attestation_effectiveness_pct');
+    // epochs 998, 999, 1000 -> 3 data rows
+    expect(lines).toHaveLength(4);
+  });
+
+  it('joins balance and effectiveness by epoch, leaving gaps blank', () => {
+    const csv = buildMetricsCsv(history, range, NOW);
+    const rows = csv.split('\n').slice(1);
+    // epoch 998: balance only
+    expect(rows[0].startsWith('998,')).toBe(true);
+    expect(rows[0].endsWith(',32,')).toBe(true); // balance 32 ETH, effectiveness blank
+    // epoch 999: both
+    expect(rows[1]).toContain('32.1');
+    expect(rows[1].endsWith(',98.5')).toBe(true);
+    // epoch 1000: effectiveness only
+    expect(rows[2].startsWith('1000,')).toBe(true);
+    expect(rows[2].endsWith(',,97')).toBe(true);
+  });
+
+  it('produces a timestamped .csv filename', () => {
+    expect(exportFilename(0)).toMatch(/^operator-metrics-1970-01-01-00-00-00\.csv$/);
+  });
+});

--- a/src/lib/operatorExport.ts
+++ b/src/lib/operatorExport.ts
@@ -1,0 +1,53 @@
+// CSV export of operator performance metrics for compliance reporting.
+// Pure functions so the CSV shape is unit-testable without a DOM.
+
+import type { OperatorHistory, TimeRange } from '@/src/types/operator';
+import { epochToUnixMs, filterEpochPointsByRange } from '@/src/lib/operatorTime';
+
+function csvEscape(value: string): string {
+  if (/[",\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`;
+  return value;
+}
+
+/**
+ * Build a CSV of per-epoch performance metrics (balance + attestation
+ * effectiveness) within the selected time range. One row per epoch present in
+ * either series; missing values are left blank.
+ */
+export function buildMetricsCsv(
+  history: OperatorHistory,
+  range: TimeRange,
+  nowMs = Date.now(),
+): string {
+  const balances = filterEpochPointsByRange(history.balances, range, nowMs);
+  const effectiveness = filterEpochPointsByRange(history.attestationEffectiveness, range, nowMs);
+
+  const balanceByEpoch = new Map(balances.map((b) => [b.epoch, b.balanceGwei]));
+  const effByEpoch = new Map(effectiveness.map((e) => [e.epoch, e.effectivenessPct]));
+
+  const epochs = Array.from(new Set([...balanceByEpoch.keys(), ...effByEpoch.keys()])).sort(
+    (a, b) => a - b,
+  );
+
+  const header = ['epoch', 'datetime_utc', 'balance_eth', 'attestation_effectiveness_pct'];
+  const rows = epochs.map((epoch) => {
+    const gwei = balanceByEpoch.get(epoch);
+    const balanceEth = gwei === undefined ? '' : (Number(gwei) / 1e9).toString();
+    const eff = effByEpoch.get(epoch);
+    const datetime = new Date(epochToUnixMs(epoch)).toISOString();
+    return [
+      String(epoch),
+      datetime,
+      balanceEth,
+      eff === undefined ? '' : eff.toString(),
+    ];
+  });
+
+  return [header, ...rows].map((cols) => cols.map(csvEscape).join(',')).join('\n');
+}
+
+/** A stable, human-readable filename for an export. */
+export function exportFilename(nowMs = Date.now()): string {
+  const stamp = new Date(nowMs).toISOString().slice(0, 19).replace(/[:T]/g, '-');
+  return `operator-metrics-${stamp}.csv`;
+}

--- a/src/lib/operatorHealth.test.ts
+++ b/src/lib/operatorHealth.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clamp,
+  computeHealthScore,
+  gradeFor,
+  HEALTHY_PEER_TARGET,
+  normalizePeerCount,
+} from './operatorHealth';
+
+describe('operatorHealth', () => {
+  it('scores a perfect validator at 100 / excellent', () => {
+    const h = computeHealthScore({
+      attestationEffectivenessPct: 100,
+      proposalTimelinessPct: 100,
+      uptimePct: 100,
+      peerCount: HEALTHY_PEER_TARGET,
+    });
+    expect(h.score).toBe(100);
+    expect(h.grade).toBe('excellent');
+  });
+
+  it('applies the 40/30/20/10 weights', () => {
+    // Only attestation effectiveness at 100, everything else 0 -> 40.
+    const h = computeHealthScore({
+      attestationEffectivenessPct: 100,
+      proposalTimelinessPct: 0,
+      uptimePct: 0,
+      peerCount: 0,
+    });
+    expect(h.score).toBe(40);
+    expect(h.components.attestationEffectiveness).toBe(40);
+  });
+
+  it('normalizes peer count against the target and caps at 100', () => {
+    expect(normalizePeerCount(0)).toBe(0);
+    expect(normalizePeerCount(HEALTHY_PEER_TARGET)).toBe(100);
+    expect(normalizePeerCount(HEALTHY_PEER_TARGET * 2)).toBe(100); // capped
+    expect(normalizePeerCount(25, 50)).toBe(50);
+  });
+
+  it('clamps out-of-range inputs instead of over/under-scoring', () => {
+    const h = computeHealthScore({
+      attestationEffectivenessPct: 250,
+      proposalTimelinessPct: -50,
+      uptimePct: 100,
+      peerCount: 9999,
+    });
+    // attestation clamps to 100 (40), proposal clamps to 0 (0), uptime 100 (20),
+    // peers cap to 100 (10) => 70.
+    expect(h.score).toBe(70);
+  });
+
+  it('grades the boundaries', () => {
+    expect(gradeFor(90)).toBe('excellent');
+    expect(gradeFor(75)).toBe('good');
+    expect(gradeFor(50)).toBe('fair');
+    expect(gradeFor(49.9)).toBe('poor');
+  });
+
+  it('clamp handles NaN by returning the min', () => {
+    expect(clamp(Number.NaN, 0, 100)).toBe(0);
+  });
+});

--- a/src/lib/operatorHealth.ts
+++ b/src/lib/operatorHealth.ts
@@ -1,0 +1,89 @@
+// Composite node-health score for the operator dashboard.
+//
+// The score is a weighted blend of four inputs, per the dashboard spec:
+//   - attestation effectiveness  40%
+//   - proposal timeliness        30%
+//   - uptime                     20%
+//   - peer count                 10%
+//
+// The first three inputs are already percentages (0..100). Peer count is a raw
+// count, normalized against a healthy target so it contributes on the same
+// 0..100 scale.
+
+import type { HealthGrade, HealthScore } from '@/src/types/operator';
+
+export const HEALTH_WEIGHTS = {
+  attestationEffectiveness: 0.4,
+  proposalTimeliness: 0.3,
+  uptime: 0.2,
+  peerCount: 0.1,
+} as const;
+
+/**
+ * Peer count considered fully healthy. At or above this, the peer-count input
+ * scores 100; below it, it scales down linearly.
+ */
+export const HEALTHY_PEER_TARGET = 50;
+
+/** Clamp a number to the inclusive [min, max] range. */
+export function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+/** Normalize a raw peer count to a 0..100 health input. */
+export function normalizePeerCount(peerCount: number, target = HEALTHY_PEER_TARGET): number {
+  if (target <= 0) return 100;
+  return clamp((peerCount / target) * 100, 0, 100);
+}
+
+/** Map a 0..100 score to a coarse grade. */
+export function gradeFor(score: number): HealthGrade {
+  if (score >= 90) return 'excellent';
+  if (score >= 75) return 'good';
+  if (score >= 50) return 'fair';
+  return 'poor';
+}
+
+export interface HealthInputs {
+  attestationEffectivenessPct: number;
+  proposalTimelinessPct: number;
+  uptimePct: number;
+  peerCount: number;
+  /** Optional override for the healthy peer target (mainly for tests). */
+  peerTarget?: number;
+}
+
+/**
+ * Compute the composite health score (0..100) and its weighted components.
+ * All percentage inputs are clamped to [0, 100]; peer count is normalized.
+ */
+export function computeHealthScore(inputs: HealthInputs): HealthScore {
+  const attestation = clamp(inputs.attestationEffectivenessPct, 0, 100);
+  const proposal = clamp(inputs.proposalTimelinessPct, 0, 100);
+  const uptime = clamp(inputs.uptimePct, 0, 100);
+  const peers = normalizePeerCount(inputs.peerCount, inputs.peerTarget);
+
+  const components = {
+    attestationEffectiveness: attestation * HEALTH_WEIGHTS.attestationEffectiveness,
+    proposalTimeliness: proposal * HEALTH_WEIGHTS.proposalTimeliness,
+    uptime: uptime * HEALTH_WEIGHTS.uptime,
+    peerCount: peers * HEALTH_WEIGHTS.peerCount,
+  };
+
+  const score =
+    components.attestationEffectiveness +
+    components.proposalTimeliness +
+    components.uptime +
+    components.peerCount;
+
+  // Round to avoid floating-point noise; score stays within [0, 100] because
+  // each component is a clamped input times a weight, and weights sum to 1.
+  const rounded = Math.round(score * 10) / 10;
+
+  return {
+    score: rounded,
+    grade: gradeFor(rounded),
+    components,
+  };
+}

--- a/src/lib/operatorTime.test.ts
+++ b/src/lib/operatorTime.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  epochToUnixMs,
+  epochToUnixSeconds,
+  filterEpochPointsByRange,
+  MAINNET_GENESIS_UNIX,
+  SECONDS_PER_EPOCH,
+  timeRangeBounds,
+} from './operatorTime';
+
+describe('operatorTime', () => {
+  it('converts epoch to unix time from genesis', () => {
+    expect(epochToUnixSeconds(0)).toBe(MAINNET_GENESIS_UNIX);
+    expect(epochToUnixSeconds(1)).toBe(MAINNET_GENESIS_UNIX + SECONDS_PER_EPOCH);
+    expect(epochToUnixMs(0)).toBe(MAINNET_GENESIS_UNIX * 1000);
+  });
+
+  it('resolves preset ranges relative to now', () => {
+    const now = 1_000_000_000_000;
+    const { fromMs, toMs } = timeRangeBounds({ kind: 'preset', preset: '24h' }, now);
+    expect(toMs).toBe(now);
+    expect(fromMs).toBe(now - 24 * 60 * 60 * 1000);
+  });
+
+  it('normalizes custom ranges (swaps reversed bounds)', () => {
+    const b = timeRangeBounds({ kind: 'custom', fromMs: 500, toMs: 100 });
+    expect(b.fromMs).toBe(100);
+    expect(b.toMs).toBe(500);
+  });
+
+  it('filters epoch points to those inside the range', () => {
+    // ~225 epochs per day (86400 / 384). Anchor "now" at epoch 1000.
+    const now = epochToUnixMs(1000);
+    // epoch 10 is ~4.4 days before epoch 1000; epochs 999/1000 are within a day.
+    const points = [{ epoch: 10 }, { epoch: 999 }, { epoch: 1000 }];
+
+    const wide = filterEpochPointsByRange(points, { kind: 'preset', preset: '30d' }, now);
+    expect(wide.map((p) => p.epoch)).toEqual([10, 999, 1000]);
+
+    const narrow = filterEpochPointsByRange(points, { kind: 'preset', preset: '24h' }, now);
+    expect(narrow.map((p) => p.epoch)).toEqual([999, 1000]);
+    expect(narrow).not.toContainEqual({ epoch: 10 });
+  });
+});

--- a/src/lib/operatorTime.ts
+++ b/src/lib/operatorTime.ts
@@ -1,0 +1,65 @@
+// Time helpers for the operator dashboard: range presets and epoch<->timestamp
+// conversion. Pure functions so they are unit-testable without a DOM.
+
+import type { TimeRange, TimeRangePreset } from '@/src/types/operator';
+
+/** Beacon-chain mainnet genesis (unix seconds) and slot/epoch timing. */
+export const MAINNET_GENESIS_UNIX = 1_606_824_023;
+export const SECONDS_PER_SLOT = 12;
+export const SLOTS_PER_EPOCH = 32;
+export const SECONDS_PER_EPOCH = SECONDS_PER_SLOT * SLOTS_PER_EPOCH; // 384
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const PRESET_MS: Record<TimeRangePreset, number> = {
+  '24h': DAY_MS,
+  '7d': 7 * DAY_MS,
+  '30d': 30 * DAY_MS,
+};
+
+/** Resolve a TimeRange to absolute [fromMs, toMs] bounds. */
+export function timeRangeBounds(range: TimeRange, nowMs = Date.now()): { fromMs: number; toMs: number } {
+  if (range.kind === 'custom') {
+    const fromMs = Math.min(range.fromMs, range.toMs);
+    const toMs = Math.max(range.fromMs, range.toMs);
+    return { fromMs, toMs };
+  }
+  return { fromMs: nowMs - PRESET_MS[range.preset], toMs: nowMs };
+}
+
+/** Convert a beacon epoch to unix seconds (start of the epoch). */
+export function epochToUnixSeconds(epoch: number, genesisUnix = MAINNET_GENESIS_UNIX): number {
+  return genesisUnix + epoch * SECONDS_PER_EPOCH;
+}
+
+/** Convert a beacon epoch to unix milliseconds. */
+export function epochToUnixMs(epoch: number, genesisUnix = MAINNET_GENESIS_UNIX): number {
+  return epochToUnixSeconds(epoch, genesisUnix) * 1000;
+}
+
+/**
+ * Filter epoch-keyed points to those falling inside a time range. Generic over
+ * any point carrying an `epoch` field.
+ */
+export function filterEpochPointsByRange<T extends { epoch: number }>(
+  points: T[],
+  range: TimeRange,
+  nowMs = Date.now(),
+  genesisUnix = MAINNET_GENESIS_UNIX,
+): T[] {
+  const { fromMs, toMs } = timeRangeBounds(range, nowMs);
+  return points.filter((p) => {
+    const ms = epochToUnixMs(p.epoch, genesisUnix);
+    return ms >= fromMs && ms <= toMs;
+  });
+}
+
+/** Filter timestamp-keyed points (ms) to a time range. */
+export function filterTimestampPointsByRange<T extends { timestamp: number }>(
+  points: T[],
+  range: TimeRange,
+  nowMs = Date.now(),
+): T[] {
+  const { fromMs, toMs } = timeRangeBounds(range, nowMs);
+  return points.filter((p) => p.timestamp >= fromMs && p.timestamp <= toMs);
+}

--- a/src/types/operator.ts
+++ b/src/types/operator.ts
@@ -1,0 +1,81 @@
+// Types for the Node Operator Dashboard (validator performance metrics).
+//
+// Live metrics arrive over WebSocket; historical series are composed from the
+// existing balance/reward hooks. All percentages are 0..100.
+
+/** Point-in-time validator metrics streamed live over WebSocket. */
+export interface LiveOperatorMetrics {
+  /** Current beacon-chain epoch. */
+  currentEpoch: number;
+  /** Current slot. */
+  currentSlot: number;
+  /** Latest finalized block/slot number. */
+  finalizedBlock: number;
+  /** Validator effective balance, in Gwei. */
+  validatorBalanceGwei: bigint;
+  /** Overall attestation effectiveness, 0..100. */
+  effectivenessPct: number;
+  /** Activation/exit queue position; null once the validator is active. */
+  queuePosition: number | null;
+  /** Attestation effectiveness component, 0..100. */
+  attestationEffectivenessPct: number;
+  /** Proposal timeliness component, 0..100. */
+  proposalTimelinessPct: number;
+  /** Uptime component, 0..100. */
+  uptimePct: number;
+  /** Connected peer count. */
+  peerCount: number;
+  /** Timestamp (ms since epoch) the metrics were observed. */
+  updatedAt: number;
+}
+
+/** A validator-balance observation at an epoch (Gwei). */
+export interface BalanceHistoryPoint {
+  epoch: number;
+  balanceGwei: bigint;
+}
+
+/** Attestation effectiveness (0..100) at an epoch. */
+export interface AttestationEffectivenessPoint {
+  epoch: number;
+  effectivenessPct: number;
+}
+
+/** A block proposal event on the timeline. */
+export interface ProposalPoint {
+  slot: number;
+  epoch: number;
+  /** ms since epoch. */
+  timestamp: number;
+  status: 'included' | 'missed' | 'orphaned';
+}
+
+/** Composite health grade buckets. */
+export type HealthGrade = 'excellent' | 'good' | 'fair' | 'poor';
+
+/** Result of the composite node-health calculation. */
+export interface HealthScore {
+  /** 0..100 composite score. */
+  score: number;
+  grade: HealthGrade;
+  /** Weighted contribution (points) of each input to the score. */
+  components: {
+    attestationEffectiveness: number;
+    proposalTimeliness: number;
+    uptime: number;
+    peerCount: number;
+  };
+}
+
+/** Time range selector for charts and export. */
+export type TimeRangePreset = '24h' | '7d' | '30d';
+export type TimeRange =
+  | { kind: 'preset'; preset: TimeRangePreset }
+  | { kind: 'custom'; fromMs: number; toMs: number };
+
+/** Historical series backing the performance charts. */
+export interface OperatorHistory {
+  balances: BalanceHistoryPoint[];
+  attestationEffectiveness: AttestationEffectivenessPoint[];
+  proposals: ProposalPoint[];
+}


### PR DESCRIPTION
## Summary

Implements the Node Operator Dashboard (#176) — live validator performance metrics, health scoring, historical charts, alert configuration, and CSV export — at a new route `/operator`.

Built to compose the repo's existing real-time data layer rather than reinvent it, and delivered in reviewable stages (two commits: foundation, then UI).

## What's included

**Data / logic (pure, unit-tested)**
- `src/types/operator.ts` — metrics, history, health, and time-range contracts.
- `src/lib/operatorHealth.ts` — composite health score weighted **attestation 40 / proposal 30 / uptime 20 / peers 10**, with peer-count normalization, clamping, and grading.
- `src/lib/operatorTime.ts` — epoch↔time conversion + range filtering (24h/7d/30d/custom).
- `src/lib/operatorExport.ts` — CSV builder for compliance export.
- `src/hooks/useOperatorMetrics.ts` — the single hook the spec asks for: live metrics over WebSocket (auto-reconnect, following this repo's stream-hook pattern), the health score derived per update, and a rolling historical buffer accumulated in the message handler.

**UI (`src/components/operator/`)**
- `OperatorOverview` — balance / epoch / slot / finalized-block cards, queue position, peers, uptime, an SVG health gauge with component breakdown, and an effectiveness badge.
- `PerformanceCharts` — **Lightweight Charts**: balance history (area), attestation effectiveness (bar), proposal timeline (colored bars). Loaded client-only (`dynamic`, `ssr:false`) since the chart lib needs the DOM.
- `TimeRangeSelector` — shared 24h/7d/30d/custom control driving both charts and export.
- `AlertConfigPanel` — threshold sliders (missed attestations, balance drop, effectiveness floor) + push/email channels, persisted to localStorage.
- `ExportButton` — downloads a CSV of the selected range.
- `OperatorDashboard` + `app/operator/page.tsx` — assembled route.

## Verification

- **13 unit tests pass** (`operatorHealth`, `operatorTime`, `operatorExport`).
- **Typecheck clean** on all new files.
- **Lint clean** on all new files (the one hydrate-from-localStorage effect uses the repo's sanctioned `eslint-disable-next-line react-hooks/set-state-in-effect` with justification, matching existing usage).

## Notes for the reviewer

- **Live metrics source:** the WS URL is read from `NEXT_PUBLIC_OPERATOR_METRICS_WS` (overridable via `OperatorDashboard` prop). The message contract is `{ type: 'operator-metrics', metrics: {...} }` — documented in `useOperatorMetrics.ts`. The dashboard renders graceful loading/empty states until the stream connects, so it's safe to merge ahead of the backend endpoint.
- **Proposals:** the live metrics payload doesn't carry proposal events, so the proposal-timeline series is fed from an optional `seedProposals` backfill (empty by default → chart shows an empty state). A REST backfill can be wired in without touching the chart components.
- **Pre-existing build error (not from this PR):** `next build` currently fails on `app/node-sync/page.tsx` (it uses `dynamic(ssr:false)` without `'use client'`). Verified this fails on a clean `main` with my changes stashed. My route follows the correct pattern (the `dynamic` import lives inside the `'use client'` `OperatorDashboard`).

Closes #176
