### PR TITLE
Fix WebSocket health scoring + slashing dedup TTL

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { SyncStatusBar } from '@/src/components/SyncStatusBar';
 import { OfflineBanner } from '@/src/components/layout/OfflineBanner';
+import { WSHealthTier3Banner } from '@/src/components/layout/WSHealthTier3Banner';
 
 // Full dashboard layout — SyncStatusBar and OfflineBanner are only loaded
 // for routes inside (dashboard), keeping the auth/login critical path lean.
@@ -9,6 +10,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   return (
     <>
       <OfflineBanner />
+      <WSHealthTier3Banner />
       {children}
       <SyncStatusBar />
     </>

--- a/app/network/page.tsx
+++ b/app/network/page.tsx
@@ -6,6 +6,7 @@ import { LightClientSyncIndicator } from '@/src/components/network/LightClientSy
 import { SloMonitoringDashboard } from '@/src/components/slo/SloMonitoringDashboard';
 import dynamic from 'next/dynamic';
 import { ChartSkeleton } from '@/src/components/charts/ChartSkeleton';
+import { WSHealthDashboard } from '@/src/components/network/WSHealthDashboard';
 
 const NetworkGraph = dynamic(
   () => import('@/src/components/network/NetworkGraph').then((m) => m.NetworkGraph),
@@ -62,6 +63,7 @@ export default function NetworkStatus() {
 
       <div className="grid grid-cols-1 gap-8">
         <SloMonitoringDashboard />
+        <WSHealthDashboard />
         <div className="bg-white dark:bg-zinc-900 rounded-xl p-6 shadow-sm border border-zinc-200 dark:border-zinc-800">
           <h2 className="mb-4 text-xl font-semibold text-zinc-900 dark:text-zinc-50">Validator topology</h2>
           <NetworkGraph />

--- a/app/validators/layout.tsx
+++ b/app/validators/layout.tsx
@@ -2,6 +2,7 @@
 
 import { SyncStatusBar } from '@/src/components/SyncStatusBar';
 import { OfflineBanner } from '@/src/components/layout/OfflineBanner';
+import { WSHealthTier3Banner } from '@/src/components/layout/WSHealthTier3Banner';
 
 // Scopes SyncStatusBar + OfflineBanner to validator routes only.
 // Auth/login routes never load these components.
@@ -9,6 +10,7 @@ export default function ValidatorsLayout({ children }: { children: React.ReactNo
   return (
     <>
       <OfflineBanner />
+      <WSHealthTier3Banner />
       {children}
       <SyncStatusBar />
     </>

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
@@ -382,6 +396,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -1786,6 +1810,112 @@
         }
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2127,6 +2257,17 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@playwright/test": {
       "version": "1.61.0",
@@ -3627,16 +3768,50 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+      "integrity": "sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.7",
+        "vitest": "3.2.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
-      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -3645,13 +3820,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
-      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.6",
+        "@vitest/spy": "3.2.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -3672,9 +3847,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
-      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3685,13 +3860,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
-      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.6",
+        "@vitest/utils": "3.2.7",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -3700,13 +3875,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
-      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
+        "@vitest/pretty-format": "3.2.7",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -3715,9 +3890,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
-      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3728,13 +3903,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
-      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.6",
+        "@vitest/pretty-format": "3.2.7",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -4022,6 +4197,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4804,6 +4998,13 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5778,6 +5979,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -5945,6 +6163,28 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5956,6 +6196,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -7113,6 +7379,60 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -7129,6 +7449,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -7667,6 +8003,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7748,6 +8125,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mrmime": {
@@ -8279,6 +8666,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8330,6 +8724,30 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -9256,6 +9674,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -9379,6 +9820,20 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9517,6 +9972,60 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tinybench": {
@@ -10666,20 +11175,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
-      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.6",
-        "@vitest/mocker": "3.2.6",
-        "@vitest/pretty-format": "^3.2.6",
-        "@vitest/runner": "3.2.6",
-        "@vitest/snapshot": "3.2.6",
-        "@vitest/spy": "3.2.6",
-        "@vitest/utils": "3.2.6",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -10709,8 +11218,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.6",
-        "@vitest/ui": "3.2.6",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -11021,6 +11530,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/ws": {

--- a/src/components/layout/WSHealthTier3Banner.tsx
+++ b/src/components/layout/WSHealthTier3Banner.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useWebSocketHealth } from '@/src/hooks/useWebSocketHealth'
+
+export function WSHealthTier3Banner() {
+  const { tier3Connections, retry } = useWebSocketHealth()
+
+  if (tier3Connections.length === 0) return null
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="sticky top-0 z-50 w-full border-b border-red-300 bg-red-50/90 shadow-sm"
+    >
+      <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-3 px-4 py-2 text-sm">
+        <div className="flex items-center gap-3">
+          <span className="inline-block h-2.5 w-2.5 animate-pulse rounded-full bg-red-500" aria-hidden="true" />
+          <div className="text-red-800">
+            {tier3Connections.length} WebSocket connection{tier3Connections.length !== 1 ? 's' : ''} need manual retry.
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {tier3Connections.slice(0, 3).map((c) => (
+            <button
+              key={c.connectionId}
+              type="button"
+              onClick={() => retry(c.connectionId)}
+              className="rounded-lg border border-red-300 bg-white px-3 py-1 text-xs font-semibold text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-400/30"
+            >
+              Retry
+            </button>
+          ))}
+          {tier3Connections.length > 3 && (
+            <span className="text-xs text-red-800/70">+{tier3Connections.length - 3} more</span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/components/network/WSHealthDashboard.tsx
+++ b/src/components/network/WSHealthDashboard.tsx
@@ -1,0 +1,219 @@
+'use client'
+
+import type { ReactElement } from 'react'
+import { useMemo } from 'react'
+import { useWebSocketHealth } from '@/src/hooks/useWebSocketHealth'
+import type { WebSocketTier } from '@/src/types/webSocketHealth'
+
+function tierBadgeStyles(tier: WebSocketTier): { bg: string; text: string; border: string } {
+  switch (tier) {
+    case 1:
+      return { bg: 'bg-emerald-500/15', text: 'text-emerald-300', border: 'border-emerald-500/30' }
+    case 2:
+      return { bg: 'bg-amber-500/15', text: 'text-amber-300', border: 'border-amber-500/30' }
+    case 3:
+      return { bg: 'bg-red-500/15', text: 'text-red-300', border: 'border-red-500/30' }
+  }
+}
+
+function scoreTone(score: number): { bar: string; chip: string } {
+  if (score >= 80) return { bar: 'bg-emerald-500', chip: 'text-emerald-300' }
+  if (score >= 50) return { bar: 'bg-amber-500', chip: 'text-amber-300' }
+  return { bar: 'bg-red-500', chip: 'text-red-300' }
+}
+
+function renderLatencySparkline(valuesMs: number[]): ReactElement {
+  const width = 120
+  const height = 24
+  const capMs = 1_000
+
+  const points = valuesMs
+    .slice(-12)
+    .map((v, idx, arr) => {
+      const x = (idx / Math.max(1, arr.length - 1)) * width
+      const clamped = Math.max(0, Math.min(capMs, v))
+      const y = height - (clamped / capMs) * height
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label="Latency sparkline (1 minute)"
+      className="shrink-0"
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="rgba(59,130,246,0.9)"
+        strokeWidth="2"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+export function WSHealthDashboard() {
+  const { connections, tier3Connections, retry } = useWebSocketHealth()
+
+  const showTier3 = tier3Connections.length > 0
+
+  const tier3Label = useMemo(() => {
+    if (!showTier3) return null
+    const count = tier3Connections.length
+    return `${count} connection${count !== 1 ? 's' : ''} need manual retry`
+  }, [showTier3, tier3Connections.length])
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/80 p-6 text-white" aria-label="WebSocket health">
+      {showTier3 && (
+        <div
+          className="mb-5 rounded-2xl border border-red-500/20 bg-red-500/10 px-4 py-3"
+          role="alert"
+          aria-live="polite"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-red-200">{tier3Label}</p>
+              <p className="text-xs text-red-200/80">
+                Auth / version mismatches stopped auto-reconnect. Use Retry to restore the stream.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {tier3Connections.slice(0, 3).map((c) => (
+                <button
+                  key={c.connectionId}
+                  type="button"
+                  onClick={() => retry(c.connectionId)}
+                  className="rounded-lg border border-red-300 bg-red-600/10 px-3 py-1 text-xs font-semibold text-red-200 hover:bg-red-600/20 focus:outline-none focus:ring-2 focus:ring-red-400/30"
+                >
+                  Retry
+                </button>
+              ))}
+              {tier3Connections.length > 3 && (
+                <span className="text-xs text-red-200/80">+{tier3Connections.length - 3} more</span>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold">WebSocket Connection Health</h2>
+          <p className="text-sm text-slate-400">Real-time 0–100 scoring with tiered reconnection.</p>
+        </div>
+      </div>
+
+      {connections.length === 0 ? (
+        <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-6 text-center text-sm text-slate-400">
+          No active WebSocket connections registered.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-2xl border border-white/10 bg-slate-950/30">
+          <table className="w-full border-collapse">
+            <thead className="bg-slate-950/40 text-left">
+              <tr className="text-xs text-slate-400">
+                <th className="px-4 py-3 font-semibold">Connection</th>
+                <th className="px-4 py-3 font-semibold">Health</th>
+                <th className="px-4 py-3 font-semibold">Tier</th>
+                <th className="px-4 py-3 font-semibold">Latency</th>
+                <th className="px-4 py-3 font-semibold">Reconnects</th>
+                <th className="px-4 py-3 font-semibold">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {connections.map((c) => {
+                const tone = scoreTone(c.healthScore)
+                const badge = tierBadgeStyles(c.tierStatus.tier)
+                const needsManual = c.tierStatus.tier === 3 && !c.autoReconnectEnabled
+                const dotColor = c.connected ? 'bg-emerald-400' : 'bg-slate-500'
+                const connectionLabel =
+                  c.url.length > 28 ? `${c.url.slice(0, 22)}…${c.url.slice(-6)}` : c.url
+
+                return (
+                  <tr key={c.connectionId} className="border-t border-white/5 text-sm">
+                    <td className="px-4 py-3">
+                      <div className="flex items-start gap-3">
+                        <span className={`mt-1 inline-block h-2.5 w-2.5 rounded-full ${dotColor}`} aria-hidden="true" />
+                        <div>
+                          <div className="font-semibold">{connectionLabel}</div>
+                          {c.lastClose?.reason ? (
+                            <div className="mt-1 text-xs text-slate-400">{c.lastClose.reason}</div>
+                          ) : (
+                            <div className="mt-1 text-xs text-slate-500">
+                              {c.connected ? 'Connected' : c.lastClose?.closeCode ? `Closed (${c.lastClose.closeCode})` : 'Disconnected'}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <div className="flex w-36 flex-col gap-2">
+                          <div className="h-2 w-full overflow-hidden rounded-full bg-white/10" aria-hidden="true">
+                            <div
+                              className={`h-full rounded-full ${tone.bar}`}
+                              style={{ width: `${c.healthScore}%` }}
+                            />
+                          </div>
+                          <div className="flex justify-between text-xs text-slate-400">
+                            <span>0</span>
+                            <span className="font-semibold text-white">{c.healthScore}</span>
+                            <span>100</span>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${badge.bg} ${badge.text} ${badge.border}`}
+                      >
+                        Tier {c.tierStatus.tier}
+                      </span>
+                    </td>
+
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <div className="min-w-[72px] text-xs text-slate-300">
+                          {Math.round(c.avgMessageLatencyMs)}ms
+                        </div>
+                        {renderLatencySparkline(c.latencySparklineMs)}
+                      </div>
+                    </td>
+
+                    <td className="px-4 py-3 text-slate-300">
+                      {c.reconnectAttempts}
+                    </td>
+
+                    <td className="px-4 py-3">
+                      {needsManual ? (
+                        <button
+                          type="button"
+                          onClick={() => retry(c.connectionId)}
+                          className="rounded-lg border border-red-300 bg-red-600/10 px-3 py-1 text-xs font-semibold text-red-200 hover:bg-red-600/20 focus:outline-none focus:ring-2 focus:ring-red-400/30"
+                        >
+                          Retry
+                        </button>
+                      ) : (
+                        <span className="text-xs text-slate-500">{c.autoReconnectEnabled ? 'Auto' : 'Stopped'}</span>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}
+

--- a/src/hooks/tests/useSlashingStream.test.ts
+++ b/src/hooks/tests/useSlashingStream.test.ts
@@ -196,9 +196,13 @@ describe('useSlashingStream', () => {
       })
     )
 
-    await waitFor(() => {
-      expect(result.current.connected).toBe(true)
+    // Flush pending microtasks (React effects + mock WS onopen) so
+    // `connected` becomes true. `waitFor` deadlocks under fake timers
+    // because it relies on real-timer retries that are now frozen.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
     })
+    expect(result.current.connected).toBe(true)
 
     const event: SlashingEvent = createMockEvent('1', 'node-1', 100)
 
@@ -207,9 +211,7 @@ describe('useSlashingStream', () => {
       wsServer.simulateMessage(event)
     })
 
-    await waitFor(() => {
-      expect(result.current.events).toHaveLength(1)
-    })
+    expect(result.current.events).toHaveLength(1)
 
     // Try to send duplicate immediately - should be filtered
     act(() => {
@@ -218,9 +220,9 @@ describe('useSlashingStream', () => {
 
     expect(result.current.events).toHaveLength(1)
 
-    // Advance time past TTL
-    act(() => {
-      vi.advanceTimersByTime(1100)
+    // Advance time past TTL and flush microtasks
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1100)
     })
 
     // Send the same event again after TTL expires - should be allowed
@@ -228,9 +230,7 @@ describe('useSlashingStream', () => {
       wsServer.simulateMessage(event)
     })
 
-    await waitFor(() => {
-      expect(result.current.events).toHaveLength(2)
-    })
+    expect(result.current.events).toHaveLength(2)
 
     vi.useRealTimers()
   })
@@ -262,7 +262,7 @@ class MockWebSocketServer {
   simulateDisconnect() {
     this.clients.forEach((client) => {
       client.readyState = 3 // CLOSED
-      client.onclose?.(new CloseEvent('close'))
+      client.onclose?.(new CloseEvent('close', { code: 1000, reason: 'mock-disconnect' }))
     })
   }
 

--- a/src/hooks/useNodeStatusStream.ts
+++ b/src/hooks/useNodeStatusStream.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useNodeStore, type NodeInfo, type NodeStatus } from '@/src/store/nodeStore';
+import { webSocketManager } from '@/src/services/webSocketManager';
 
 interface WSStatusEvent {
   type: 'node-status-update';
@@ -27,8 +28,6 @@ interface UseNodeStatusStreamOptions {
  * queued rather than applied, preventing the race condition described in #40.
  */
 export function useNodeStatusStream({ url, enabled = true }: UseNodeStatusStreamOptions) {
-  const wsRef = useRef<WebSocket | null>(null);
-  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const mountedRef = useRef(true);
 
   useEffect(() => {
@@ -36,58 +35,40 @@ export function useNodeStatusStream({ url, enabled = true }: UseNodeStatusStream
 
     mountedRef.current = true;
 
-    function connect() {
-      if (!mountedRef.current) return;
-
-      const ws = new WebSocket(url);
-      wsRef.current = ws;
-
-      ws.onopen = () => {
-        console.log('[NodeStatusStream] WebSocket connected:', url);
-      };
-
-      ws.onmessage = (event) => {
+    const release = webSocketManager.acquireConnection({
+      connectionId: `node-status:${url}`,
+      url,
+      enabled: true,
+      onMessage: (data) => {
+        if (!mountedRef.current) return;
         try {
-          const data: WSEvent = JSON.parse(event.data);
+          const parsed =
+            typeof data === 'string' ? (JSON.parse(data) as unknown) : (data as unknown);
+          const event = parsed as WSEvent
           const store = useNodeStore.getState();
 
-          switch (data.type) {
+          switch (event.type) {
             case 'node-list-init':
-              store.setNodes(data.nodes);
+              store.setNodes(event.nodes);
               break;
             case 'node-status-update':
-              store.updateNodeStatus(data.nodeId, data.status);
+              store.updateNodeStatus(event.nodeId, event.status);
               break;
           }
         } catch (err) {
-          console.error('[NodeStatusStream] Failed to parse message:', err);
+          // Ignore malformed frames; a single bad message shouldn't kill the feed.
+          console.error('[NodeStatusStream] Failed to process message:', err);
         }
-      };
-
-      ws.onerror = (err) => {
-        console.error('[NodeStatusStream] WebSocket error:', err);
-      };
-
-      ws.onclose = () => {
-        wsRef.current = null;
-        // Auto-reconnect after 5s
-        if (mountedRef.current) {
-          reconnectTimeoutRef.current = setTimeout(connect, 5000);
-        }
-      };
-    }
-
-    connect();
+      },
+      onError: (errMsg) => {
+        // Keep it cheap; the tier-3 banner/health dashboard will surface persistent issues.
+        console.error('[NodeStatusStream] WS error:', errMsg);
+      },
+    })
 
     return () => {
       mountedRef.current = false;
-      if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current);
-      }
-      if (wsRef.current) {
-        wsRef.current.close();
-        wsRef.current = null;
-      }
+      release()
     };
   }, [url, enabled]);
 }

--- a/src/hooks/useNodeStream.ts
+++ b/src/hooks/useNodeStream.ts
@@ -7,9 +7,9 @@ import {
   type NodeStatusEvent,
   type UseNodeStatusResult,
 } from '@/src/hooks/useNodeStatus'
+import { webSocketManager } from '@/src/services/webSocketManager'
 
 const DEDUP_WINDOW_MS = 50
-const RECONNECT_DELAY_MS = 5000
 
 interface UseNodeStreamOptions {
   url: string
@@ -59,8 +59,6 @@ export function useNodeStream({
     if (!enabled || !url) return
 
     const bufferMap = bufferRef.current
-    let ws: WebSocket | null = null
-    let reconnectTimer: ReturnType<typeof setTimeout> | undefined
     let closed = false
 
     const flush = () => {
@@ -76,34 +74,28 @@ export function useNodeStream({
       if (!existing || event.seq > existing.seq) bufferMap.set(event.nodeId, event)
     }
 
-    const connect = () => {
-      if (closed) return
-      ws = new WebSocket(url)
-      ws.onmessage = (e) => {
+    const release = webSocketManager.acquireConnection({
+      connectionId: `node-stream:${url}`,
+      url,
+      enabled: true,
+      onMessage: (data) => {
+        if (closed) return
         try {
-          const parsed = parseEvent(JSON.parse(e.data))
+          const parsedRaw =
+            typeof data === 'string' ? (JSON.parse(data) as unknown) : (data as unknown)
+          const parsed = parseEvent(parsedRaw)
           if (parsed) enqueue(parsed)
         } catch {
           // Ignore malformed frames.
         }
-      }
-      ws.onclose = () => {
-        ws = null
-        if (!closed) reconnectTimer = setTimeout(connect, RECONNECT_DELAY_MS)
-      }
-      ws.onerror = () => {
-        // The close handler performs reconnection.
-      }
-    }
-
-    connect()
+      },
+    })
     const flushTimer = setInterval(flush, dedupWindowMs)
 
     return () => {
       closed = true
       clearInterval(flushTimer)
-      if (reconnectTimer) clearTimeout(reconnectTimer)
-      if (ws) ws.close()
+      release()
       bufferMap.clear()
     }
   }, [url, enabled, dedupWindowMs, applyEvents])

--- a/src/hooks/useSlashingStream.ts
+++ b/src/hooks/useSlashingStream.ts
@@ -5,11 +5,11 @@ import type { SlashingEvent, UseSlashingStreamOptions, UseSlashingStreamResult }
 import { useWebSocketReconnect } from './useWebSocketReconnect'
 
 const DEFAULT_DEDUP_WINDOW_MS = 300000 // 5 minutes
-const CLEANUP_INTERVAL_MS = 60000 // Clean up every minute
 const MAX_EVENTS = 1000 // Maximum events to keep in memory
 
 interface ReceivedEventEntry {
-  timestamp: number
+  timestampMs: number
+  perfTimestampMs: number
 }
 
 function isSlashingEvent(value: unknown): value is SlashingEvent {
@@ -48,26 +48,46 @@ export function useSlashingStream({
   const [error, setError] = useState<string | null>(null)
   const [lastEventId, setLastEventId] = useState<string | null>(null)
 
-  // Clean up expired event IDs based on TTL
-  const cleanupExpiredIds = useCallback(() => {
-    const now = Date.now()
-    const receivedIds = receivedIdsRef.current
-
-    for (const [eventId, entry] of receivedIds.entries()) {
-      if (now - entry.timestamp > dedupWindowMs) {
-        receivedIds.delete(eventId)
-      }
-    }
-  }, [dedupWindowMs])
+  const receivedIdsRef = useRef<Map<string, ReceivedEventEntry>>(new Map())
 
   // Check if event ID has already been received
-  const isDuplicate = useCallback((eventId: string): boolean => {
-    return receivedIdsRef.current.has(eventId)
-  }, [])
+  const isDuplicate = useCallback(
+    (eventId: string): boolean => {
+      const entry = receivedIdsRef.current.get(eventId)
+      if (!entry) return false
+
+      const nowMs = Date.now()
+      const nowPerfMs = typeof performance !== 'undefined' ? performance.now() : nowMs
+
+      const expired =
+        nowMs - entry.timestampMs > dedupWindowMs ||
+        nowPerfMs - entry.perfTimestampMs > dedupWindowMs
+
+      if (expired) {
+        receivedIdsRef.current.delete(eventId)
+        return false
+      }
+
+      return true
+    },
+    [dedupWindowMs],
+  )
 
   // Add event ID to received set
-  const markAsReceived = useCallback((eventId: string) => {
-    receivedIdsRef.current.set(eventId, { timestamp: Date.now() })
+  const markAsReceived = useCallback(
+    (eventId: string) => {
+      const tsMs = Date.now()
+      const perfTsMs = typeof performance !== 'undefined' ? performance.now() : tsMs
+      receivedIdsRef.current.set(eventId, { timestampMs: tsMs, perfTimestampMs: perfTsMs })
+    },
+    [],
+  )
+
+  // Cleanup cache on unmount to avoid cross-test interference.
+  useEffect(() => {
+    return () => {
+      receivedIdsRef.current.clear()
+    }
   }, [])
 
   // Handle incoming slashing events
@@ -81,7 +101,6 @@ export function useSlashingStream({
 
         // Check for duplicate using received event ID set
         if (isDuplicate(data.id)) {
-          console.debug(`Duplicate slashing event ignored: ${data.id}`)
           return
         }
 
@@ -90,12 +109,6 @@ export function useSlashingStream({
         setLastEventId(data.id)
 
         setEvents((prevEvents) => {
-          // Double-check: ensure event is not already in the list
-          // (React render key dedup + array filter)
-          if (prevEvents.some((e) => e.id === data.id)) {
-            return prevEvents
-          }
-
           const newEvents = [data, ...prevEvents]
 
           // Trim to max events
@@ -116,9 +129,9 @@ export function useSlashingStream({
 
   // WebSocket reconnect hook with catch-up support
   const { connected } = useWebSocketReconnect({
-    url: enabled ? url : '',
+    url,
     enabled,
-    reconnectDelayMs: 5000,
+    connectionId: `slashing:${url}`,
     onMessage: (data) => {
       handleMessage(data)
     },
@@ -131,19 +144,6 @@ export function useSlashingStream({
   useEffect(() => {
     onEvents?.(events)
   }, [events, onEvents])
-
-  // Set up cleanup interval for expired event IDs
-  useEffect(() => {
-    if (!enabled) return
-
-    cleanupTimerRef.current = setInterval(cleanupExpiredIds, CLEANUP_INTERVAL_MS)
-
-    return () => {
-      if (cleanupTimerRef.current) {
-        clearInterval(cleanupTimerRef.current)
-      }
-    }
-  }, [enabled, cleanupExpiredIds])
 
   return {
     events,

--- a/src/hooks/useSyncStatus.ts
+++ b/src/hooks/useSyncStatus.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { fetchSyncStatus } from '@/src/lib/api/syncStatus'
+import { webSocketManager } from '@/src/services/webSocketManager'
 import type {
   SyncStatus,
   SyncSpeedPoint,
@@ -120,11 +121,9 @@ export function useSyncStatus({
   const [error, setError] = useState<string | null>(null)
   const [wsConnected, setWsConnected] = useState(false)
 
-  const wsRef = useRef<WebSocket | null>(null)
-  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>()
-  const pollTimerRef = useRef<ReturnType<typeof setInterval> | undefined>()
+  const releaseRef = useRef<null | (() => void)>(null)
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined)
   const mountedRef = useRef(true)
-  const reconnectAttemptsRef = useRef(0)
 
   // ------------------------------------------------------------------
   // REST fetch
@@ -151,53 +150,20 @@ export function useSyncStatus({
   // ------------------------------------------------------------------
   // WebSocket
   // ------------------------------------------------------------------
-
-  const connectWs = useCallback(() => {
-    if (!wsUrl || !mountedRef.current) return
-
-    if (reconnectAttemptsRef.current > 10) {
-      // Give up silently; REST polling (if enabled) is the fallback.
-      return
-    }
-
-    try {
-      const ws = new WebSocket(wsUrl)
-      wsRef.current = ws
-
-      ws.onopen = () => {
-        if (!mountedRef.current) { ws.close(); return }
-        reconnectAttemptsRef.current = 0
-        setWsConnected(true)
-      }
-
-      ws.onmessage = (event) => {
-        if (!mountedRef.current) return
-        try {
-          const msg: WSSyncUpdate = JSON.parse(event.data as string)
-          if (msg.type === 'sync-status-update') {
-            setSyncStatus(simulateStall ? buildDemoStallStatus() : msg.data)
-          }
-        } catch {
-          // Ignore malformed frames
+  const onWsMessage = useCallback(
+    (data: unknown) => {
+      if (!mountedRef.current) return
+      try {
+        const msg = data as WSSyncUpdate
+        if (msg && msg.type === 'sync-status-update') {
+          setSyncStatus(simulateStall ? buildDemoStallStatus() : msg.data)
         }
+      } catch {
+        // Ignore malformed frames
       }
-
-      ws.onerror = () => {
-        // onclose handles reconnect
-      }
-
-      ws.onclose = () => {
-        wsRef.current = null
-        if (!mountedRef.current) return
-        setWsConnected(false)
-        reconnectAttemptsRef.current += 1
-        const delay = Math.min(5_000 * Math.pow(2, reconnectAttemptsRef.current - 1), 30_000)
-        reconnectTimerRef.current = setTimeout(connectWs, delay)
-      }
-    } catch {
-      // new WebSocket() can throw in some environments (SSR, tests)
-    }
-  }, [wsUrl, simulateStall])
+    },
+    [simulateStall],
+  )
 
   // ------------------------------------------------------------------
   // Mount / cleanup
@@ -210,7 +176,20 @@ export function useSyncStatus({
     loadRest()
 
     // 2. Open WebSocket for live updates.
-    if (wsUrl) connectWs()
+    if (wsUrl) {
+      releaseRef.current = webSocketManager.acquireConnection({
+        connectionId: `sync-status:${wsUrl}`,
+        url: wsUrl,
+        enabled: true,
+        onMessage: (data) => onWsMessage(data),
+        onConnected: () => mountedRef.current && setWsConnected(true),
+        onDisconnected: () => mountedRef.current && setWsConnected(false),
+        onError: (errMsg) => {
+          if (!mountedRef.current) return
+          setError(errMsg)
+        },
+      })
+    }
 
     // 3. Optional polling fallback.
     if (pollIntervalMs > 0) {
@@ -219,16 +198,11 @@ export function useSyncStatus({
 
     return () => {
       mountedRef.current = false
-      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current)
       if (pollTimerRef.current) clearInterval(pollTimerRef.current)
-      if (wsRef.current) {
-        wsRef.current.onclose = null // prevent reconnect on intentional close
-        wsRef.current.close()
-        wsRef.current = null
-      }
+      releaseRef.current?.()
+      releaseRef.current = null
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wsUrl, pollIntervalMs])
+  }, [wsUrl, pollIntervalMs, loadRest, onWsMessage])
 
   return {
     syncStatus,

--- a/src/hooks/useWebSocketHealth.ts
+++ b/src/hooks/useWebSocketHealth.ts
@@ -1,0 +1,20 @@
+'use client'
+
+import { useCallback } from 'react'
+import { webSocketManager } from '@/services/webSocketManager'
+import { useWebSocketHealthStore } from '@/store/webSocketHealthSlice'
+
+export function useWebSocketHealth() {
+  const connections = useWebSocketHealthStore((s) =>
+    Object.values(s.connections).sort((a, b) => a.connectionId.localeCompare(b.connectionId)),
+  )
+
+  const tier3Connections = connections.filter((c) => c.tierStatus.tier === 3 && !c.autoReconnectEnabled)
+
+  const retry = useCallback((connectionId: string) => {
+    webSocketManager.retryConnection(connectionId)
+  }, [])
+
+  return { connections, tier3Connections, retry }
+}
+

--- a/src/hooks/useWebSocketReconnect.ts
+++ b/src/hooks/useWebSocketReconnect.ts
@@ -1,28 +1,27 @@
 'use client'
 
-import { useCallback, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { webSocketManager } from '@/services/webSocketManager'
 
 interface UseWebSocketReconnectOptions {
   url: string
   enabled?: boolean
-  reconnectDelayMs?: number
-  maxReconnectAttempts?: number
+  /**
+   * Stable identifier used for multi-connection health scoring.
+   * When omitted, defaults to `url`.
+   */
+  connectionId?: string
   onMessage?: (data: unknown, headers: Record<string, string>) => void
   onConnected?: () => void
   onDisconnected?: () => void
   onError?: (error: string) => void
 }
 
-interface WebSocketHeaders {
-  'x-last-event-id'?: string
-  'x-catchup-from'?: string
-}
-
 /**
  * Hook to manage WebSocket connection with automatic reconnection and catch-up support.
  *
  * Features:
- * - Automatic reconnection with exponential backoff
+ * - Automatic reconnection with tiered strategy (health scoring)
  * - Sends last received event ID to server on reconnect
  * - Handles catch-up burst from server (x-catchup-from header)
  * - Deduplication through event ID headers
@@ -30,122 +29,93 @@ interface WebSocketHeaders {
 export function useWebSocketReconnect({
   url,
   enabled = true,
-  reconnectDelayMs = 5000,
-  maxReconnectAttempts = 10,
+  connectionId,
   onMessage,
   onConnected,
   onDisconnected,
   onError,
 }: UseWebSocketReconnectOptions) {
+  // -------------------------
+  // State
+  // -------------------------
   const [connected, setConnected] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const wsRef = useRef<WebSocket | null>(null)
-  const reconnectTimerRef = useRef<NodeJS.Timeout | undefined>()
-  const reconnectAttemptsRef = useRef(0)
-  const closedRef = useRef(false)
+  // -------------------------
+  // Connection helpers
+  // -------------------------
   const lastEventIdRef = useRef<string | null>(null)
+  const releaseRef = useRef<null | (() => void)>(null)
 
-  const handleError = useCallback(
-    (errMsg: string) => {
-      setError(errMsg)
-      onError?.(errMsg)
-    },
-    [onError]
-  )
+  // Keep latest callbacks without reconnecting the socket.
+  const onMessageRef = useRef(onMessage)
+  const onConnectedRef = useRef(onConnected)
+  const onDisconnectedRef = useRef(onDisconnected)
+  const onErrorRef = useRef(onError)
 
-  const connect = useCallback(() => {
-    if (closedRef.current || !enabled || !url) return
+  useEffect(() => {
+    onMessageRef.current = onMessage
+    onConnectedRef.current = onConnected
+    onDisconnectedRef.current = onDisconnected
+    onErrorRef.current = onError
+  }, [onMessage, onConnected, onDisconnected, onError])
 
-    if (reconnectAttemptsRef.current > maxReconnectAttempts) {
-      handleError('Max reconnection attempts exceeded')
-      return
-    }
+  useEffect(() => {
+    if (!enabled || !url) return
+    if (typeof window === 'undefined') return
 
-    try {
-      wsRef.current = new WebSocket(url)
+    const effectiveConnectionId = connectionId ?? url
 
-      wsRef.current.onopen = () => {
-        reconnectAttemptsRef.current = 0
+    releaseRef.current?.()
+    releaseRef.current = webSocketManager.acquireConnection({
+      connectionId: effectiveConnectionId,
+      url,
+      enabled: true,
+      onMessage: (data, headers) => {
+        if (data && typeof data === 'object' && 'id' in (data as Record<string, unknown>)) {
+          const id = (data as Record<string, unknown>).id
+          if (typeof id === 'string') lastEventIdRef.current = id
+        }
+        onMessageRef.current?.(data, headers)
+      },
+      onConnected: () => {
         setConnected(true)
         setError(null)
-        onConnected?.()
-
-        // Send last event ID to server for catch-up logic
-        if (lastEventIdRef.current && wsRef.current?.readyState === WebSocket.OPEN) {
-          wsRef.current.send(
+        onConnectedRef.current?.()
+      },
+      onDisconnected: () => {
+        setConnected(false)
+        onDisconnectedRef.current?.()
+      },
+      onError: (errMsg) => {
+        setError(errMsg)
+        onErrorRef.current?.(errMsg)
+      },
+      onOpen: (ws) => {
+        const openState = typeof WebSocket.OPEN === 'number' ? WebSocket.OPEN : 1
+        if (lastEventIdRef.current && ws.readyState === openState) {
+          ws.send(
             JSON.stringify({
               type: 'sync',
               lastEventId: lastEventIdRef.current,
-            })
+            }),
           )
         }
-      }
+      },
+    })
 
-      wsRef.current.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data)
-
-          // Extract headers from message or from WebSocket headers
-          const headers: Record<string, string> = {}
-          if (event.data.includes('x-last-event-id')) {
-            const match = event.data.match(/"x-last-event-id":"([^"]+)"/)
-            if (match) headers['x-last-event-id'] = match[1]
-          }
-          if (event.data.includes('x-catchup-from')) {
-            const match = event.data.match(/"x-catchup-from":"([^"]+)"/)
-            if (match) headers['x-catchup-from'] = match[1]
-          }
-
-          // Update last event ID if provided
-          if (data.id) {
-            lastEventIdRef.current = data.id
-          }
-
-          onMessage?.(data, headers)
-        } catch (err) {
-          handleError(`Failed to parse message: ${err}`)
-        }
-      }
-
-      wsRef.current.onclose = () => {
-        wsRef.current = null
-        setConnected(false)
-        onDisconnected?.()
-
-        if (!closedRef.current) {
-          reconnectAttemptsRef.current += 1
-          const delay = Math.min(reconnectDelayMs * Math.pow(2, reconnectAttemptsRef.current - 1), 30000)
-          connectRef.current()
-        }
-      }
-
-      wsRef.current.onerror = () => {
-        // Error is handled by onclose
-      }
-    } catch (err) {
-      handleError(`WebSocket connection failed: ${err}`)
+    return () => {
+      releaseRef.current?.()
+      releaseRef.current = null
     }
-  }, [url, enabled, reconnectDelayMs, maxReconnectAttempts, onMessage, onConnected, onDisconnected, handleError])
+  }, [url, enabled, connectionId])
 
-  const connectRef = useRef(connect)
-  // eslint-disable-next-line react-hooks/immutability
-  useEffect(() => { connectRef.current = connect }, [connect])
-
-  // Initialize connection
-  const setupRef = useRef(false)
-  if (enabled && url && !setupRef.current && typeof window !== 'undefined') {
-    setupRef.current = true
-    closedRef.current = false
-    connect()
+  // Stable cleanup function for existing callers.
+  const cleanup = () => {
+    releaseRef.current?.()
+    releaseRef.current = null
+    setConnected(false)
   }
-
-  // Cleanup
-  const cleanup = useCallback(() => {
-    closedRef.current = true
-    if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current)
-    if (wsRef.current) wsRef.current.close()
-  }, [])
 
   return {
     connected,

--- a/src/services/beaconChainService.ts
+++ b/src/services/beaconChainService.ts
@@ -9,6 +9,7 @@ import {
   computeParticipationRate,
   type SyncCommitteePeriodData,
 } from '@/src/utils/syncCommittee'
+import { webSocketManager } from '@/src/services/webSocketManager'
 
 export type BeaconFinalityProvider = {
   fetchCheckpoint(slot: number): Promise<FinalityCheckpointInput>
@@ -73,13 +74,26 @@ export function createBeaconChainService(baseUrl: string): BeaconFinalityProvide
       }
     },
     subscribeToHead(onCheckpoint) {
-      const socket = new WebSocket(`${normalizedBaseUrl.replace(/^http/, 'ws')}/eth/v1/events?topics=head`)
-      socket.onmessage = (event) => {
-        const payload = JSON.parse(event.data) as { data?: { slot?: string | number } }
-        const slot = toNumber(payload.data?.slot)
-        if (slot > 0) this.fetchCheckpoint(slot).then(onCheckpoint).catch(console.error)
-      }
-      return () => socket.close()
+      const wsUrl = `${normalizedBaseUrl.replace(/^http/, 'ws')}/eth/v1/events?topics=head`
+      const connectionId = `beacon-head:${normalizedBaseUrl}`
+
+      const release = webSocketManager.acquireConnection({
+        connectionId,
+        url: wsUrl,
+        enabled: true,
+        onMessage: (data) => {
+          try {
+            const payload = data as { data?: { slot?: string | number } }
+            const slot = toNumber(payload.data?.slot)
+            if (slot > 0) this.fetchCheckpoint(slot).then(onCheckpoint).catch(console.error)
+          } catch {
+            // Ignore malformed frames; health scoring will still reflect uptime.
+          }
+        },
+        onError: (err) => console.error('[beaconChainService] WS error:', err),
+      })
+
+      return () => release()
     },
   }
 }

--- a/src/services/tests/webSocketManager.test.ts
+++ b/src/services/tests/webSocketManager.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { webSocketManager } from '@/src/services/webSocketManager'
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.OPEN
+  onopen: ((ev: Event) => void) | null = null
+  onclose: ((ev: CloseEvent) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this)
+    setTimeout(() => this.onopen?.(new Event('open')), 0)
+  }
+
+  send() {
+    // no-op
+  }
+
+  close() {
+    this.readyState = 3
+    // no-op: tests trigger close manually via `onclose`
+  }
+
+  triggerClose(code: number, reason?: string) {
+    this.readyState = 3
+    this.onclose?.(({ code, reason } as unknown) as CloseEvent)
+  }
+}
+
+describe('webSocketManager (tiered reconnection + tier-3 disable)', () => {
+  const connectionId = 'test-connection'
+  const url = 'ws://localhost/ws'
+
+  const originalWebSocket = globalThis.WebSocket
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    MockWebSocket.instances = []
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+  })
+
+  afterEach(() => {
+    webSocketManager.retryConnection(connectionId) // best-effort cleanup path
+    // Release all active connections if they still exist.
+    // (The manager will stop ticking once idle.)
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    globalThis.WebSocket = originalWebSocket
+  })
+
+  it('reconnects immediately for Tier 1 (1000) close code', () => {
+    const release = webSocketManager.acquireConnection({
+      connectionId,
+      url,
+      enabled: true,
+    })
+
+    expect(MockWebSocket.instances.length).toBe(1)
+    const ws = MockWebSocket.instances[0]
+    ws.triggerClose(1000, 'normal')
+
+    // Tier 1 reconnect delay is immediate (0ms).
+    vi.runOnlyPendingTimers()
+
+    expect(MockWebSocket.instances.length).toBe(2)
+
+    release()
+  })
+
+  it('escalates to Tier 2 after 3 Tier 1 reconnect attempts, then backs off (5s)', () => {
+    const release = webSocketManager.acquireConnection({
+      connectionId,
+      url,
+      enabled: true,
+    })
+
+    expect(MockWebSocket.instances.length).toBe(1)
+
+    for (let i = 0; i < 3; i++) {
+      const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1]
+      ws.triggerClose(1000)
+      vi.runOnlyPendingTimers()
+    }
+
+    // After 3 attempts, tier1ReconnectAttempts is 3.
+    const ws4 = MockWebSocket.instances[MockWebSocket.instances.length - 1]
+    ws4.triggerClose(1000)
+
+    // No new socket before the 5s Tier 2 backoff.
+    vi.advanceTimersByTime(4_999)
+    expect(MockWebSocket.instances.length).toBe(4)
+
+    vi.advanceTimersByTime(1)
+    expect(MockWebSocket.instances.length).toBe(5)
+
+    release()
+  })
+
+  it('disables auto-reconnect for Tier 3 (auth codes 4000–4009) and retries only on manual call', () => {
+    const release = webSocketManager.acquireConnection({
+      connectionId,
+      url,
+      enabled: true,
+    })
+
+    expect(MockWebSocket.instances.length).toBe(1)
+    const ws = MockWebSocket.instances[0]
+    ws.triggerClose(4001, 'auth-error')
+
+    vi.advanceTimersByTime(60_000)
+    expect(MockWebSocket.instances.length).toBe(1)
+
+    webSocketManager.retryConnection(connectionId)
+    expect(MockWebSocket.instances.length).toBe(2)
+
+    release()
+  })
+})
+

--- a/src/services/webSocketManager.ts
+++ b/src/services/webSocketManager.ts
@@ -1,0 +1,556 @@
+import { classifyWebSocketCloseCode, type WebSocketTier } from '@/utils/connectionClassifier'
+import { computeTier2ExponentialBackoffMs } from '@/utils/exponentialBackoff'
+import { computeWebSocketHealthScore } from '@/utils/healthScore'
+import type {
+  WebSocketCloseInfo,
+  WebSocketConnectionHealthSummary,
+  WebSocketHealthSnapshot,
+  WebSocketTierStatus,
+} from '@/types/webSocketHealth'
+import { useWebSocketHealthStore } from '@/store/webSocketHealthSlice'
+
+type ExtractSentTimestampMs = (parsedData: unknown) => number | null
+
+const MAX_SIMULTANEOUS_CONNECTIONS = 10
+
+// Snapshot / scoring windows.
+const HEALTH_SNAPSHOT_INTERVAL_MS = 5_000
+const HEALTH_HISTORY_MAX_ENTRIES = 720 // 1 hour @ 5s intervals
+const UPTIME_WINDOW_MS = 60_000
+const LATENCY_WINDOW_MS = 60_000
+
+// Reconnect policy.
+const STABLE_RESET_MS = 5 * 60_000
+const TIER1_MAX_RECONNECT_ATTEMPTS = 3
+
+function defaultExtractSentTimestampMs(parsedData: unknown): number | null {
+  if (!parsedData || typeof parsedData !== 'object') return null
+
+  const record = parsedData as Record<string, unknown>
+
+  const maybeTimestamp =
+    typeof record.timestamp === 'number'
+      ? record.timestamp
+      : typeof record.ts === 'number'
+        ? record.ts
+        : typeof record.sentAt === 'number'
+          ? record.sentAt
+          : null
+
+  // Guard against test fixtures / relative timestamps: require plausible epoch ms.
+  // 2001-09-09 in ms ≈ 1_000_000_000_000.
+  if (maybeTimestamp === null) return null
+  if (maybeTimestamp < 1_000_000_000_000) return null
+
+  return maybeTimestamp
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function buildTierStatusFromClassification(tier: WebSocketTier, label: string): WebSocketTierStatus {
+  return { tier, label }
+}
+
+export interface WebSocketManagerConnectionConfig {
+  connectionId: string
+  url: string
+  enabled?: boolean
+
+  onMessage?: (data: unknown, headers: Record<string, string>) => void
+  onConnected?: () => void
+  onDisconnected?: (closeInfo: WebSocketCloseInfo) => void
+  onError?: (error: string) => void
+
+  /**
+   * Called after the socket successfully opens.
+   * Use this to send any catch-up / subscription messages.
+   */
+  onOpen?: (ws: WebSocket) => void
+
+  /**
+   * Extract the client-observable "sent timestamp" for computing message latency.
+   * When omitted, attempts `timestamp` / `ts` / `sentAt` fields.
+   */
+  extractSentTimestampMs?: ExtractSentTimestampMs
+}
+
+type InternalLatencySample = { receivedAtMs: number; latencyMs: number }
+
+class InternalConnectionState {
+  readonly connectionId: string
+  readonly url: string
+  refCount = 0
+
+  // Socket state.
+  ws: WebSocket | null = null
+  // Used to detect stale sockets in test environments where the global
+  // `WebSocket` constructor is swapped between tests.
+  wsConstructor: typeof WebSocket | null = null
+  connected = false
+  manualCloseNext = false
+
+  // For uptime calculation / stable reset.
+  openedAtMs: number | null = null
+  lastConnectionDurationMs: number | null = null
+
+  // Reconnect attempts.
+  autoReconnectEnabled = true
+  tierStatus: WebSocketTierStatus = buildTierStatusFromClassification(1, 'normal')
+  lastClose?: WebSocketCloseInfo
+  consecutiveReconnectAttempts = 0
+  tier1ReconnectAttempts = 0
+  tier2ReconnectAttempts = 0
+
+  // Message latency samples (for avg over last 60 seconds).
+  latencySamples: InternalLatencySample[] = []
+
+  // Health snapshot history (5s interval, max 720 entries).
+  healthHistory: WebSocketHealthSnapshot[] = []
+
+  // Reconnect scheduling.
+  reconnectTimeout: ReturnType<typeof setTimeout> | null = null
+
+  // Callback wiring.
+  config: Omit<WebSocketManagerConnectionConfig, 'connectionId' | 'url'>
+  extractSentTimestampMs: ExtractSentTimestampMs
+
+  constructor(
+    connectionId: string,
+    url: string,
+    config: Omit<WebSocketManagerConnectionConfig, 'connectionId' | 'url'>,
+  ) {
+    this.connectionId = connectionId
+    this.url = url
+    this.config = config
+    this.extractSentTimestampMs = config.extractSentTimestampMs ?? defaultExtractSentTimestampMs
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimeout) clearTimeout(this.reconnectTimeout)
+    this.reconnectTimeout = null
+  }
+
+  private pushLatencySample(latencyMs: number, receivedAtMs: number): void {
+    // Keep samples bounded by time window (lazy pruning).
+    this.latencySamples.push({ latencyMs, receivedAtMs })
+  }
+
+  private pruneLatencySamples(nowMs: number): void {
+    const cutoff = nowMs - LATENCY_WINDOW_MS
+    if (this.latencySamples.length === 0) return
+    let idx = 0
+    while (idx < this.latencySamples.length && this.latencySamples[idx].receivedAtMs < cutoff) idx++
+    if (idx > 0) this.latencySamples = this.latencySamples.slice(idx)
+  }
+
+  private computeAvgLatencyMs(nowMs: number): number {
+    this.pruneLatencySamples(nowMs)
+    if (this.latencySamples.length === 0) return 1_000 // worst-case until latency observed
+
+    const sum = this.latencySamples.reduce((acc, s) => acc + s.latencyMs, 0)
+    return sum / this.latencySamples.length
+  }
+
+  private computeUptimeRatioLast60s(nowMs: number): number {
+    const cutoff = nowMs - UPTIME_WINDOW_MS
+    const recent = this.healthHistory.filter((s) => s.timestamp >= cutoff)
+
+    const connectedSamples = recent.filter((s) => s.connected).length + (this.connected ? 1 : 0)
+    const uptimeSeconds = connectedSamples * (HEALTH_SNAPSHOT_INTERVAL_MS / 1000)
+    return clamp(uptimeSeconds / (UPTIME_WINDOW_MS / 1000), 0, 1)
+  }
+
+  private buildSnapshot(nowMs: number): WebSocketHealthSnapshot {
+    const uptimeRatioLast60s = this.computeUptimeRatioLast60s(nowMs)
+    const avgMessageLatencyMs = this.computeAvgLatencyMs(nowMs)
+
+    const { totalScore } = computeWebSocketHealthScore({
+      uptimeRatioLast60s,
+      avgMessageLatencyMs,
+      consecutiveReconnects: this.consecutiveReconnectAttempts,
+    })
+
+    const snapshot: WebSocketHealthSnapshot = {
+      timestamp: nowMs,
+      uptimeRatioLast60s,
+      avgMessageLatencyMs,
+      consecutiveReconnects: this.consecutiveReconnectAttempts,
+      connected: this.connected,
+      healthScore: totalScore,
+      tierStatus: this.tierStatus,
+      lastClose: this.lastClose,
+      avgLatencyForSparklineMs: avgMessageLatencyMs,
+    }
+
+    return snapshot
+  }
+
+  private recordSnapshot(nowMs: number): WebSocketHealthSnapshot {
+    const snapshot = this.buildSnapshot(nowMs)
+    this.healthHistory.push(snapshot)
+    if (this.healthHistory.length > HEALTH_HISTORY_MAX_ENTRIES) this.healthHistory.shift()
+    return snapshot
+  }
+
+  private computeLatencySparklineMs(): number[] {
+    // Last 60s sparkline at 5s intervals = 12 points.
+    const points = this.healthHistory.slice(-12).map((s) => s.avgLatencyForSparklineMs)
+    // Ensure stable length for the UI.
+    if (points.length < 12) {
+      const filler = Array.from({ length: 12 - points.length }, () => points.length ? points[0] : 1_000)
+      return [...filler, ...points]
+    }
+    return points
+  }
+
+  updateStoreWithLatestSnapshot(nowMs: number): void {
+    const snapshot = this.recordSnapshot(nowMs)
+    const reconnectAttempts = this.consecutiveReconnectAttempts
+    const autoReconnectEnabled = this.autoReconnectEnabled
+
+    const summary: WebSocketConnectionHealthSummary = {
+      connectionId: this.connectionId,
+      url: this.url,
+      connected: this.connected,
+      healthScore: snapshot.healthScore,
+      tierStatus: snapshot.tierStatus,
+      uptimeRatioLast60s: snapshot.uptimeRatioLast60s,
+      avgMessageLatencyMs: snapshot.avgMessageLatencyMs,
+      consecutiveReconnects: snapshot.consecutiveReconnects,
+      reconnectAttempts,
+      autoReconnectEnabled,
+      lastClose: snapshot.lastClose,
+      latencySparklineMs: this.computeLatencySparklineMs(),
+      lastSnapshotAt: snapshot.timestamp,
+    }
+
+    useWebSocketHealthStore.getState().upsertConnectionHealth(summary)
+  }
+
+  private scheduleReconnect(delayMs: number): void {
+    this.clearReconnectTimer()
+    this.reconnectTimeout = setTimeout(() => {
+      this.reconnectTimeout = null
+      this.connect()
+    }, delayMs)
+  }
+
+  connect(): void {
+    if (!this.config.enabled) return
+    if (!this.autoReconnectEnabled && this.tierStatus.tier === 3) return
+    if (this.reconnectTimeout) return
+    // Some test WebSocket mocks don't provide static OPEN/CONNECTING constants.
+    const OPEN_STATE = typeof WebSocket.OPEN === 'number' ? WebSocket.OPEN : 1
+    const CONNECTING_STATE = typeof WebSocket.CONNECTING === 'number' ? WebSocket.CONNECTING : 0
+
+    // If the global WebSocket constructor changed (common in unit tests),
+    // treat the existing socket as stale and create a new one.
+    if (this.ws && this.wsConstructor && this.wsConstructor !== WebSocket) {
+      try {
+        this.ws.onopen = null
+        this.ws.onmessage = null
+        this.ws.onclose = null
+        this.ws.onerror = null
+        this.ws.close()
+      } catch {
+        // ignore
+      }
+      this.ws = null
+      this.wsConstructor = null
+      this.connected = false
+      this.openedAtMs = null
+    }
+
+    if (this.ws && (this.ws.readyState === OPEN_STATE || this.ws.readyState === CONNECTING_STATE)) return
+
+    try {
+      this.manualCloseNext = false
+      this.ws = new WebSocket(this.url)
+      this.wsConstructor = WebSocket
+      const ws = this.ws
+
+      const handleOpen = () => {
+        // In some test environments (and certain WebSocket implementations),
+        // the socket can already report OPEN at construction time while the
+        // `onopen` event is delivered asynchronously. If so, mark connected
+        // immediately so consumers don't depend on a timer tick.
+        if (this.connected) return
+
+        const now = Date.now()
+        if (this.lastConnectionDurationMs !== null && this.lastConnectionDurationMs >= STABLE_RESET_MS) {
+          this.consecutiveReconnectAttempts = 0
+          this.tier1ReconnectAttempts = 0
+          this.tier2ReconnectAttempts = 0
+        }
+        this.lastConnectionDurationMs = null
+
+        this.connected = true
+        this.openedAtMs = now
+
+        // Once a connection is up again, Tier 3 manual disable no longer applies.
+        // If Tier 3 was triggered earlier, `retryConnection()` will explicitly
+        // re-enable auto reconnect and call `connect()`.
+        if (this.tierStatus.tier !== 3) {
+          this.autoReconnectEnabled = true
+        }
+
+        this.config.onConnected?.()
+        this.config.onOpen?.(ws as WebSocket)
+      }
+
+      ws.onopen = handleOpen
+
+      ws.onmessage = (event) => {
+        const rawData = typeof event.data === 'string' ? event.data : ''
+        const headers: Record<string, string> = {}
+
+        if (rawData.includes('x-last-event-id')) {
+          const match = rawData.match(/"x-last-event-id":"([^"]+)"/)
+          if (match) headers['x-last-event-id'] = match[1]
+        }
+        if (rawData.includes('x-catchup-from')) {
+          const match = rawData.match(/"x-catchup-from":"([^"]+)"/)
+          if (match) headers['x-catchup-from'] = match[1]
+        }
+
+        let parsed: unknown = rawData
+        if (rawData) {
+          try {
+            parsed = JSON.parse(rawData)
+          } catch {
+            // Keep raw string for consumers that want it.
+            parsed = rawData
+          }
+        }
+
+        const sentTs = this.extractSentTimestampMs(parsed)
+        if (sentTs !== null) {
+          const latencyMs = Math.max(0, Date.now() - sentTs)
+          this.pushLatencySample(latencyMs, Date.now())
+        }
+
+        this.config.onMessage?.(parsed, headers)
+      }
+
+      ws.onerror = () => {
+        this.config.onError?.('WebSocket error')
+      }
+
+      ws.onclose = (ev: CloseEvent) => {
+        const now = Date.now()
+        const wasManual = this.manualCloseNext
+
+        if (wasManual) {
+          this.ws = null
+          this.connected = false
+          return
+        }
+
+        this.ws = null
+        this.connected = false
+
+        // Compute previous open duration (used for 5-minute stable reset).
+        if (this.openedAtMs !== null) {
+          this.lastConnectionDurationMs = now - this.openedAtMs
+        }
+        this.openedAtMs = null
+        this.clearReconnectTimer()
+
+        const closeCode = typeof ev.code === 'number' ? ev.code : undefined
+        const reason = typeof ev.reason === 'string' && ev.reason.length > 0 ? ev.reason : undefined
+        const classification = classifyWebSocketCloseCode(closeCode, reason)
+        this.tierStatus = buildTierStatusFromClassification(classification.tier, classification.label)
+
+        this.lastClose = {
+          closeCode,
+          reason,
+          tierStatus: this.tierStatus,
+        }
+
+        const closeInfo = this.lastClose
+        this.config.onDisconnected?.(closeInfo)
+
+        if (classification.tier === 3) {
+          // Tier 3: manual intervention required → disable auto reconnect.
+          this.autoReconnectEnabled = false
+          return
+        }
+
+        // Tier 1 / Tier 2 strategy.
+        const effectiveTier: 1 | 2 =
+          classification.tier === 1 && this.tier1ReconnectAttempts < TIER1_MAX_RECONNECT_ATTEMPTS
+            ? 1
+            : 2
+
+        if (effectiveTier === 1) {
+          this.tier1ReconnectAttempts += 1
+          this.consecutiveReconnectAttempts += 1
+          // Immediate (<5s) reconnect.
+          this.scheduleReconnect(0)
+          return
+        }
+
+        this.tier2ReconnectAttempts += 1
+        this.consecutiveReconnectAttempts += 1
+        const delayMs = computeTier2ExponentialBackoffMs(this.tier2ReconnectAttempts)
+        this.scheduleReconnect(delayMs)
+      }
+
+      // Handle already-open sockets (e.g., test WebSocket mocks) after all
+      // handlers are wired to avoid races where consumers send messages
+      // immediately after `connected` flips to true.
+      if (ws.readyState === OPEN_STATE) {
+        handleOpen()
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      this.config.onError?.(`WebSocket connection failed: ${message}`)
+
+      // Treat creation failures as Tier 2 network instability.
+      this.tierStatus = { tier: 2, label: 'abnormal' }
+      this.lastClose = {
+        closeCode: undefined,
+        reason: message,
+        tierStatus: this.tierStatus,
+      }
+      this.config.onDisconnected?.(this.lastClose)
+
+      // Apply Tier 2 policy.
+      this.tier2ReconnectAttempts += 1
+      this.consecutiveReconnectAttempts += 1
+      const delayMs = computeTier2ExponentialBackoffMs(this.tier2ReconnectAttempts)
+      this.scheduleReconnect(delayMs)
+    }
+  }
+
+  release(): boolean {
+    this.refCount = Math.max(0, this.refCount - 1)
+    if (this.refCount > 0) return false
+
+    this.autoReconnectEnabled = false
+    this.manualCloseNext = true
+    this.clearReconnectTimer()
+
+    if (this.ws) {
+      try {
+        this.ws.onopen = null
+        this.ws.onmessage = null
+        this.ws.onclose = null
+        this.ws.onerror = null
+        this.ws.close()
+      } catch {
+        // ignore
+      }
+    }
+    this.ws = null
+    this.wsConstructor = null
+    this.connected = false
+    return true
+  }
+}
+
+class WebSocketHealthManager {
+  private connections = new Map<string, InternalConnectionState>()
+  private ticker: ReturnType<typeof setInterval> | null = null
+
+  private ensureTickerRunning(): void {
+    if (this.ticker) return
+    this.ticker = setInterval(() => {
+      const now = Date.now()
+      for (const conn of this.connections.values()) conn.updateStoreWithLatestSnapshot(now)
+    }, HEALTH_SNAPSHOT_INTERVAL_MS)
+  }
+
+  private stopTickerIfIdle(): void {
+    if (this.connections.size > 0) return
+    if (this.ticker) clearInterval(this.ticker)
+    this.ticker = null
+  }
+
+  acquireConnection(config: WebSocketManagerConnectionConfig): () => void {
+    const enabled = config.enabled ?? true
+    if (!config.connectionId || !config.url) {
+      throw new Error('webSocketManager.acquireConnection: connectionId and url are required')
+    }
+
+    // Enforce the “up to 10 simultaneous connections” invariant.
+    if (!this.connections.has(config.connectionId) && this.connections.size >= MAX_SIMULTANEOUS_CONNECTIONS) {
+      config.onError?.(`Too many WebSocket connections (max ${MAX_SIMULTANEOUS_CONNECTIONS})`)
+      return () => undefined
+    }
+
+    const existing = this.connections.get(config.connectionId)
+    if (existing) {
+      existing.refCount += 1
+      const { connectionId: _connectionId, url: _url, ...rest } = config
+      existing.config = {
+        ...existing.config,
+        ...rest,
+        enabled,
+      }
+      if (rest.extractSentTimestampMs) {
+        existing.extractSentTimestampMs = rest.extractSentTimestampMs
+      }
+
+      if (enabled) {
+        existing.connect()
+
+        // If the connection is already open, notify the new subscriber
+        // immediately. Some consumers (and unit tests) don't advance the
+        // WebSocket `onopen` timer under fake timers.
+        const OPEN_STATE = typeof WebSocket.OPEN === 'number' ? WebSocket.OPEN : 1
+        if (existing.connected && existing.ws && existing.ws.readyState === OPEN_STATE) {
+          existing.config.onConnected?.()
+          existing.config.onOpen?.(existing.ws)
+        }
+      }
+      this.ensureTickerRunning()
+      return () => {
+        const fullyReleased = existing.release()
+        if (!fullyReleased) return
+        this.connections.delete(config.connectionId)
+        useWebSocketHealthStore.getState().removeConnectionHealth(config.connectionId)
+        this.stopTickerIfIdle()
+      }
+    }
+
+    const { connectionId: _connectionId, url: _url, ...rest } = config
+    const conn = new InternalConnectionState(config.connectionId, config.url, {
+      ...rest,
+      enabled,
+    })
+
+    conn.refCount = 1
+    conn.connect()
+    this.connections.set(config.connectionId, conn)
+    this.ensureTickerRunning()
+
+    return () => {
+      const fullyReleased = conn.release()
+      if (!fullyReleased) return
+      this.connections.delete(config.connectionId)
+      useWebSocketHealthStore.getState().removeConnectionHealth(config.connectionId)
+      this.stopTickerIfIdle()
+    }
+  }
+
+  retryConnection(connectionId: string): void {
+    const conn = this.connections.get(connectionId)
+    if (!conn) return
+
+    conn.autoReconnectEnabled = true
+    conn.tierStatus = { tier: 1, label: 'normal' }
+    conn.lastClose = undefined
+    conn.consecutiveReconnectAttempts = 0
+    conn.tier1ReconnectAttempts = 0
+    conn.tier2ReconnectAttempts = 0
+
+    conn.connect()
+    this.ensureTickerRunning()
+  }
+}
+
+export const webSocketManager = new WebSocketHealthManager()
+

--- a/src/store/webSocketHealthSlice.ts
+++ b/src/store/webSocketHealthSlice.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand'
+import type { WebSocketConnectionHealthSummary } from '@/types/webSocketHealth'
+
+interface WebSocketHealthState {
+  connections: Record<string, WebSocketConnectionHealthSummary>
+  upsertConnectionHealth: (summary: WebSocketConnectionHealthSummary) => void
+  removeConnectionHealth: (connectionId: string) => void
+  clearAll: () => void
+}
+
+export const useWebSocketHealthStore = create<WebSocketHealthState>((set) => ({
+  connections: {},
+  upsertConnectionHealth: (summary) =>
+    set((s) => ({
+      connections: {
+        ...s.connections,
+        [summary.connectionId]: summary,
+      },
+    })),
+  removeConnectionHealth: (connectionId) =>
+    set((s) => {
+      if (!s.connections[connectionId]) return s
+      const next = { ...s.connections }
+      delete next[connectionId]
+      return { connections: next }
+    }),
+  clearAll: () => set({ connections: {} }),
+}))
+

--- a/src/types/webSocketHealth.ts
+++ b/src/types/webSocketHealth.ts
@@ -1,0 +1,50 @@
+export type WebSocketTier = 1 | 2 | 3
+
+export type WebSocketTierStatus = {
+  tier: WebSocketTier
+  /** Human-readable classification label. */
+  label: string
+}
+
+export interface WebSocketCloseInfo {
+  closeCode?: number
+  reason?: string
+  tierStatus: WebSocketTierStatus
+}
+
+export interface WebSocketHealthSnapshot {
+  /** Unix timestamp (ms) for this 5s health snapshot tick. */
+  timestamp: number
+  uptimeRatioLast60s: number
+  avgMessageLatencyMs: number
+  consecutiveReconnects: number
+  connected: boolean
+  healthScore: number
+  /** Tier derived from the most recent close classification. */
+  tierStatus: WebSocketTierStatus
+  lastClose?: WebSocketCloseInfo
+  /**
+   * Latency points used for sparkline rendering.
+   * Stores average latency over the last 60 seconds at this tick.
+   */
+  avgLatencyForSparklineMs: number
+}
+
+export interface WebSocketConnectionHealthSummary {
+  connectionId: string
+  url: string
+  connected: boolean
+  healthScore: number
+  tierStatus: WebSocketTierStatus
+  uptimeRatioLast60s: number
+  avgMessageLatencyMs: number
+  consecutiveReconnects: number
+  reconnectAttempts: number
+  autoReconnectEnabled: boolean
+  lastClose?: WebSocketCloseInfo
+  /** 1-minute latency sparkline (12 points at 5s interval), oldest→newest. */
+  latencySparklineMs: number[]
+  /** Most recent snapshot time. */
+  lastSnapshotAt: number
+}
+

--- a/src/utils/connectionClassifier.ts
+++ b/src/utils/connectionClassifier.ts
@@ -1,0 +1,60 @@
+export type WebSocketTier = 1 | 2 | 3
+
+export type WebSocketCloseClassification =
+  | {
+      tier: 1
+      label: 'normal'
+      closeCode: number
+      reason?: string
+    }
+  | {
+      tier: 2
+      label: 'abnormal'
+      closeCode?: number
+      reason?: string
+    }
+  | {
+      tier: 3
+      label: 'auth-error' | 'version-mismatch'
+      closeCode?: number
+      reason?: string
+    }
+
+const AUTH_CODE_RE = /^400\d$/ // 4000–4009 inclusive
+const VERSION_MISMATCH_CODE_RE = /^300\d$/ // 3000–3009 inclusive
+
+/**
+ * Classify WebSocket close codes into reconnection tiers.
+ *
+ * Tier mapping (per issue spec):
+ * - `1000` → Tier 1 (normal / transient)
+ * - `1006` / `1015` → Tier 2 (abnormal / network instability)
+ * - `4000–4009` → Tier 3 (auth error)
+ * - `3000–3009` → Tier 3 (version mismatch)
+ * - anything else → Tier 2 (abnormal)
+ */
+export function classifyWebSocketCloseCode(
+  code: number | undefined,
+  reason?: string,
+): WebSocketCloseClassification {
+  if (code === 1000) {
+    return { tier: 1, label: 'normal', closeCode: 1000, reason }
+  }
+
+  if (code === 1006 || code === 1015) {
+    return { tier: 2, label: 'abnormal', closeCode: code, reason }
+  }
+
+  if (typeof code === 'number') {
+    const asString = String(code)
+    if (AUTH_CODE_RE.test(asString)) {
+      return { tier: 3, label: 'auth-error', closeCode: code, reason }
+    }
+    if (VERSION_MISMATCH_CODE_RE.test(asString)) {
+      return { tier: 3, label: 'version-mismatch', closeCode: code, reason }
+    }
+  }
+
+  return { tier: 2, label: 'abnormal', closeCode: code, reason }
+}
+

--- a/src/utils/exponentialBackoff.ts
+++ b/src/utils/exponentialBackoff.ts
@@ -1,0 +1,31 @@
+function randIntInclusive(maxExclusive: number): number {
+  return Math.floor(Math.random() * maxExclusive)
+}
+
+/**
+ * Tier 2 backoff schedule:
+ *   5s → 15s → 45s → 135s (×3 multiplier), capped at 300s.
+ *
+ * Adds full jitter (+ up to 500ms) to avoid synchronized reconnect storms.
+ */
+export function computeTier2ExponentialBackoffMs(
+  tier2Attempts: number,
+  opts?: {
+    baseDelayMs?: number
+    multiplier?: number
+    jitterMs?: number
+    maxDelayMs?: number
+  },
+): number {
+  const baseDelayMs = opts?.baseDelayMs ?? 5_000
+  const multiplier = opts?.multiplier ?? 3
+  const jitterMs = opts?.jitterMs ?? 500
+  const maxDelayMs = opts?.maxDelayMs ?? 300_000
+
+  if (tier2Attempts < 1) tier2Attempts = 1
+
+  const expDelay = baseDelayMs * Math.pow(multiplier, tier2Attempts - 1)
+  const jitter = randIntInclusive(jitterMs)
+  return Math.min(expDelay + jitter, maxDelayMs)
+}
+

--- a/src/utils/healthScore.ts
+++ b/src/utils/healthScore.ts
@@ -1,0 +1,65 @@
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value))
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+export interface WebSocketHealthScoreComponents {
+  uptimeRatioLast60s: number
+  avgMessageLatencyMs: number
+  consecutiveReconnects: number
+  uptimeScore: number
+  latencyScore: number
+  reconnectScore: number
+  totalScore: number
+}
+
+export interface ComputeWebSocketHealthScoreParams {
+  /** Fraction of the last 60 seconds where the connection was open (0–1). */
+  uptimeRatioLast60s: number
+  /** Average message latency over the last 60 seconds (ms). */
+  avgMessageLatencyMs: number
+  /** Consecutive reconnect attempts since the last stable open. */
+  consecutiveReconnects: number
+}
+
+/**
+ * Health score formula (0–100) per issue spec:
+ *   50 × uptimeRatio_last_60s
+ * + 30 × (avg_message_latency_ms / 1000, clamped 0–1 inverted)
+ * + 20 × (consecutive_reconnects, decaying: max at 0 reconnects)
+ *
+ * The decay curve for reconnects is anchored to the Tier 1 escalation bound:
+ * Tier 1 allows up to 3 immediate attempts before escalating to Tier 2, so
+ * the reconnect sub-score linearly decays to 0 by `consecutiveReconnects = 3`.
+ */
+export function computeWebSocketHealthScore({
+  uptimeRatioLast60s,
+  avgMessageLatencyMs,
+  consecutiveReconnects,
+}: ComputeWebSocketHealthScoreParams): WebSocketHealthScoreComponents {
+  const uptimeRatio = clamp01(uptimeRatioLast60s)
+  const latencyRatio = clamp(avgMessageLatencyMs / 1_000, 0, 1)
+  const latencySubScore = 1 - latencyRatio // inverted: lower latency → higher health
+
+  const reconnectDecayAtZero = 3
+  const reconnectSubScore = Math.max(0, 1 - consecutiveReconnects / reconnectDecayAtZero)
+
+  const uptimeScore = 50 * uptimeRatio
+  const latencyScore = 30 * latencySubScore
+  const reconnectScore = 20 * reconnectSubScore
+  const totalScore = clamp(Math.round(uptimeScore + latencyScore + reconnectScore), 0, 100)
+
+  return {
+    uptimeRatioLast60s: uptimeRatio,
+    avgMessageLatencyMs,
+    consecutiveReconnects,
+    uptimeScore,
+    latencyScore,
+    reconnectScore,
+    totalScore,
+  }
+}
+

--- a/src/utils/tests/connectionClassifier.test.ts
+++ b/src/utils/tests/connectionClassifier.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { classifyWebSocketCloseCode } from '@/src/utils/connectionClassifier'
+
+describe('connectionClassifier', () => {
+  it('classifies 1000 as Tier 1', () => {
+    const result = classifyWebSocketCloseCode(1000, 'normal')
+    expect(result.tier).toBe(1)
+    expect(result.label).toBe('normal')
+  })
+
+  it('classifies 1006 / 1015 as Tier 2', () => {
+    const a = classifyWebSocketCloseCode(1006)
+    expect(a.tier).toBe(2)
+    expect(a.label).toBe('abnormal')
+
+    const b = classifyWebSocketCloseCode(1015)
+    expect(b.tier).toBe(2)
+    expect(b.label).toBe('abnormal')
+  })
+
+  it('classifies 4000–4009 as Tier 3 auth error', () => {
+    const result = classifyWebSocketCloseCode(4001, 'no credentials')
+    expect(result.tier).toBe(3)
+    expect(result.label).toBe('auth-error')
+  })
+
+  it('classifies 3000–3009 as Tier 3 version mismatch', () => {
+    const result = classifyWebSocketCloseCode(3009, 'unsupported version')
+    expect(result.tier).toBe(3)
+    expect(result.label).toBe('version-mismatch')
+  })
+
+  it('defaults unknown close codes to Tier 2', () => {
+    const result = classifyWebSocketCloseCode(9999)
+    expect(result.tier).toBe(2)
+    expect(result.label).toBe('abnormal')
+  })
+})
+

--- a/src/utils/tests/exponentialBackoff.test.ts
+++ b/src/utils/tests/exponentialBackoff.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+import { computeTier2ExponentialBackoffMs } from '@/src/utils/exponentialBackoff'
+
+describe('computeTier2ExponentialBackoffMs', () => {
+  it('uses 5s → 15s → 45s → 135s schedule (with deterministic zero jitter)', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    expect(computeTier2ExponentialBackoffMs(1)).toBe(5_000)
+    expect(computeTier2ExponentialBackoffMs(2)).toBe(15_000)
+    expect(computeTier2ExponentialBackoffMs(3)).toBe(45_000)
+    expect(computeTier2ExponentialBackoffMs(4)).toBe(135_000)
+    expect(computeTier2ExponentialBackoffMs(5)).toBe(300_000)
+
+    vi.restoreAllMocks()
+  })
+})
+

--- a/src/utils/tests/healthScore.test.ts
+++ b/src/utils/tests/healthScore.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { computeWebSocketHealthScore } from '@/src/utils/healthScore'
+
+describe('computeWebSocketHealthScore', () => {
+  it('returns 100 for perfect uptime, zero latency, and zero reconnects', () => {
+    const result = computeWebSocketHealthScore({
+      uptimeRatioLast60s: 1,
+      avgMessageLatencyMs: 0,
+      consecutiveReconnects: 0,
+    })
+
+    expect(result.totalScore).toBe(100)
+  })
+
+  it('returns 0 when latency is ≥ 1000ms and reconnects are at decay zero point', () => {
+    const result = computeWebSocketHealthScore({
+      uptimeRatioLast60s: 0,
+      avgMessageLatencyMs: 1_000,
+      consecutiveReconnects: 3,
+    })
+
+    expect(result.totalScore).toBe(0)
+  })
+
+  it('clamps and decays linearly across the reconnects component', () => {
+    const result = computeWebSocketHealthScore({
+      uptimeRatioLast60s: 0.5,
+      avgMessageLatencyMs: 1_000,
+      consecutiveReconnects: 1,
+    })
+
+    // uptimeScore = 25
+    // latencyScore = 0
+    // reconnectScore = 20 * (1 - 1/3) = 13.33 → 13
+    // total = 38
+    expect(result.totalScore).toBe(38)
+  })
+})
+


### PR DESCRIPTION
- Harden WebSocket lifecycle integration for tiered reconnect and per-connection health tracking.
- Make slashing event deduplication TTL deterministic under Vitest fake timers.

## Summary

Implements a real-time 0–100 health scoring system for WebSocket connections, classifies disconnection reasons by close code, and applies a tiered reconnection strategy: Tier 1 (immediate) for transient blips, Tier 2 (exponential backoff) for network instability, and Tier 3 (manual intervention) for auth/version mismatches. Refactors all existing WS consumer hooks to delegate lifecycle management to a central manager. Adds operator-facing UI (dashboard + Tier 3 alert banner). Fixes slashing stream deduplication TTL behavior under Vitest fake timers.

## Related Issue

Closes #177 

## Changes

### New files
- `src/utils/connectionClassifier.ts` — Maps WS close codes to Tier 1/2/3 with descriptive labels
- `src/utils/exponentialBackoff.ts` — Computes Tier 2 reconnect delay (×3 multiplier, 500ms jitter, 300s cap)
- `src/utils/healthScore.ts` — Weighted health score: 50% uptime, 30% latency, 20% reconnect decay
- `src/services/webSocketManager.ts` — Central WS lifecycle manager with per-connection health tracking, tiered reconnect, reference counting, and rolling 1-hour snapshot buffer (720 entries at 5s intervals)
- `src/store/webSocketHealthSlice.ts` — Zustand store for per-connection health summaries
- `src/types/webSocketHealth.ts` — Types for tiers, snapshots, close info, and health summaries
- `src/hooks/useWebSocketHealth.ts` — Hook exposing per-connection health data and Tier 3 retry
- `src/components/network/WSHealthDashboard.tsx` — Connection health table with health bars, tier badges, latency sparklines, and reconnect counts
- `src/components/layout/WSHealthTier3Banner.tsx` — Sticky operator notification banner for Tier 3 disconnections with Retry buttons
- `src/utils/tests/connectionClassifier.test.ts` — Unit tests for close-code classification
- `src/utils/tests/exponentialBackoff.test.ts` — Unit tests for backoff calculation
- `src/utils/tests/healthScore.test.ts` — Unit tests for health score formula
- `src/services/tests/webSocketManager.test.ts` — Unit tests for tiered reconnection and Tier 3 disable/retry

### Modified files
- `src/hooks/useWebSocketReconnect.ts` — Refactored to delegate WS lifecycle to `webSocketManager`
- `src/hooks/useNodeStream.ts` — Replaced manual WS management with `webSocketManager.acquireConnection`
- `src/hooks/useNodeStatusStream.ts` — Replaced manual WS management with `webSocketManager.acquireConnection`
- `src/hooks/useSyncStatus.ts` — Replaced manual WS management with `webSocketManager.acquireConnection`; fixed `useRef` missing initial value for React 19 types
- `src/services/beaconChainService.ts` — Refactored `subscribeToHead` to use `webSocketManager`
- `src/hooks/useSlashingStream.ts` — Dual-clock TTL eviction (`Date.now` + `performance.now`) for deduplication; removed stale timer-based cleanup
- `src/hooks/tests/useSlashingStream.test.ts` — Replaced `waitFor` + `vi.advanceTimersByTime` with `act` + `vi.advanceTimersByTimeAsync` to prevent fake-timer deadlocks; updated mock disconnect close code
- `src/components/network/WSHealthDashboard.tsx` — Fixed `JSX` namespace error (→ `ReactElement` import)
- `app/(dashboard)/layout.tsx` — Mounted `WSHealthTier3Banner`
- `app/network/page.tsx` — Mounted `WSHealthDashboard`
- `app/validators/layout.tsx` — Mounted `WSHealthTier3Banner`
- `package-lock.json` — Regenerated to resolve prior lockfile mismatch (no new dependencies)

## Testing

- [x] TypeScript: no type errors (`npm run build`)
- [x] Linting: no errors (`npm run lint`)
- [x] Unit tests pass (`npm run test:unit`) — 402/403 pass; 1 pre-existing flaky failure in `treeFlattener.test.ts` (randomness-dependent assertion, unrelated to this PR)
- [ ] E2E tests pass (`npm run test:e2e:ci`)

## Notes

- The `treeFlattener > does not exceed requested node count` test failure is pre-existing and unrelated — it intermittently fails due to a randomness-dependent node-count tolerance assertion.
- `package-lock.json` was updated by `npm install` to resolve a prior lockfile mismatch; no new runtime dependencies were introduced.
- Tier mapping: `1000` → Tier 1, `1006/1015` → Tier 2, `4000–4009` / `3000–3009` → Tier 3.
- Health score formula: `50 × uptime_ratio_60s + 30 × (1 − avg_latency/1000) + 20 × max(0, 1 − reconnects/3)`.
- Multi-connection support enforces max 10 simultaneous WS connections with independent health scoring.
- The `webSocketManager` detects stale sockets when the global `WebSocket` constructor changes between test runs, preventing cross-test state leakage.