### PR TITLE
feat(developer-portal): add API key CRUD and usage dashboard

### DIFF
--- a/app/(dashboard)/developer/page.tsx
+++ b/app/(dashboard)/developer/page.tsx
@@ -1,0 +1,36 @@
+import { ApiKeyCreate } from '@/src/components/developer/ApiKeyCreate'
+import { ApiKeyList } from '@/src/components/developer/ApiKeyList'
+import { UsageDashboard } from '@/src/components/developer/UsageDashboard'
+
+export default function DeveloperPortalPage() {
+  return (
+    <div className="mx-auto max-w-5xl space-y-8 px-4 py-8">
+      <div>
+        <h1 className="text-xl font-bold text-zinc-900 dark:text-zinc-50">Developer portal</h1>
+        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+          Manage API keys, monitor usage, and test endpoints.
+        </p>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <section aria-labelledby="api-keys-heading" className="min-w-0">
+          <h2 id="api-keys-heading" className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+            API keys
+          </h2>
+          <ApiKeyList />
+        </section>
+
+        <aside>
+          <ApiKeyCreate />
+        </aside>
+      </div>
+
+      <section aria-labelledby="usage-heading">
+        <h2 id="usage-heading" className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+          Usage
+        </h2>
+        <UsageDashboard />
+      </section>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6078,6 +6078,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/components/developer/ApiKeyCreate.tsx
+++ b/src/components/developer/ApiKeyCreate.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useState } from 'react'
+import { useApiKeyStore } from '@/src/store/apiKeyStore'
+import type { ApiKeyScope } from '@/src/types/apiKey'
+import { ScopeCheckboxGroup } from './ScopeCheckboxGroup'
+
+export function ApiKeyCreate() {
+  const { createKey, justCreated, clearJustCreated, isLoading } = useApiKeyStore()
+  const [name, setName] = useState('')
+  const [scopes, setScopes] = useState<ApiKeyScope[]>([])
+  const [copied, setCopied] = useState(false)
+
+  const canSubmit = name.trim().length > 0 && scopes.length > 0 && !isLoading
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) return
+    await createKey(name.trim(), scopes)
+    setName('')
+    setScopes([])
+  }
+
+  async function handleCopy() {
+    if (!justCreated) return
+    await navigator.clipboard.writeText(justCreated.secret)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  function handleClose() {
+    setCopied(false)
+    clearJustCreated()
+  }
+
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      <h3 className="mb-1 text-sm font-semibold text-zinc-900 dark:text-zinc-50">Create API key</h3>
+      <p className="mb-4 text-xs text-zinc-500 dark:text-zinc-400">
+        The key secret is shown once. Store it somewhere safe — it can&apos;t be retrieved again.
+      </p>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="api-key-name" className="mb-1 block text-sm font-medium text-zinc-900 dark:text-zinc-50">
+            Name
+          </label>
+          <input
+            id="api-key-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Production backend"
+            className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50"
+          />
+        </div>
+
+        <ScopeCheckboxGroup selected={scopes} onChange={setScopes} />
+
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="w-full rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
+        >
+          {isLoading ? 'Creating…' : 'Create key'}
+        </button>
+      </form>
+
+      {justCreated ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="key-created-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+        >
+          <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl dark:bg-zinc-900">
+            <h2 id="key-created-title" className="mb-1 text-lg font-bold text-zinc-900 dark:text-zinc-50">
+              Key created
+            </h2>
+            <p className="mb-4 text-sm text-zinc-500 dark:text-zinc-400">
+              Copy <span className="font-semibold">{justCreated.name}</span> now — this is the only time it&apos;s
+              shown.
+            </p>
+
+            <div className="mb-4 flex items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2.5 dark:border-zinc-800 dark:bg-zinc-950">
+              <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono text-xs text-zinc-900 dark:text-zinc-50">
+                {justCreated.secret}
+              </code>
+              <button
+                onClick={handleCopy}
+                className="shrink-0 rounded-md bg-zinc-900 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
+              >
+                {copied ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+
+            <button
+              onClick={handleClose}
+              className="w-full rounded-lg border border-zinc-200 px-4 py-2.5 text-sm font-medium text-zinc-900 hover:bg-zinc-50 dark:border-zinc-800 dark:text-zinc-50 dark:hover:bg-zinc-800"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/developer/ApiKeyList.tsx
+++ b/src/components/developer/ApiKeyList.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useApiKeyStore } from '@/src/store/apiKeyStore'
+import type { ApiKey } from '@/src/types/apiKey'
+
+function formatDate(ms: number | null): string {
+  if (ms === null) return 'Never'
+  return new Date(ms).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function StatusBadge({ status }: { status: ApiKey['status'] }) {
+  const isActive = status === 'active'
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+        isActive
+          ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400'
+          : 'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400'
+      }`}
+    >
+      {isActive ? 'Active' : 'Revoked'}
+    </span>
+  )
+}
+
+export function ApiKeyList() {
+  const { keys, isLoading, error, fetchKeys, revokeKey } = useApiKeyStore()
+  const [pendingRevoke, setPendingRevoke] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchKeys()
+  }, [fetchKeys])
+
+  async function handleRevoke(id: string) {
+    setPendingRevoke(id)
+    await revokeKey(id)
+    setPendingRevoke(null)
+  }
+
+  if (isLoading && keys.length === 0) {
+    return (
+      <div className="rounded-xl border border-zinc-200 bg-white p-6 text-sm text-zinc-500 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
+        Loading API keys…
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-400">
+        {error}
+      </div>
+    )
+  }
+
+  if (keys.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-zinc-300 bg-white p-8 text-center dark:border-zinc-700 dark:bg-zinc-900">
+        <p className="text-sm font-medium text-zinc-900 dark:text-zinc-50">No API keys yet</p>
+        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">Create one to start calling the API.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-zinc-200 text-xs uppercase tracking-wide text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+            <th className="px-4 py-3 font-medium">Name</th>
+            <th className="px-4 py-3 font-medium">Scopes</th>
+            <th className="px-4 py-3 font-medium">Created</th>
+            <th className="px-4 py-3 font-medium">Last used</th>
+            <th className="px-4 py-3 font-medium">Status</th>
+            <th className="px-4 py-3 font-medium">
+              <span className="sr-only">Actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
+          {keys.map((key) => (
+            <tr key={key.id}>
+              <td className="px-4 py-3">
+                <div className="font-medium text-zinc-900 dark:text-zinc-50">{key.name}</div>
+                <div className="font-mono text-xs text-zinc-500 dark:text-zinc-400">{key.keyPreview}</div>
+              </td>
+              <td className="px-4 py-3">
+                <div className="flex flex-wrap gap-1">
+                  {key.scopes.map((scope) => (
+                    <span
+                      key={scope}
+                      className="rounded-md bg-zinc-100 px-1.5 py-0.5 font-mono text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+                    >
+                      {scope}
+                    </span>
+                  ))}
+                </div>
+              </td>
+              <td className="px-4 py-3 text-zinc-500 dark:text-zinc-400">{formatDate(key.createdAt)}</td>
+              <td className="px-4 py-3 text-zinc-500 dark:text-zinc-400">{formatDate(key.lastUsedAt)}</td>
+              <td className="px-4 py-3">
+                <StatusBadge status={key.status} />
+              </td>
+              <td className="px-4 py-3 text-right">
+                {key.status === 'active' ? (
+                  <button
+                    onClick={() => handleRevoke(key.id)}
+                    disabled={pendingRevoke === key.id}
+                    className="text-xs font-medium text-red-600 hover:text-red-800 disabled:opacity-40 dark:text-red-400 dark:hover:text-red-300"
+                  >
+                    {pendingRevoke === key.id ? 'Revoking…' : 'Revoke'}
+                  </button>
+                ) : null}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/developer/ErrorRateGauge.tsx
+++ b/src/components/developer/ErrorRateGauge.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useMemo } from 'react'
+import { ArcElement, Chart as ChartJS, Tooltip } from 'chart.js'
+import { Doughnut } from 'react-chartjs-2'
+
+ChartJS.register(ArcElement, Tooltip)
+
+interface ErrorRateGaugeProps {
+  /** 0-1 fraction, e.g. 0.023 = 2.3%. */
+  errorRate: number
+}
+
+function gaugeColor(errorRate: number): string {
+  if (errorRate < 0.01) return '#10b981' // emerald-500 — healthy
+  if (errorRate < 0.05) return '#f59e0b' // amber-500 — watch
+  return '#ef4444' // red-500 — unhealthy
+}
+
+export function ErrorRateGauge({ errorRate }: ErrorRateGaugeProps) {
+  const percent = errorRate * 100
+  const color = gaugeColor(errorRate)
+
+  const data = useMemo(
+    () => ({
+      datasets: [
+        {
+          data: [percent, Math.max(0, 100 - percent)],
+          backgroundColor: [color, 'rgba(161, 161, 170, 0.15)'],
+          borderWidth: 0,
+        },
+      ],
+    }),
+    [percent, color],
+  )
+
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      circumference: 180,
+      rotation: 270,
+      cutout: '75%',
+      plugins: { tooltip: { enabled: false }, legend: { display: false } },
+    }),
+    [],
+  )
+
+  return (
+    <div className="relative h-32">
+      <Doughnut data={data} options={options} />
+      <div className="absolute inset-x-0 bottom-2 flex flex-col items-center">
+        <span className="text-xl font-bold" style={{ color }}>
+          {percent.toFixed(2)}%
+        </span>
+        <span className="text-[11px] text-zinc-400 dark:text-zinc-500">error rate</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/developer/LatencyHeatmap.tsx
+++ b/src/components/developer/LatencyHeatmap.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useMemo } from 'react'
+import type { LatencyBucket } from '@/src/types/usage'
+
+interface LatencyHeatmapProps {
+  buckets: LatencyBucket[]
+}
+
+/** Maps a 0-1 intensity to a Tailwind zinc/amber scale — darker = slower. */
+function intensityColor(intensity: number): string {
+  if (intensity < 0.2) return 'bg-emerald-200 dark:bg-emerald-900/60'
+  if (intensity < 0.4) return 'bg-emerald-300 dark:bg-emerald-800/70'
+  if (intensity < 0.6) return 'bg-amber-300 dark:bg-amber-700/70'
+  if (intensity < 0.8) return 'bg-orange-400 dark:bg-orange-700/80'
+  return 'bg-red-500 dark:bg-red-700'
+}
+
+export function LatencyHeatmap({ buckets }: LatencyHeatmapProps) {
+  const maxP95 = useMemo(() => Math.max(1, ...buckets.map((b) => b.p95Ms)), [buckets])
+
+  if (buckets.length === 0) {
+    return (
+      <div className="flex h-24 items-center justify-center text-xs text-zinc-400 dark:text-zinc-500">
+        No latency data in this range yet
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div className="flex gap-0.5">
+        {buckets.map((bucket) => {
+          const intensity = bucket.p95Ms / maxP95
+          return (
+            <div
+              key={bucket.timestamp}
+              title={`p50 ${bucket.p50Ms}ms · p95 ${bucket.p95Ms}ms`}
+              className={`h-8 flex-1 rounded-sm ${intensityColor(intensity)}`}
+            />
+          )
+        })}
+      </div>
+      <div className="mt-2 flex items-center justify-between text-[11px] text-zinc-400 dark:text-zinc-500">
+        <span>{new Date(buckets[0].timestamp).toLocaleString()}</span>
+        <span>{new Date(buckets[buckets.length - 1].timestamp).toLocaleString()}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/developer/RequestCountChart.tsx
+++ b/src/components/developer/RequestCountChart.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useMemo } from 'react'
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Filler,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Tooltip,
+} from 'chart.js'
+import { Line } from 'react-chartjs-2'
+import type { UsageTimeRange, UsageTimeseriesPoint } from '@/src/types/usage'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Filler)
+
+interface RequestCountChartProps {
+  timeseries: UsageTimeseriesPoint[]
+  range: UsageTimeRange
+}
+
+function formatLabel(timestamp: number, range: UsageTimeRange): string {
+  const date = new Date(timestamp)
+  if (range === '1d') return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+export function RequestCountChart({ timeseries, range }: RequestCountChartProps) {
+  const data = useMemo(
+    () => ({
+      labels: timeseries.map((p) => formatLabel(p.timestamp, range)),
+      datasets: [
+        {
+          label: 'Requests',
+          data: timeseries.map((p) => p.requestCount),
+          borderColor: '#3f3f46',
+          backgroundColor: 'rgba(63, 63, 70, 0.08)',
+          fill: true,
+          tension: 0.3,
+          pointRadius: 0,
+          borderWidth: 2,
+        },
+      ],
+    }),
+    [timeseries, range],
+  )
+
+  const options = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: { mode: 'index' as const, intersect: false },
+      },
+      scales: {
+        x: { grid: { display: false }, ticks: { maxTicksLimit: 8 } },
+        y: { beginAtZero: true, grid: { color: 'rgba(161, 161, 170, 0.15)' } },
+      },
+    }),
+    [],
+  )
+
+  if (timeseries.length === 0) {
+    return (
+      <div className="flex h-56 items-center justify-center text-xs text-zinc-400 dark:text-zinc-500">
+        No requests in this range yet
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-56">
+      <Line data={data} options={options} />
+    </div>
+  )
+}

--- a/src/components/developer/ScopeCheckboxGroup.tsx
+++ b/src/components/developer/ScopeCheckboxGroup.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { API_KEY_SCOPES, type ApiKeyScope } from '@/src/types/apiKey'
+
+interface ScopeCheckboxGroupProps {
+  selected: ApiKeyScope[]
+  onChange: (scopes: ApiKeyScope[]) => void
+}
+
+const SCOPE_DESCRIPTIONS: Record<ApiKeyScope, string> = {
+  'node:read': 'View node status and topology',
+  'node:write': 'Register and configure nodes',
+  'staking:read': 'View staking balances and rewards',
+  'governance:read': 'View proposals and votes',
+  'governance:write': 'Create proposals and cast votes',
+  admin: 'Full account access — grants every scope above',
+}
+
+export function ScopeCheckboxGroup({ selected, onChange }: ScopeCheckboxGroupProps) {
+  function toggle(scope: ApiKeyScope) {
+    if (selected.includes(scope)) {
+      onChange(selected.filter((s) => s !== scope))
+    } else {
+      onChange([...selected, scope])
+    }
+  }
+
+  return (
+    <fieldset className="space-y-2">
+      <legend className="mb-1 text-sm font-semibold text-zinc-900 dark:text-zinc-50">Permission scopes</legend>
+      {API_KEY_SCOPES.map((scope) => (
+        <label
+          key={scope}
+          className="flex cursor-pointer items-start gap-3 rounded-lg border border-zinc-200 px-3 py-2.5 transition hover:border-zinc-400 dark:border-zinc-800 dark:hover:border-zinc-600"
+        >
+          <input
+            type="checkbox"
+            checked={selected.includes(scope)}
+            onChange={() => toggle(scope)}
+            className="mt-0.5 h-4 w-4 rounded border-zinc-300 text-zinc-900 focus:ring-2 focus:ring-zinc-500 dark:border-zinc-700"
+          />
+          <span className="min-w-0">
+            <span className="block font-mono text-sm text-zinc-900 dark:text-zinc-50">{scope}</span>
+            <span className="block text-xs text-zinc-500 dark:text-zinc-400">{SCOPE_DESCRIPTIONS[scope]}</span>
+          </span>
+        </label>
+      ))}
+    </fieldset>
+  )
+}

--- a/src/components/developer/TimeRangeSelector.tsx
+++ b/src/components/developer/TimeRangeSelector.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { USAGE_TIME_RANGES, type UsageTimeRange } from '@/src/types/usage'
+
+const LABELS: Record<UsageTimeRange, string> = {
+  '1d': '24h',
+  '7d': '7d',
+  '30d': '30d',
+}
+
+interface TimeRangeSelectorProps {
+  value: UsageTimeRange
+  onChange: (range: UsageTimeRange) => void
+}
+
+export function TimeRangeSelector({ value, onChange }: TimeRangeSelectorProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Time range"
+      className="inline-flex rounded-lg border border-zinc-200 bg-zinc-50 p-0.5 dark:border-zinc-800 dark:bg-zinc-950"
+    >
+      {USAGE_TIME_RANGES.map((range) => {
+        const isActive = range === value
+        return (
+          <button
+            key={range}
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(range)}
+            className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              isActive
+                ? 'bg-white text-zinc-900 shadow-sm dark:bg-zinc-800 dark:text-zinc-50'
+                : 'text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
+            }`}
+          >
+            {LABELS[range]}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/developer/UsageDashboard.tsx
+++ b/src/components/developer/UsageDashboard.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useApiKeyStore } from '@/src/store/apiKeyStore'
+import { usageService } from '@/src/services/usageService'
+import type { UsageSummary, UsageTimeRange } from '@/src/types/usage'
+import { TimeRangeSelector } from './TimeRangeSelector'
+import { RequestCountChart } from './RequestCountChart'
+import { LatencyHeatmap } from './LatencyHeatmap'
+import { ErrorRateGauge } from './ErrorRateGauge'
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      <h3 className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-50">{title}</h3>
+      {children}
+    </div>
+  )
+}
+
+export function UsageDashboard() {
+  const { keys, fetchKeys } = useApiKeyStore()
+  const activeKeys = keys.filter((k) => k.status === 'active')
+
+  const [selectedKeyId, setSelectedKeyId] = useState<string | null>(null)
+  const [range, setRange] = useState<UsageTimeRange>('7d')
+  const [summary, setSummary] = useState<UsageSummary | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchKeys()
+  }, [fetchKeys])
+
+  useEffect(() => {
+    if (!selectedKeyId && activeKeys.length > 0) {
+      setSelectedKeyId(activeKeys[0].id)
+    }
+  }, [activeKeys, selectedKeyId])
+
+  useEffect(() => {
+    if (!selectedKeyId) return
+    let cancelled = false
+    setIsLoading(true)
+    setError(null)
+    usageService
+      .getUsage(selectedKeyId, range)
+      .then((result) => {
+        if (!cancelled) setSummary(result)
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load usage data')
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedKeyId, range])
+
+  if (activeKeys.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-zinc-300 bg-white p-8 text-center dark:border-zinc-700 dark:bg-zinc-900">
+        <p className="text-sm font-medium text-zinc-900 dark:text-zinc-50">No active keys to show usage for</p>
+        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">Create an API key to start seeing analytics.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <select
+          value={selectedKeyId ?? ''}
+          onChange={(e) => setSelectedKeyId(e.target.value)}
+          className="rounded-lg border border-zinc-200 px-3 py-1.5 text-sm dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50"
+        >
+          {activeKeys.map((key) => (
+            <option key={key.id} value={key.id}>
+              {key.name}
+            </option>
+          ))}
+        </select>
+        <TimeRangeSelector value={range} onChange={setRange} />
+      </div>
+
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-400">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <Card title="Requests">
+            {isLoading || !summary ? (
+              <div className="flex h-56 items-center justify-center text-xs text-zinc-400 dark:text-zinc-500">
+                Loading…
+              </div>
+            ) : (
+              <RequestCountChart timeseries={summary.timeseries} range={range} />
+            )}
+          </Card>
+        </div>
+
+        <Card title="Error rate">
+          {isLoading || !summary ? (
+            <div className="flex h-32 items-center justify-center text-xs text-zinc-400 dark:text-zinc-500">
+              Loading…
+            </div>
+          ) : (
+            <ErrorRateGauge errorRate={summary.errorRate} />
+          )}
+        </Card>
+
+        <div className="lg:col-span-2">
+          <Card title="Latency (p95 per bucket)">
+            {isLoading || !summary ? (
+              <div className="flex h-24 items-center justify-center text-xs text-zinc-400 dark:text-zinc-500">
+                Loading…
+              </div>
+            ) : (
+              <LatencyHeatmap buckets={summary.latencyBuckets} />
+            )}
+            {summary ? (
+              <p className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
+                p50 {summary.p50LatencyMs}ms · p95 {summary.p95LatencyMs}ms
+              </p>
+            ) : null}
+          </Card>
+        </div>
+
+        <Card title="Top endpoints">
+          {isLoading || !summary ? (
+            <div className="flex h-24 items-center justify-center text-xs text-zinc-400 dark:text-zinc-500">
+              Loading…
+            </div>
+          ) : summary.topEndpoints.length === 0 ? (
+            <p className="text-xs text-zinc-400 dark:text-zinc-500">No requests yet</p>
+          ) : (
+            <ul className="space-y-2">
+              {summary.topEndpoints.map((ep) => (
+                <li key={ep.endpoint} className="flex items-center justify-between text-xs">
+                  <code className="text-zinc-700 dark:text-zinc-300">{ep.endpoint}</code>
+                  <span className="font-medium text-zinc-500 dark:text-zinc-400">{ep.requestCount}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/api/devPortalClient.ts
+++ b/src/lib/api/devPortalClient.ts
@@ -1,0 +1,54 @@
+/**
+ * ASSUMPTION — placeholder HTTP client.
+ *
+ * I don't yet have the contents of the real `src/lib/api/` client, so this
+ * is a minimal stand-in with the same shape most fetch wrappers use
+ * (base URL + JSON in/out + thrown ApiError on non-2xx). Once you paste
+ * the real client, delete this file and point `apiKeyService.ts` /
+ * `webhookTesterService.ts` at it instead — the call sites are written
+ * against a `{ get, post, delete }` shape so the swap should be a
+ * one-line import change.
+ */
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body?: unknown,
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? '/api/v1'
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  })
+
+  if (!res.ok) {
+    let body: unknown
+    try {
+      body = await res.json()
+    } catch {
+      body = null
+    }
+    throw new ApiError(`Request to ${path} failed with status ${res.status}`, res.status, body)
+  }
+
+  if (res.status === 204) return undefined as T
+  return res.json() as Promise<T>
+}
+
+export const devPortalClient = {
+  get: <T>(path: string) => request<T>(path, { method: 'GET' }),
+  post: <T>(path: string, body?: unknown) =>
+    request<T>(path, { method: 'POST', body: body !== undefined ? JSON.stringify(body) : undefined }),
+  delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
+}

--- a/src/services/apiKeyService.ts
+++ b/src/services/apiKeyService.ts
@@ -1,0 +1,34 @@
+/**
+ * Developer Portal — API Key Service (#dev-portal)
+ *
+ * CRUD against the API-key management endpoints. Follows the factory-
+ * function convention used elsewhere in src/services (see
+ * createWebhookService, createPerTenantRateLimiter) so it composes the
+ * same way and is trivially mockable in tests.
+ */
+
+import { devPortalClient } from '@/src/lib/api/devPortalClient'
+import type { ApiKey, CreateApiKeyRequest, CreatedApiKey } from '@/src/types/apiKey'
+
+export interface ApiKeyService {
+  list(): Promise<ApiKey[]>
+  create(req: CreateApiKeyRequest): Promise<CreatedApiKey>
+  revoke(id: string): Promise<void>
+}
+
+export function createApiKeyService(client = devPortalClient): ApiKeyService {
+  return {
+    list() {
+      return client.get<ApiKey[]>('/dev/keys')
+    },
+    create(req: CreateApiKeyRequest) {
+      return client.post<CreatedApiKey>('/dev/keys', req)
+    },
+    revoke(id: string) {
+      return client.delete<void>(`/dev/keys/${id}`)
+    },
+  }
+}
+
+/** Shared singleton for components that don't need a custom client (e.g. tests). */
+export const apiKeyService = createApiKeyService()

--- a/src/services/usageService.ts
+++ b/src/services/usageService.ts
@@ -1,0 +1,23 @@
+/**
+ * Developer Portal — Usage Service (#dev-portal)
+ *
+ * Same factory-function + devPortalClient pattern as apiKeyService.ts.
+ * Swap the client injection once the real src/lib/api client is shared.
+ */
+
+import { devPortalClient } from '@/src/lib/api/devPortalClient'
+import type { UsageSummary, UsageTimeRange } from '@/src/types/usage'
+
+export interface UsageService {
+  getUsage(keyId: string, range: UsageTimeRange): Promise<UsageSummary>
+}
+
+export function createUsageService(client = devPortalClient): UsageService {
+  return {
+    getUsage(keyId: string, range: UsageTimeRange) {
+      return client.get<UsageSummary>(`/dev/keys/${keyId}/usage?range=${range}`)
+    },
+  }
+}
+
+export const usageService = createUsageService()

--- a/src/store/apiKeyStore.ts
+++ b/src/store/apiKeyStore.ts
@@ -1,0 +1,63 @@
+import { create } from "zustand"
+import { apiKeyService } from "@/src/services/apiKeyService"
+import type { ApiKey, ApiKeyScope, CreatedApiKey } from "@/src/types/apiKey"
+
+interface ApiKeyState {
+  keys: ApiKey[]
+  isLoading: boolean
+  error: string | null
+  /** The most recently created key, secret included — cleared once the modal closes. */
+  justCreated: CreatedApiKey | null
+
+  fetchKeys: () => Promise<void>
+  createKey: (name: string, scopes: ApiKeyScope[]) => Promise<void>
+  revokeKey: (id: string) => Promise<void>
+  clearJustCreated: () => void
+}
+
+export const useApiKeyStore = create<ApiKeyState>((set, get) => ({
+  keys: [],
+  isLoading: false,
+  error: null,
+  justCreated: null,
+
+  fetchKeys: async () => {
+    set({ isLoading: true, error: null })
+    try {
+      const keys = await apiKeyService.list()
+      set({ keys, isLoading: false })
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Failed to load API keys", isLoading: false })
+    }
+  },
+
+  createKey: async (name, scopes) => {
+    set({ isLoading: true, error: null })
+    try {
+      const created = await apiKeyService.create({ name, scopes })
+      set({
+        keys: [...get().keys, created],
+        justCreated: created,
+        isLoading: false,
+      })
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Failed to create API key", isLoading: false })
+      throw err
+    }
+  },
+
+  revokeKey: async (id) => {
+    const prevKeys = get().keys
+    // Optimistic update — flip status immediately, roll back on failure.
+    set({
+      keys: prevKeys.map((k) => (k.id === id ? { ...k, status: "revoked" as const } : k)),
+    })
+    try {
+      await apiKeyService.revoke(id)
+    } catch (err) {
+      set({ keys: prevKeys, error: err instanceof Error ? err.message : "Failed to revoke API key" })
+    }
+  },
+
+  clearJustCreated: () => set({ justCreated: null }),
+}))

--- a/src/types/apiKey.ts
+++ b/src/types/apiKey.ts
@@ -1,0 +1,45 @@
+/**
+ * Developer Portal — API Key types (#dev-portal)
+ *
+ * Mirrors the scope set defined in the issue spec. Keep this list in sync
+ * with whatever the backend enforces — it is the single source of truth
+ * for the scope checkboxes rendered in `ApiKeyCreate`.
+ */
+
+export const API_KEY_SCOPES = [
+  'node:read',
+  'node:write',
+  'staking:read',
+  'governance:read',
+  'governance:write',
+  'admin',
+] as const
+
+export type ApiKeyScope = (typeof API_KEY_SCOPES)[number]
+
+export type ApiKeyStatus = 'active' | 'revoked'
+
+/** A key as returned by the list endpoint — the raw secret is never included here. */
+export interface ApiKey {
+  id: string
+  name: string
+  scopes: ApiKeyScope[]
+  /** Redacted preview e.g. "vn_live_••••7f2a" for display in the table. */
+  keyPreview: string
+  status: ApiKeyStatus
+  createdAt: number
+  lastUsedAt: number | null
+  /** Tier drives the rate limit shown in RateLimitGauge (e.g. 'free' | 'pro' | 'enterprise'). */
+  tier: string
+}
+
+/** Response shape returned exactly once, at creation time, containing the raw secret. */
+export interface CreatedApiKey extends ApiKey {
+  /** The full, usable secret. Shown once in the creation modal, never persisted client-side. */
+  secret: string
+}
+
+export interface CreateApiKeyRequest {
+  name: string
+  scopes: ApiKeyScope[]
+}

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -1,0 +1,36 @@
+/**
+ * Developer Portal — Usage Dashboard types (#dev-portal)
+ */
+
+export const USAGE_TIME_RANGES = ['1d', '7d', '30d'] as const
+export type UsageTimeRange = (typeof USAGE_TIME_RANGES)[number]
+
+export interface UsageTimeseriesPoint {
+  /** Unix-millisecond timestamp for this bucket. */
+  timestamp: number
+  requestCount: number
+}
+
+export interface LatencyBucket {
+  timestamp: number
+  p50Ms: number
+  p95Ms: number
+}
+
+export interface EndpointUsage {
+  endpoint: string
+  requestCount: number
+}
+
+export interface UsageSummary {
+  keyId: string
+  range: UsageTimeRange
+  totalRequests: number
+  /** 0-1 fraction, e.g. 0.023 = 2.3% error rate. */
+  errorRate: number
+  p50LatencyMs: number
+  p95LatencyMs: number
+  timeseries: UsageTimeseriesPoint[]
+  latencyBuckets: LatencyBucket[]
+  topEndpoints: EndpointUsage[]
+}


### PR DESCRIPTION
## Summary
Implements steps 1–3 of the Developer Portal issue: API key management (create, list, revoke) and a per-key usage analytics dashboard.

Closes #171 

## What's included
- **API key CRUD**
  - `ApiKeyList` — table of keys with name, scopes, created date, last used, status, and revoke action
  - `ApiKeyCreate` — form with name input + scope checkboxes; shows the raw secret once in a modal with copy-to-clipboard
  - `apiKeyService` + `apiKeyStore` (Zustand) wiring it to the backend, with optimistic revoke
- **Usage dashboard**
  - Time range selector (24h / 7d / 30d)
  - Request-count line chart (`chart.js` / `react-chartjs-2`)
  - Latency view (p50/p95 per bucket)
  - Error-rate gauge (doughnut-as-gauge, no new dependency)
  - Top endpoints list
  - Per-key selector, defaults to the first active key
- New route: `app/(dashboard)/developer`

## Not yet included (follow-up PRs)
- Swagger UI playground with dynamic Authorization header
- Rate limit gauge
- Webhook tester (`POST /api/v1/dev/webhook`)

## Notes for reviewers
- `src/lib/api/devPortalClient.ts` is a minimal placeholder fetch client — happy to swap it for the project's existing `lib/api` client if reviewers point me to the preferred pattern.
- Backend contract assumed for `GET /dev/keys`, `POST /dev/keys`, `DELETE /dev/keys/:id`, and `GET /dev/keys/:id/usage?range=` — flag if these don't match the actual API shape.
- UI primitives (table, modal) are inline JSX styled to match existing `zinc`/Tailwind conventions rather than pulled from `components/ui`, since I didn't have visibility into what's there — can refactor to reuse existing primitives if pointed to them.

## Testing
- [ ] Manually verified key creation, list, and revoke flow
- [ ] Manually verified usage dashboard renders across all three time ranges
- [ ] `npm run lint`
- [ ] `npm run test:e2e:wallet`