### PR TITLE
feat: optimize Docker image layer caching for CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Build context minimization: every excluded path shrinks the context sent to
+# the daemon and prevents irrelevant changes from busting Docker layer cache.
+
+# Dependencies / build output
+node_modules
+.next
+out
+build
+coverage
+reports
+
+# Version control & CI
+.git
+.github
+.githooks
+.vscode
+
+# Tests & tooling (not needed at runtime)
+test-results
+playwright-report
+tests
+e2e
+monitoring
+deploy
+docs
+scripts
+
+# Misc
+*.md
+.env*
+!.env.example
+*.log
+.DS_Store
+*.pem
+*.tsbuildinfo
+next-env.d.ts

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,60 @@
+name: Docker Image Build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  packages: write
+  actions: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker-build:
+    name: Build & cache Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # BuildKit is required for the `gha` cache backend and cache mounts.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata (tags & labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      # The `gha` cache backend stores each layer in GitHub Actions' cache so
+      # that unchanged layers (deps → builder → runner) are reused across runs
+      # instead of being rebuilt from scratch.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: npm
       - name: Install Dependencies
         run: npm ci
       - name: Run Linter
@@ -39,14 +40,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: npm
 
       - name: Install Dependencies
         run: npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# syntax=docker/dockerfile:1.4
+
+# ---------------------------------------------------------------------------
+# VeriNode Frontend — multi-stage Docker image.
+#
+# Layer-caching strategy (issue #167):
+#   1. `deps`    — copies ONLY the lockfile manifests first, so `npm ci` is
+#                  cached independently of source code. The npm store is kept
+#                  in a BuildKit cache mount that survives between builds.
+#   2. `builder` — reuses the dependency layer and only re-runs when source
+#                  files change.
+#   3. `runner`  — ships only `next build`'s standalone output (no
+#                  `node_modules`), yielding a small, immutable final layer.
+# ---------------------------------------------------------------------------
+
+# ---- Stage 1: install dependencies (cached by package manifests) ----------
+FROM node:22-alpine AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+# Copy manifests first so dependency resolution is its own cacheable layer.
+COPY package.json package-lock.json ./
+
+# `--mount=type=cache` keeps the npm store in the BuildKit cache, so repeated
+# builds don't re-download the registry even when the lockfile changes.
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+
+# ---- Stage 2: build the application ---------------------------------------
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+# Reuse the dependency layer verbatim (no re-install).
+COPY --from=deps /app/node_modules ./node_modules
+
+# Copy source and config needed by `next build`.
+COPY . .
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Re-run the npm cache mount so any installs triggered at build time are also
+# cached, and the production bundle is emitted as standalone output.
+RUN --mount=type=cache,target=/root/.npm \
+    npm run build
+
+# ---- Stage 3: minimal production runtime -----------------------------------
+FROM node:22-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+# Run as an unprivileged user.
+RUN addgroup --system --gid 1001 nodejs \
+    && adduser --system --uid 1001 nextjs
+
+# Static assets must be copied next to the standalone server.
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,11 @@ const CONTENT_SECURITY_POLICY = [
 ].join("; ");
 
 const nextConfig: NextConfig = {
+  // Emit a self-contained server bundle (`.next/standalone`) so the Docker
+  // image only ships the minimal runtime artifacts instead of `node_modules`.
+  // This keeps the final layer small and lets `docker build` cache layers that
+  // are unaffected by source-only changes. See issue #167.
+  output: "standalone",
   headers: async () => [
     {
       source: "/(.*)",


### PR DESCRIPTION
## Summary

Closes #167

This PR adds Docker image layer caching optimization for CI. Previously the repository had **no `Dockerfile`, no `.dockerignore`, and no Docker build job**, and the existing test workflow ran uncached `npm ci` / `npm run build` on every run.

## Changes

### 1. Optimized multi-stage `Dockerfile`
- **Stage 1 (`deps`)** — copies only `package.json` + `package-lock.json` first, then runs `npm ci` with a BuildKit cache mount (`--mount=type=cache,target=/root/.npm`). Dependency resolution becomes its own cacheable layer that only re-runs when the lockfile changes.
- **Stage 2 (`builder`)** — reuses the dependency layer verbatim (no re-install) and only rebuilds when source files change.
- **Stage 3 (`runner`)** — ships only Next.js **standalone output** (no `node_modules`), runs as an unprivileged `nextjs` user, and yields a small immutable final layer.

### 2. `next.config.ts`
- Enabled `output: "standalone"` so the production image carries only the minimal runtime artifacts.

### 3. `.dockerignore`
- Excludes `node_modules`, `.next`, `.git`, `.github`, tests, docs, and other build context bloat so irrelevant changes don't invalidate layer cache.

### 4. New `.github/workflows/docker-build.yml`
- Uses Buildx with the GitHub Actions cache backend:
  - `cache-from: type=gha`
  - `cache-to: type=gha,mode=max`
- Pushes the image to **GHCR** on `main`, builds only (no push) on PRs.
- Auto-generates tags/labels via `docker/metadata-action`.

### 5. Existing `.github/workflows/test.yml`
- Added `cache: npm` to `actions/setup-node` and bumped `checkout`/`setup-node` to `v4`, so dependency installs are cached across CI runs.

## Verification

- ✅ `npm run build` succeeds with `output: "standalone"`.
- ✅ `docker buildx build` completes successfully (multi-stage build).
- ✅ Smoke test: container serves the app with **HTTP 200** on `/`.

## Notes

- The image is tagged `ghcr.io/VeriNode-Labs/VeriNode-Frontend`; the GHCR push on `main` uses the built-in `GITHUB_TOKEN`.

---

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>