### PR TITLE
feat(theme): dark mode theme system with system preference detection

### DIFF
--- a/FRONTEND.md
+++ b/FRONTEND.md
@@ -190,16 +190,19 @@ const config: Config = {
 
 ### Theme System
 
-Four themes are supported, defined in `src/styles/themes.ts` and driven by the palette in `src/styles/colors.ts`:
+Four themes are supported, defined in `src/styles/themes.ts` and driven by the palette in `src/styles/colors.ts`, plus a `system` mode that follows the OS `prefers-color-scheme` setting:
 
 | Theme ID | Description |
 |----------|-------------|
+| `system` | Follow the OS light/dark preference (default) |
 | `light` | Default light mode for office use |
 | `dark` | Standard dark mode |
 | `hc-dark` | High-contrast palette tuned for dim server rooms |
 | `hc-light` | High-contrast palette tuned for bright NOC floors |
 
-Theme switching applies a `data-theme` attribute to `:root`, which activates CSS custom properties injected by the Tailwind plugin.
+Theme switching applies a `data-theme` attribute to `:root`, which activates CSS custom properties injected by the Tailwind plugin. The `ThemeProvider` reads the stored preference (`localStorage`, key `verinode-theme`), falls back to `prefers-color-scheme` when nothing is stored, listens for OS preference changes via `matchMedia`, and exposes `useTheme()` returning `(theme, setTheme, resolvedTheme)`. A pre-hydration script (`public/theme-init.js`) applies the theme before first paint to avoid a flash of the wrong theme.
+
+The `ThemeToggle` button (sun/moon/monitor icons) cycles `system -> light -> dark`; it lives in the dashboard header and on the home page. Lightweight Charts instances re-theme on mode change via `chart.applyOptions()` using the tokens in `src/styles/chartTheme.ts`.
 
 ### Color Tokens
 

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -3,15 +3,19 @@
 import { SyncStatusBar } from '@/src/components/SyncStatusBar';
 import { OfflineBanner } from '@/src/components/layout/OfflineBanner';
 import { WSHealthTier3Banner } from '@/src/components/layout/WSHealthTier3Banner';
+import { ThemeToggle } from '@/src/components/ui/ThemeToggle';
 
 // Full dashboard layout — SyncStatusBar and OfflineBanner are only loaded
 // for routes inside (dashboard), keeping the auth/login critical path lean.
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-screen flex-col" role="application" aria-label="Dashboard">
+    <div className="flex min-h-screen flex-col bg-background" role="application" aria-label="Dashboard">
       <a href="#main-content" className="skip-to-content">
         Skip to main content
       </a>
+      <header className="sticky top-0 z-40 flex h-12 items-center justify-end border-b border-border bg-surface/90 px-4 backdrop-blur">
+        <ThemeToggle />
+      </header>
       <OfflineBanner />
       <WSHealthTier3Banner />
       <main id="main-content" aria-label="Main dashboard content">

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,56 +1,367 @@
 @import "tailwindcss";
 
+/* ===========================================================================
+   Theme token system (issue #169)
+   ---------------------------------------------------------------------------
+   60+ CSS custom properties per theme: colors, spacing, shadows, radii.
+   Themes are activated by the `data-theme` attribute on <html>, which the
+   ThemeProvider sets from the user's stored preference (falling back to the
+   OS `prefers-color-scheme` setting). Token values are consumed either
+   directly via `var(--token)` or through the mapped Tailwind utilities
+   (e.g. `bg-surface`, `text-muted-foreground`, `shadow-card`).
+   =========================================================================== */
+
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-  --surface: #f8fafc;
+  /* Colors — light (default) */
+  --background: #f8fafc;
+  --foreground: #0f172a;
+  --surface: #ffffff;
+  --surface-alt: #f1f5f9;
+  --surface-hover: #f1f5f9;
+  --surface-active: #e2e8f0;
+  --surface-sunken: #f1f5f9;
   --border: #cbd5e1;
+  --border-strong: #94a3b8;
+  --border-muted: #e2e8f0;
   --muted: #64748b;
+  --muted-foreground: #64748b;
+  --muted-bg: #f1f5f9;
   --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  --primary-active: #1e40af;
   --primary-foreground: #ffffff;
+  --secondary: #f1f5f9;
+  --secondary-foreground: #334155;
+  --accent: #e0e7ff;
+  --accent-foreground: #3730a3;
   --destructive: #dc2626;
+  --destructive-hover: #b91c1c;
+  --destructive-foreground: #ffffff;
   --success: #16a34a;
+  --success-foreground: #ffffff;
+  --warning: #d97706;
+  --warning-foreground: #ffffff;
+  --info: #0284c7;
+  --info-foreground: #ffffff;
+  --link: #2563eb;
+  --focus-ring: #2563eb;
+  --selection: rgba(37, 99, 235, 0.2);
+  --overlay: rgba(15, 23, 42, 0.5);
+  --input: #ffffff;
+  --card: #ffffff;
+  --popover: #ffffff;
+  --skeleton: #e2e8f0;
+  --scrollbar-thumb: #cbd5e1;
+  --scrollbar-track: transparent;
+  --chart-1: #2563eb;
+  --chart-2: #16a34a;
+  --chart-3: #d97706;
+  --chart-4: #dc2626;
+  --chart-5: #7c3aed;
+  --chart-6: #0891b2;
+  --chart-7: #db2777;
+  --chart-8: #65a30d;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Border radius */
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-2xl: 1.5rem;
+  --radius-full: 9999px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgb(15 23 42 / 0.06);
+  --shadow-md: 0 4px 6px -1px rgb(15 23 42 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(15 23 42 / 0.1);
+  --shadow-xl: 0 20px 25px -5px rgb(15 23 42 / 0.1);
+  --shadow-card: 0 1px 3px rgb(15 23 42 / 0.08);
+  --shadow-popover: 0 10px 30px rgb(0 0 0 / 0.2);
 }
 
 :root[data-theme='dark'] {
   --background: #020617;
   --foreground: #f8fafc;
   --surface: #0f172a;
+  --surface-alt: #1e293b;
+  --surface-hover: #1e293b;
+  --surface-active: #334155;
+  --surface-sunken: #020617;
   --border: #475569;
+  --border-strong: #64748b;
+  --border-muted: #334155;
   --muted: #cbd5e1;
+  --muted-foreground: #94a3b8;
+  --muted-bg: #1e293b;
   --primary: #60a5fa;
+  --primary-hover: #93c5fd;
+  --primary-active: #3b82f6;
   --primary-foreground: #020617;
+  --secondary: #1e293b;
+  --secondary-foreground: #e2e8f0;
+  --accent: #312e81;
+  --accent-foreground: #c7d2fe;
   --destructive: #f87171;
+  --destructive-hover: #fca5a5;
+  --destructive-foreground: #450a0a;
   --success: #4ade80;
+  --success-foreground: #052e16;
+  --warning: #fbbf24;
+  --warning-foreground: #451a03;
+  --info: #38bdf8;
+  --info-foreground: #082f49;
+  --link: #93c5fd;
+  --focus-ring: #60a5fa;
+  --selection: rgba(96, 165, 250, 0.3);
+  --overlay: rgba(2, 6, 23, 0.7);
+  --input: #0f172a;
+  --card: #0f172a;
+  --popover: #1e293b;
+  --skeleton: #1e293b;
+  --scrollbar-thumb: #334155;
+  --scrollbar-track: transparent;
+  --chart-1: #60a5fa;
+  --chart-2: #4ade80;
+  --chart-3: #fbbf24;
+  --chart-4: #f87171;
+  --chart-5: #a78bfa;
+  --chart-6: #22d3ee;
+  --chart-7: #f472b6;
+  --chart-8: #a3e635;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-2xl: 1.5rem;
+  --radius-full: 9999px;
+
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.4);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.5);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.5);
+  --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.6);
+  --shadow-card: 0 1px 3px rgb(0 0 0 / 0.4);
+  --shadow-popover: 0 10px 30px rgb(0 0 0 / 0.7);
 }
 
 :root[data-theme='hc-dark'] {
   --background: #000000;
   --foreground: #f5f5f5;
   --surface: #111111;
+  --surface-alt: #1a1a1a;
+  --surface-hover: #1a1a1a;
+  --surface-active: #2a2a2a;
+  --surface-sunken: #000000;
   --border: #ffffff;
+  --border-strong: #ffffff;
+  --border-muted: #808080;
   --muted: #d4d4d4;
+  --muted-foreground: #d4d4d4;
+  --muted-bg: #1a1a1a;
   --primary: #ffd700;
+  --primary-hover: #ffe44d;
+  --primary-active: #ccac00;
   --primary-foreground: #000000;
+  --secondary: #1a1a1a;
+  --secondary-foreground: #f5f5f5;
+  --accent: #2a2a2a;
+  --accent-foreground: #ffd700;
   --destructive: #ff0000;
+  --destructive-hover: #ff6666;
+  --destructive-foreground: #ffffff;
   --success: #00cc00;
+  --success-foreground: #000000;
+  --warning: #ffcc00;
+  --warning-foreground: #000000;
+  --info: #66ccff;
+  --info-foreground: #000000;
+  --link: #ffd700;
+  --focus-ring: #ffd700;
+  --selection: rgba(255, 215, 0, 0.35);
+  --overlay: rgba(0, 0, 0, 0.8);
+  --input: #111111;
+  --card: #111111;
+  --popover: #1a1a1a;
+  --skeleton: #2a2a2a;
+  --scrollbar-thumb: #808080;
+  --scrollbar-track: #000000;
+  --chart-1: #ffd700;
+  --chart-2: #00cc00;
+  --chart-3: #ffcc00;
+  --chart-4: #ff0000;
+  --chart-5: #ff66cc;
+  --chart-6: #66ccff;
+  --chart-7: #ff9933;
+  --chart-8: #99ff66;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-2xl: 1.5rem;
+  --radius-full: 9999px;
+
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.6);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.7);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.7);
+  --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.8);
+  --shadow-card: 0 1px 3px rgb(0 0 0 / 0.6);
+  --shadow-popover: 0 10px 30px rgb(0 0 0 / 0.9);
 }
 
 :root[data-theme='hc-light'] {
   --background: #ffffff;
   --foreground: #000000;
-  --surface: #f5f5f5;
+  --surface: #ffffff;
+  --surface-alt: #f0f0f0;
+  --surface-hover: #f0f0f0;
+  --surface-active: #dcdcdc;
+  --surface-sunken: #f0f0f0;
   --border: #000000;
+  --border-strong: #000000;
+  --border-muted: #666666;
   --muted: #333333;
+  --muted-foreground: #333333;
+  --muted-bg: #f0f0f0;
   --primary: #0000ff;
+  --primary-hover: #3333ff;
+  --primary-active: #0000cc;
   --primary-foreground: #ffffff;
+  --secondary: #f0f0f0;
+  --secondary-foreground: #000000;
+  --accent: #ccccff;
+  --accent-foreground: #0000cc;
   --destructive: #ff0000;
-  --success: #00cc00;
+  --destructive-hover: #cc0000;
+  --destructive-foreground: #ffffff;
+  --success: #008800;
+  --success-foreground: #ffffff;
+  --warning: #884400;
+  --warning-foreground: #ffffff;
+  --info: #0044cc;
+  --info-foreground: #ffffff;
+  --link: #0000ff;
+  --focus-ring: #0000ff;
+  --selection: rgba(0, 0, 255, 0.25);
+  --overlay: rgba(0, 0, 0, 0.5);
+  --input: #ffffff;
+  --card: #ffffff;
+  --popover: #ffffff;
+  --skeleton: #dcdcdc;
+  --scrollbar-thumb: #666666;
+  --scrollbar-track: #ffffff;
+  --chart-1: #0000ff;
+  --chart-2: #008800;
+  --chart-3: #884400;
+  --chart-4: #ff0000;
+  --chart-5: #6600cc;
+  --chart-6: #0066cc;
+  --chart-7: #cc0066;
+  --chart-8: #446600;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-2xl: 1.5rem;
+  --radius-full: 9999px;
+
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.2);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.25);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.25);
+  --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.3);
+  --shadow-card: 0 1px 3px rgb(0 0 0 / 0.2);
+  --shadow-popover: 0 10px 30px rgb(0 0 0 / 0.3);
 }
 
+/* Map tokens to Tailwind v4 utilities (bg-surface, text-muted-foreground, ...) */
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-surface-alt: var(--surface-alt);
+  --color-surface-hover: var(--surface-hover);
+  --color-surface-active: var(--surface-active);
+  --color-surface-sunken: var(--surface-sunken);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-border-muted: var(--border-muted);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted-bg: var(--muted-bg);
+  --color-primary: var(--primary);
+  --color-primary-hover: var(--primary-hover);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-info: var(--info);
+  --color-link: var(--link);
+  --color-card: var(--card);
+  --color-popover: var(--popover);
+  --color-input: var(--input);
+  --color-overlay: var(--overlay);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-chart-6: var(--chart-6);
+  --color-chart-7: var(--chart-7);
+  --color-chart-8: var(--chart-8);
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
+  --radius-xl: var(--radius-xl);
+  --radius-2xl: var(--radius-2xl);
+  --shadow-sm: var(--shadow-sm);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
+  --shadow-xl: var(--shadow-xl);
+  --shadow-card: var(--shadow-card);
+  --shadow-popover: var(--shadow-popover);
   --font-sans: Arial, Helvetica, sans-serif;
   --font-mono: "Courier New", Courier, monospace;
 }
@@ -59,6 +370,34 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Smooth theme transition                                                   */
+/* ------------------------------------------------------------------------- */
+/* The ThemeProvider adds `theme-transitioning` to <html> for the duration of
+   a theme switch so color changes animate instead of snapping. The class is
+   only present while the switch happens, so hover states elsewhere are never
+   affected. Disabled for users who prefer reduced motion. */
+html.theme-transitioning,
+html.theme-transitioning *,
+html.theme-transitioning *::before,
+html.theme-transitioning *::after {
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease,
+    color 0.3s ease,
+    fill 0.3s ease,
+    stroke 0.3s ease !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.theme-transitioning,
+  html.theme-transitioning *,
+  html.theme-transitioning *::before,
+  html.theme-transitioning *::after {
+    transition: none !important;
+  }
 }
 
 /* ------------------------------------------------------------------------- */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import { Inter } from "next/font/google";
 import { Providers } from "@/src/components/providers/Providers";
 
@@ -29,7 +30,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Apply the stored/system theme before first paint to avoid a flash
+            of the wrong theme (issue #169). The ThemeProvider takes over
+            after hydration. */}
+        <Script src="/theme-init.js" strategy="beforeInteractive" />
+      </head>
       <body
         className={`${inter.variable} antialiased`}
       >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,25 +2,30 @@
 
 import { DegradableFeature } from '@/src/components/DegradableFeature';
 import { ThemeSwitcher } from '@/src/components/ui/ThemeSwitcher';
+import { ThemeToggle } from '@/src/components/ui/ThemeToggle';
 import { SyncStatusBar } from '@/src/components/SyncStatusBar';
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen flex-col items-center bg-zinc-50 p-4 font-sans dark:bg-black">
-      <main id="main-content" className="flex w-full max-w-lg flex-col gap-6 rounded-xl bg-white p-8 shadow-sm dark:bg-zinc-900" aria-label="Home">
-        <DegradableFeature feature="staking">
-        <div>
-          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">
+    <div className="flex min-h-screen flex-col items-center bg-background p-4 font-sans">
+      <main id="main-content" className="flex w-full max-w-lg flex-col gap-6 rounded-xl bg-surface p-8 shadow-card" aria-label="Home">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-foreground">
             Submit Stake
           </h1>
-          <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-            Submit your staking transaction to the Soroban network
-          </p>
+          <ThemeToggle />
         </div>
 
-        <div className="mb-6">
-          <ThemeSwitcher />
-        </div>
+        <DegradableFeature feature="staking">
+          <div className="flex flex-col gap-4">
+            <p className="mt-1 text-sm text-muted-foreground">
+              Submit your staking transaction to the Soroban network
+            </p>
+
+            <div className="mb-6">
+              <ThemeSwitcher />
+            </div>
+          </div>
         </DegradableFeature>
       </main>
 

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,48 @@
+/**
+ * Theme pre-hydration bootstrap (issue #169).
+ *
+ * Runs before React hydrates so the first paint already reflects the user's
+ * stored theme preference (falling back to the OS `prefers-color-scheme`).
+ * The ThemeProvider reads the same storage key and takes over afterwards.
+ *
+ * This file is intentionally dependency-free and must stay valid ES5 so it
+ * executes in every supported browser, including older WebViews.
+ */
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'verinode-theme';
+  var VALID_MODES = ['system', 'light', 'dark', 'hc-dark', 'hc-light'];
+
+  try {
+    var stored = null;
+    try {
+      stored = window.localStorage.getItem(STORAGE_KEY);
+    } catch (e) {
+      stored = null;
+    }
+
+    var mode = VALID_MODES.indexOf(stored) !== -1 ? stored : 'system';
+    var prefersDark = false;
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      prefersDark = true;
+    }
+
+    var isHc = mode === 'hc-dark' || mode === 'hc-light';
+    var resolved = isHc ? (mode === 'hc-dark' ? 'dark' : 'light') : prefersDark ? 'dark' : 'light';
+    if (mode === 'light' || mode === 'dark') {
+      resolved = mode;
+    }
+
+    var root = document.documentElement;
+    root.dataset.theme = isHc ? mode : resolved;
+    if (resolved === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    root.style.colorScheme = resolved;
+  } catch (e) {
+    // Never block first paint on theme bootstrapping.
+  }
+})();

--- a/src/__tests__/themeProvider.test.tsx
+++ b/src/__tests__/themeProvider.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
+import { ThemeProvider } from '@/src/components/providers/ThemeProvider'
+import { ThemeToggle } from '@/src/components/ui/ThemeToggle'
+import { resolveTheme, isThemeMode } from '@/src/styles/themes'
+
+// ---------------------------------------------------------------------------
+// matchMedia mock — jsdom does not implement it natively.
+// ---------------------------------------------------------------------------
+interface MediaQueryListMock {
+  matches: boolean
+  media: string
+  addEventListener: ReturnType<typeof vi.fn>
+  removeEventListener: ReturnType<typeof vi.fn>
+  addListener: ReturnType<typeof vi.fn>
+  removeListener: ReturnType<typeof vi.fn>
+  dispatch: (matches: boolean) => void
+}
+
+function installMatchMedia(initialMatches: boolean): MediaQueryListMock {
+  const listeners = new Set<(event: { matches: boolean }) => void>()
+  const mql: MediaQueryListMock = {
+    matches: initialMatches,
+    media: '(prefers-color-scheme: dark)',
+    addEventListener: vi.fn((_type: string, cb: (event: { matches: boolean }) => void) => {
+      listeners.add(cb)
+    }),
+    removeEventListener: vi.fn((_type: string, cb: (event: { matches: boolean }) => void) => {
+      listeners.delete(cb)
+    }),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatch: (matches: boolean) => {
+      mql.matches = matches
+      listeners.forEach((cb) => cb({ matches }))
+    },
+  }
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia
+  return mql
+}
+
+const THEME_STORAGE_KEY = 'verinode-theme'
+
+/**
+ * The ThemeProvider animates theme switches inside a requestAnimationFrame
+ * callback (vitest's jsdom polyfill schedules it ~16ms later). This helper
+ * flushes pending rAF callbacks and state updates so assertions see the
+ * fully-applied theme.
+ */
+async function flushThemeChanges(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.clear()
+  window.matchMedia = undefined as unknown as typeof window.matchMedia
+})
+
+describe('theme resolution utilities', () => {
+  it('resolves explicit light and dark modes without touching the system preference', () => {
+    expect(resolveTheme('light', false)).toBe('light')
+    expect(resolveTheme('dark', false)).toBe('dark')
+    expect(resolveTheme('hc-light', true)).toBe('light')
+    expect(resolveTheme('hc-dark', true)).toBe('dark')
+  })
+
+  it('resolves system mode from the OS prefers-color-scheme preference', () => {
+    expect(resolveTheme('system', true)).toBe('dark')
+    expect(resolveTheme('system', false)).toBe('light')
+    expect(resolveTheme(undefined, false)).toBe('light')
+  })
+
+  it('validates stored mode strings', () => {
+    expect(isThemeMode('system')).toBe(true)
+    expect(isThemeMode('light')).toBe(true)
+    expect(isThemeMode('dark')).toBe(true)
+    expect(isThemeMode('hc-dark')).toBe(true)
+    expect(isThemeMode('hc-light')).toBe(true)
+    expect(isThemeMode('sepia')).toBe(false)
+    expect(isThemeMode(null)).toBe(false)
+  })
+})
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    installMatchMedia(false)
+  })
+
+  it('applies the stored theme to <html> on mount', async () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>,
+    )
+    await flushThemeChanges()
+
+    expect(document.documentElement.dataset.theme).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('falls back to the OS preference when nothing is stored', async () => {
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>,
+    )
+    await flushThemeChanges()
+
+    expect(document.documentElement.dataset.theme).toBe('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('follows OS preference changes while in system mode', async () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'system')
+    const mql = installMatchMedia(false)
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>,
+    )
+    await flushThemeChanges()
+
+    expect(document.documentElement.dataset.theme).toBe('light')
+
+    act(() => {
+      mql.dispatch(true)
+    })
+    await flushThemeChanges()
+
+    expect(document.documentElement.dataset.theme).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('persists the selection to localStorage when the theme changes', async () => {
+    render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>,
+    )
+    await flushThemeChanges()
+
+    fireEvent.click(screen.getByTestId('theme-toggle'))
+    await flushThemeChanges()
+
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light')
+    expect(document.documentElement.dataset.theme).toBe('light')
+  })
+
+  it('applies high-contrast themes verbatim as the data-theme attribute', async () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'hc-dark')
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>,
+    )
+    await flushThemeChanges()
+
+    expect(document.documentElement.dataset.theme).toBe('hc-dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+})
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    installMatchMedia(false)
+  })
+
+  it('cycles system -> light -> dark -> system on click', () => {
+    render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>,
+    )
+
+    const toggle = screen.getByTestId('theme-toggle')
+    expect(toggle.getAttribute('aria-label')).toContain('System')
+
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-label')).toContain('Light')
+
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-label')).toContain('Dark')
+
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-label')).toContain('System')
+  })
+
+  it('renders distinct icons per mode', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+    const { container } = render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>,
+    )
+
+    const svg = container.querySelector('[data-testid="theme-toggle"] svg')
+    expect(svg).toBeTruthy()
+
+    // Moon icon (dark) path marker: the moon path contains "a6 6 0 0 0".
+    expect(svg?.innerHTML).toContain('a6 6 0 0 0')
+  })
+})

--- a/src/components/SyncStatusBar.tsx
+++ b/src/components/SyncStatusBar.tsx
@@ -11,7 +11,7 @@ export function SyncStatusBar() {
   const lastSync = useSyncStore((s) => s.lastSync)
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-50 flex h-10 items-center justify-between border-t bg-white px-4 text-sm dark:border-zinc-700 dark:bg-zinc-900">
+    <div className="fixed bottom-0 left-0 right-0 z-50 flex h-10 items-center justify-between border-t border-border bg-surface px-4 text-sm">
       <div className="flex items-center gap-3">
         <div className="flex items-center gap-1.5">
           <span
@@ -19,12 +19,12 @@ export function SyncStatusBar() {
               isOnline ? 'bg-green-500' : 'bg-red-500'
             }`}
           />
-          <span className="text-zinc-600 dark:text-zinc-400">
+          <span className="text-muted-foreground">
             {isOnline ? 'Online' : 'Offline'}
           </span>
         </div>
         {!isOnline && pendingCount > 0 && (
-          <span className="rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+          <span className="rounded bg-warning/15 px-2 py-0.5 text-xs font-medium text-warning">
             {pendingCount} pending
           </span>
         )}
@@ -33,17 +33,17 @@ export function SyncStatusBar() {
       <div className="flex items-center gap-3">
         {isSyncing && (
           <div className="flex items-center gap-2">
-            <div className="h-2 w-24 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+            <div className="h-2 w-24 overflow-hidden rounded-full bg-surface-active">
               <div
                 className="h-full rounded-full bg-blue-500 transition-all duration-300"
                 style={{ width: `${progress}%` }}
               />
             </div>
-            <span className="text-xs text-zinc-500">{progress}%</span>
+            <span className="text-xs text-muted-foreground">{progress}%</span>
           </div>
         )}
         {lastSync && (
-          <span className="text-xs text-zinc-400">
+          <span className="text-xs text-muted-foreground">
             Last sync: {new Date(lastSync).toLocaleTimeString()}
           </span>
         )}

--- a/src/components/operator/PerformanceCharts.tsx
+++ b/src/components/operator/PerformanceCharts.tsx
@@ -16,6 +16,8 @@ import {
   filterEpochPointsByRange,
   filterTimestampPointsByRange,
 } from '@/src/lib/operatorTime';
+import { useTheme } from '@/src/components/providers/ThemeProvider';
+import { getChartTheme } from '@/src/styles/chartTheme';
 
 interface Point {
   time: UTCTimestamp;
@@ -48,6 +50,8 @@ function LwChart({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const seriesRef = useRef<ISeriesApi<'Area'> | ISeriesApi<'Histogram'> | null>(null);
+  const { resolvedTheme } = useTheme();
+  const chartTheme = useMemo(() => getChartTheme(resolvedTheme), [resolvedTheme]);
 
   // Create the chart once.
   useEffect(() => {
@@ -58,12 +62,12 @@ function LwChart({
       height,
       layout: {
         background: { type: ColorType.Solid, color: 'transparent' },
-        textColor: '#71717a',
+        textColor: chartTheme.textColor,
         attributionLogo: false,
       },
       grid: {
-        vertLines: { color: 'rgba(113,113,122,0.1)' },
-        horzLines: { color: 'rgba(113,113,122,0.1)' },
+        vertLines: { color: chartTheme.gridColor },
+        horzLines: { color: chartTheme.gridColor },
       },
       rightPriceScale: { borderVisible: false },
       timeScale: { borderVisible: false, timeVisible: true },
@@ -75,12 +79,12 @@ function LwChart({
     seriesRef.current =
       kind === 'area'
         ? chart.addSeries(AreaSeries, {
-            lineColor: '#3b82f6',
-            topColor: 'rgba(59,130,246,0.35)',
-            bottomColor: 'rgba(59,130,246,0.02)',
+            lineColor: chartTheme.seriesColor,
+            topColor: chartTheme.areaTopColor,
+            bottomColor: chartTheme.areaBottomColor,
             lineWidth: 2,
           })
-        : chart.addSeries(HistogramSeries, { color: '#3b82f6' });
+        : chart.addSeries(HistogramSeries, { color: chartTheme.seriesColor });
 
     const ro = new ResizeObserver((entries) => {
       const w = entries[0]?.contentRect.width;
@@ -95,7 +99,38 @@ function LwChart({
       chartRef.current = null;
       seriesRef.current = null;
     };
+    // `chartTheme` is intentionally omitted: recreating the chart on theme
+    // change would reset the viewport. Colors are re-applied in the dedicated
+    // effect below via `chart.applyOptions()`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [kind, height]);
+
+  // Re-theme the existing chart instance on mode change (issue #169).
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+    chart.applyOptions({
+      layout: {
+        textColor: chartTheme.textColor,
+        background: { type: ColorType.Solid, color: 'transparent' },
+      },
+      grid: {
+        vertLines: { color: chartTheme.gridColor },
+        horzLines: { color: chartTheme.gridColor },
+      },
+    });
+    const series = seriesRef.current;
+    if (!series) return;
+    if (series.seriesType() === 'Area') {
+      series.applyOptions({
+        lineColor: chartTheme.seriesColor,
+        topColor: chartTheme.areaTopColor,
+        bottomColor: chartTheme.areaBottomColor,
+      });
+    } else {
+      series.applyOptions({ color: chartTheme.seriesColor });
+    }
+  }, [chartTheme]);
 
   // Update data when it changes.
   useEffect(() => {
@@ -118,10 +153,10 @@ function ChartCard({
   children: React.ReactNode;
 }) {
   return (
-    <div className="rounded-xl border bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
-      <h3 className="mb-2 text-sm font-medium text-zinc-700 dark:text-zinc-200">{title}</h3>
+    <div className="rounded-xl border border-border bg-surface p-4">
+      <h3 className="mb-2 text-sm font-medium text-foreground">{title}</h3>
       {empty ? (
-        <div className="flex h-[220px] items-center justify-center text-sm text-zinc-400">
+        <div className="flex h-[220px] items-center justify-center text-sm text-muted-foreground">
           No data in the selected range
         </div>
       ) : (
@@ -131,10 +166,10 @@ function ChartCard({
   );
 }
 
-const PROPOSAL_COLORS: Record<string, string> = {
-  included: '#16a34a',
-  missed: '#dc2626',
-  orphaned: '#d97706',
+const PROPOSAL_STATUS: Record<string, 'success' | 'destructive' | 'warning' | 'series'> = {
+  included: 'success',
+  missed: 'destructive',
+  orphaned: 'warning',
 };
 
 export interface PerformanceChartsProps {
@@ -148,6 +183,9 @@ export interface PerformanceChartsProps {
  * status). All three respect the shared time range.
  */
 export function PerformanceCharts({ history, timeRange }: PerformanceChartsProps) {
+  const { resolvedTheme } = useTheme();
+  const chartTheme = useMemo(() => getChartTheme(resolvedTheme), [resolvedTheme]);
+
   const balancePoints = useMemo<Point[]>(() => {
     return filterEpochPointsByRange(history.balances, timeRange).map((p) => ({
       time: epochToUnixSeconds(p.epoch) as UTCTimestamp,
@@ -163,12 +201,16 @@ export function PerformanceCharts({ history, timeRange }: PerformanceChartsProps
   }, [history.attestationEffectiveness, timeRange]);
 
   const proposalPoints = useMemo<Point[]>(() => {
-    return filterTimestampPointsByRange(history.proposals, timeRange).map((p) => ({
-      time: Math.floor(p.timestamp / 1000) as UTCTimestamp,
-      value: 1,
-      color: PROPOSAL_COLORS[p.status] ?? '#3b82f6',
-    }));
-  }, [history.proposals, timeRange]);
+    return filterTimestampPointsByRange(history.proposals, timeRange).map((p) => {
+      const tone = PROPOSAL_STATUS[p.status] ?? 'series';
+      const color = tone === 'series' ? chartTheme.seriesColor : chartTheme[tone];
+      return {
+        time: Math.floor(p.timestamp / 1000) as UTCTimestamp,
+        value: 1,
+        color,
+      };
+    });
+  }, [history.proposals, timeRange, chartTheme]);
 
   return (
     <section aria-label="Performance charts" className="grid grid-cols-1 gap-4 lg:grid-cols-3">

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,44 +1,143 @@
 'use client'
 
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
-import type { ThemeMode } from '@/src/styles/themes'
+import React, { createContext, useContext, useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import {
+  DEFAULT_THEME_MODE,
+  THEME_STORAGE_KEY,
+  isThemeMode,
+  resolveTheme,
+  type ResolvedTheme,
+  type ThemeMode,
+} from '@/src/styles/themes'
 
 interface ThemeContextValue {
+  /** User-selected mode: 'system' | 'light' | 'dark' | 'hc-dark' | 'hc-light'. */
+  theme: ThemeMode
+  /** Set the user-selected mode. Persists to localStorage. */
+  setTheme: (theme: ThemeMode) => void
+  /** Effective color scheme ('light' | 'dark') after resolving 'system'. */
+  resolvedTheme: ResolvedTheme
+  /** @deprecated Use `theme` / `setTheme` instead. */
   themeMode: ThemeMode
+  /** @deprecated Use `theme` / `setTheme` instead. */
   setThemeMode: (theme: ThemeMode) => void
 }
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
-const STORAGE_KEY = 'verinode-theme'
 
 function readStoredTheme(): ThemeMode {
   if (typeof window === 'undefined') {
-    return 'dark'
+    return DEFAULT_THEME_MODE
   }
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
+    return isThemeMode(stored) ? stored : DEFAULT_THEME_MODE
+  } catch {
+    return DEFAULT_THEME_MODE
+  }
+}
 
-  const storedTheme = window.localStorage.getItem(STORAGE_KEY)
-  return storedTheme === 'light' || storedTheme === 'dark' || storedTheme === 'hc-dark' || storedTheme === 'hc-light'
-    ? storedTheme
-    : 'dark'
+function readSystemPrefersDark(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+  try {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  } catch {
+    return false
+  }
+}
+
+/** Subscribe to OS `prefers-color-scheme` changes (external store). */
+function subscribeToSystemTheme(onChange: () => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {}
+  }
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+  mediaQuery.addEventListener('change', onChange)
+  return () => mediaQuery.removeEventListener('change', onChange)
 }
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [themeMode, setThemeModeState] = useState<ThemeMode>(() => readStoredTheme())
 
+  // Live OS `prefers-color-scheme` value. Consumed only while in 'system'
+  // mode; subscribing unconditionally keeps the subscription simple and lets
+  // resolvedTheme update the moment the user switches to 'system'.
+  const systemPrefersDark = useSyncExternalStore(
+    subscribeToSystemTheme,
+    readSystemPrefersDark,
+    () => false,
+  )
+
+  const resolvedTheme = useMemo<ResolvedTheme>(
+    () => resolveTheme(themeMode, systemPrefersDark),
+    [themeMode, systemPrefersDark],
+  )
+
+  // Apply the theme to <html> and persist the selection. `theme-transitioning`
+  // is added around the switch so colors animate smoothly (see globals.css).
   useEffect(() => {
     const root = document.documentElement
-    root.dataset.theme = themeMode
-    root.classList.toggle('dark', themeMode === 'dark' || themeMode === 'hc-dark')
-    root.style.colorScheme = themeMode === 'light' || themeMode === 'hc-light' ? 'light' : 'dark'
-    window.localStorage.setItem(STORAGE_KEY, themeMode)
-  }, [themeMode])
+    const datasetTheme =
+      themeMode === 'hc-dark' || themeMode === 'hc-light' ? themeMode : resolvedTheme
+
+    const apply = () => {
+      root.dataset.theme = datasetTheme
+      root.classList.toggle('dark', resolvedTheme === 'dark')
+      root.style.colorScheme = resolvedTheme
+      try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, themeMode)
+      } catch {
+        // Storage may be unavailable (e.g. private browsing); the in-memory
+        // selection still applies for this session.
+      }
+    }
+
+    // Nothing to animate when the applied theme did not change (including the
+    // initial mount, where the pre-hydration script already set the attribute).
+    if (root.dataset.theme === datasetTheme) {
+      apply()
+      return
+    }
+
+    root.classList.add('theme-transitioning')
+    let timeoutId: number | undefined
+
+    const commit = () => {
+      apply()
+      timeoutId = window.setTimeout(() => {
+        root.classList.remove('theme-transitioning')
+      }, 350)
+    }
+
+    let rafId: number | undefined
+    if (typeof window.requestAnimationFrame === 'function') {
+      rafId = window.requestAnimationFrame(commit)
+    } else {
+      commit()
+    }
+
+    return () => {
+      if (rafId !== undefined) {
+        window.cancelAnimationFrame(rafId)
+      }
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId)
+      }
+      root.classList.remove('theme-transitioning')
+    }
+  }, [themeMode, resolvedTheme])
 
   const value = useMemo<ThemeContextValue>(
     () => ({
+      theme: themeMode,
+      setTheme: (nextTheme) => setThemeModeState(nextTheme),
+      resolvedTheme,
       themeMode,
       setThemeMode: (nextTheme) => setThemeModeState(nextTheme),
     }),
-    [themeMode],
+    [themeMode, resolvedTheme],
   )
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>

--- a/src/components/staking/StakingChart.tsx
+++ b/src/components/staking/StakingChart.tsx
@@ -21,6 +21,8 @@ import {
   type UTCTimestamp,
 } from 'lightweight-charts';
 import type { StakingChartDataPoint } from '@/src/types/staking';
+import { useTheme } from '@/src/components/providers/ThemeProvider';
+import { getChartTheme } from '@/src/styles/chartTheme';
 
 interface StakingChartProps {
   balanceHistory: StakingChartDataPoint[];
@@ -69,6 +71,8 @@ function LwChart({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const seriesRef = useRef<ISeriesApi<'Area'> | null>(null);
+  const { resolvedTheme } = useTheme();
+  const chartTheme = useMemo(() => getChartTheme(resolvedTheme), [resolvedTheme]);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -78,12 +82,12 @@ function LwChart({
       height,
       layout: {
         background: { type: ColorType.Solid, color: 'transparent' },
-        textColor: '#71717a',
+        textColor: chartTheme.textColor,
         attributionLogo: false,
       },
       grid: {
-        vertLines: { color: 'rgba(113,113,122,0.1)' },
-        horzLines: { color: 'rgba(113,113,122,0.1)' },
+        vertLines: { color: chartTheme.gridColor },
+        horzLines: { color: chartTheme.gridColor },
       },
       rightPriceScale: { borderVisible: false },
       timeScale: { borderVisible: false, timeVisible: false },
@@ -92,8 +96,8 @@ function LwChart({
     });
     chartRef.current = chart;
 
-    const resolvedTopColor = topColor ?? `${color}59`;
-    const resolvedBottomColor = bottomColor ?? `${color}05`;
+    const resolvedTopColor = topColor ?? chartTheme.areaTopColor;
+    const resolvedBottomColor = bottomColor ?? chartTheme.areaBottomColor;
 
     seriesRef.current = chart.addSeries(AreaSeries, {
       lineColor: color,
@@ -115,7 +119,34 @@ function LwChart({
       chartRef.current = null;
       seriesRef.current = null;
     };
+    // `chartTheme` is intentionally omitted: recreating the chart on theme
+    // change would reset the viewport. Colors are re-applied in the dedicated
+    // effect below via `chart.applyOptions()`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [height, color, topColor, bottomColor]);
+
+  // Re-theme the existing chart instance on mode change (issue #169).
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+    chart.applyOptions({
+      layout: {
+        textColor: chartTheme.textColor,
+        background: { type: ColorType.Solid, color: 'transparent' },
+      },
+      grid: {
+        vertLines: { color: chartTheme.gridColor },
+        horzLines: { color: chartTheme.gridColor },
+      },
+    });
+    const series = seriesRef.current;
+    if (!series) return;
+    series.applyOptions({
+      lineColor: color,
+      topColor: topColor ?? chartTheme.areaTopColor,
+      bottomColor: bottomColor ?? chartTheme.areaBottomColor,
+    });
+  }, [chartTheme, color, topColor, bottomColor]);
 
   useEffect(() => {
     const series = seriesRef.current;
@@ -139,14 +170,14 @@ function ChartCard({
   subtitle?: string;
 }) {
   return (
-    <div className="rounded-xl border border-white/10 bg-slate-900/70 p-4">
+    <div className="rounded-xl border border-border bg-surface p-4">
       <div className="mb-2">
-        <h3 className="text-sm font-medium text-slate-200">{title}</h3>
-        {subtitle && <p className="text-[11px] text-slate-500">{subtitle}</p>}
+        <h3 className="text-sm font-medium text-foreground">{title}</h3>
+        {subtitle && <p className="text-[11px] text-muted-foreground">{subtitle}</p>}
       </div>
       {empty ? (
         <div
-          className="flex items-center justify-center text-sm text-slate-500"
+          className="flex items-center justify-center text-sm text-muted-foreground"
           style={{ height: 220 }}
         >
           No data in the selected range

--- a/src/components/ui/ThemeSwitcher.tsx
+++ b/src/components/ui/ThemeSwitcher.tsx
@@ -5,22 +5,22 @@ import { contrastRatio, getThemeOptions } from '@/src/styles/themes'
 import { useTheme } from '@/src/components/providers/ThemeProvider'
 
 export function ThemeSwitcher() {
-  const { themeMode, setThemeMode } = useTheme()
+  const { theme: currentTheme, setTheme } = useTheme()
   const [hoveredTheme, setHoveredTheme] = useState<string | null>(null)
   const themes = useMemo(() => getThemeOptions(), [])
 
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+    <div className="rounded-xl border border-border bg-surface p-4 shadow-card">
       <div className="mb-3 flex items-center justify-between">
         <div>
-          <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-50">Theme</p>
-          <p className="text-xs text-zinc-500 dark:text-zinc-400">Switch between standard and high-contrast modes.</p>
+          <p className="text-sm font-semibold text-foreground">Theme</p>
+          <p className="text-xs text-muted-foreground">Switch between standard and high-contrast modes.</p>
         </div>
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
         {themes.map((theme) => {
-          const isActive = themeMode === theme.id
+          const isActive = currentTheme === theme.id
           const ratio = contrastRatio(theme.colors.foreground, theme.colors.background)
           const showRatio = hoveredTheme === theme.id
 
@@ -28,10 +28,10 @@ export function ThemeSwitcher() {
             <button
               key={theme.id}
               type="button"
-              onClick={() => setThemeMode(theme.id)}
+              onClick={() => setTheme(theme.id)}
               onMouseEnter={() => setHoveredTheme(theme.id)}
               onMouseLeave={() => setHoveredTheme(null)}
-              className={`flex items-center gap-3 rounded-lg border px-3 py-3 text-left transition ${isActive ? 'ring-2 ring-offset-2 ring-zinc-500 dark:ring-zinc-300' : 'hover:border-zinc-400 dark:hover:border-zinc-600'}`}
+              className={`flex items-center gap-3 rounded-lg border px-3 py-3 text-left transition ${isActive ? 'ring-2 ring-offset-2 ring-border-strong' : 'hover:border-border-strong'}`}
               style={{ borderColor: theme.colors.border, backgroundColor: theme.colors.surface }}
             >
               <span

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import React from 'react'
+import { useTheme } from '@/src/components/providers/ThemeProvider'
+import type { ThemeMode } from '@/src/styles/themes'
+
+const MODE_LABELS: Record<ThemeMode, string> = {
+  system: 'System',
+  light: 'Light',
+  dark: 'Dark',
+  'hc-dark': 'High contrast dark',
+  'hc-light': 'High contrast light',
+}
+
+const CYCLE_ORDER: ThemeMode[] = ['system', 'light', 'dark']
+
+function nextMode(current: ThemeMode): ThemeMode {
+  // High-contrast modes participate in the cycle from their resolved base.
+  const index = CYCLE_ORDER.indexOf(current === 'hc-dark' || current === 'hc-light' ? (current === 'hc-dark' ? 'dark' : 'light') : current)
+  return CYCLE_ORDER[(index + 1) % CYCLE_ORDER.length]
+}
+
+function SunIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2" />
+      <path d="M12 20v2" />
+      <path d="m4.93 4.93 1.41 1.41" />
+      <path d="m17.66 17.66 1.41 1.41" />
+      <path d="M2 12h2" />
+      <path d="M20 12h2" />
+      <path d="m6.34 17.66-1.41 1.41" />
+      <path d="m19.07 4.93-1.41 1.41" />
+    </svg>
+  )
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+    </svg>
+  )
+}
+
+function MonitorIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <rect width="20" height="14" x="2" y="3" rx="2" />
+      <line x1="8" x2="16" y1="21" y2="21" />
+      <line x1="12" x2="12" y1="17" y2="21" />
+    </svg>
+  )
+}
+
+/**
+ * Theme toggle button that cycles System -> Light -> Dark.
+ * Shows a sun, moon, or monitor icon for the current selection.
+ */
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const target = nextMode(theme)
+
+  const Icon = theme === 'system' ? MonitorIcon : theme === 'dark' || theme === 'hc-dark' ? MoonIcon : SunIcon
+
+  return (
+    <button
+      type="button"
+      data-testid="theme-toggle"
+      onClick={() => setTheme(target)}
+      aria-label={`Theme: ${MODE_LABELS[theme]}. Switch to ${MODE_LABELS[target]}.`}
+      title={`Theme: ${MODE_LABELS[theme]} — click to switch to ${MODE_LABELS[target]}`}
+      className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-border bg-surface text-muted-foreground transition-colors hover:bg-surface-hover hover:text-foreground"
+    >
+      <Icon />
+    </button>
+  )
+}

--- a/src/styles/chartTheme.ts
+++ b/src/styles/chartTheme.ts
@@ -1,0 +1,50 @@
+import type { ResolvedTheme } from './themes'
+
+/**
+ * Chart color tokens per resolved color scheme. Lightweight Charts (and
+ * Chart.js) cannot read CSS custom properties directly for their canvas
+ * layouts, so theme colors are resolved to concrete values and re-applied
+ * via `chart.applyOptions()` when the theme changes (issue #169).
+ */
+export interface ChartTheme {
+  /** Axis / label text color. */
+  textColor: string
+  /** Grid line color (translucent so it works over any surface). */
+  gridColor: string
+  /** Series line / bar color. */
+  seriesColor: string
+  /** Area gradient stops for area series. */
+  areaTopColor: string
+  areaBottomColor: string
+  /** Status colors used for colored bars. */
+  success: string
+  destructive: string
+  warning: string
+}
+
+export const chartThemes: Record<ResolvedTheme, ChartTheme> = {
+  light: {
+    textColor: '#71717a',
+    gridColor: 'rgba(113, 113, 122, 0.12)',
+    seriesColor: '#2563eb',
+    areaTopColor: 'rgba(37, 99, 235, 0.35)',
+    areaBottomColor: 'rgba(37, 99, 235, 0.02)',
+    success: '#16a34a',
+    destructive: '#dc2626',
+    warning: '#d97706',
+  },
+  dark: {
+    textColor: '#a1a1aa',
+    gridColor: 'rgba(161, 161, 170, 0.15)',
+    seriesColor: '#60a5fa',
+    areaTopColor: 'rgba(96, 165, 250, 0.35)',
+    areaBottomColor: 'rgba(96, 165, 250, 0.02)',
+    success: '#4ade80',
+    destructive: '#f87171',
+    warning: '#fbbf24',
+  },
+}
+
+export function getChartTheme(resolvedTheme: ResolvedTheme): ChartTheme {
+  return chartThemes[resolvedTheme]
+}

--- a/src/styles/themes.ts
+++ b/src/styles/themes.ts
@@ -1,6 +1,36 @@
 import { tokenPalette } from './colors'
 
-export type ThemeMode = 'light' | 'dark' | 'hc-dark' | 'hc-light'
+/** User-selectable theme modes. `system` follows the OS `prefers-color-scheme`. */
+export type ThemeMode = 'system' | 'light' | 'dark' | 'hc-dark' | 'hc-light'
+
+/** The effective color scheme after resolving `system` against the OS preference. */
+export type ResolvedTheme = 'light' | 'dark'
+
+/** Hard-coded fallback used when no stored preference exists yet. */
+export const DEFAULT_THEME_MODE: ThemeMode = 'system'
+
+/** Storage key for the persisted theme preference. */
+export const THEME_STORAGE_KEY = 'verinode-theme'
+
+export function isThemeMode(value: string | null | undefined): value is ThemeMode {
+  return (
+    value === 'system' ||
+    value === 'light' ||
+    value === 'dark' ||
+    value === 'hc-dark' ||
+    value === 'hc-light'
+  )
+}
+
+/**
+ * Resolve a theme mode to the effective color scheme. `system` (and any
+ * unknown value) falls back to the OS `prefers-color-scheme` preference.
+ */
+export function resolveTheme(mode: ThemeMode | string | null | undefined, prefersDark: boolean): ResolvedTheme {
+  if (mode === 'light' || mode === 'hc-light') return 'light'
+  if (mode === 'dark' || mode === 'hc-dark') return 'dark'
+  return prefersDark ? 'dark' : 'light'
+}
 
 export interface ThemeDefinition {
   id: ThemeMode
@@ -19,7 +49,7 @@ export interface ThemeDefinition {
   }
 }
 
-function createTheme(id: ThemeMode, label: string, description: string): ThemeDefinition {
+function createTheme(id: Exclude<ThemeMode, 'system'>, label: string, description: string): ThemeDefinition {
   const colors = tokenPalette[id]
   return { id, label, description, colors }
 }


### PR DESCRIPTION
Closes #169

## Summary

Implements a full dark mode theme system with automatic system preference detection, a manual light/dark/system toggle, persistent storage, and chart theme sync.

## Changes

### Theme tokens (60+ CSS custom properties)
- Expanded `app/globals.css` with 60+ tokens per theme (colors, spacing, shadows, border radii) defined on `:root` (light), `[data-theme='dark']`, and both high-contrast themes (`hc-dark`, `hc-light`).
- Tokens are mapped to Tailwind v4 utilities via `@theme inline` (e.g. `bg-surface`, `text-muted-foreground`, `border-border`, `shadow-card`).

### ThemeProvider (`src/components/providers/ThemeProvider.tsx`)
- `useTheme()` now returns `(theme, setTheme, resolvedTheme)`.
- New `system` mode: reads `prefers-color-scheme` via `matchMedia` (subscribed with `useSyncExternalStore`) and live-updates `resolvedTheme` when the OS preference changes.
- Reads the stored preference from `localStorage` on mount, falls back to the OS preference, and persists every selection.
- Applies `data-theme`, the Tailwind `dark` class, and `color-scheme` on `<html>`.
- Smooth 0.3s color transitions during switches (disabled for `prefers-reduced-motion` users).
- Backward-compatible `themeMode` / `setThemeMode` aliases retained.

### ThemeToggle (`src/components/ui/ThemeToggle.tsx`)
- Navbar button with sun/moon/monitor icons cycling `system -> light -> dark`, with accessible labels. Mounted in the dashboard header and on the home page.

### No flash of wrong theme
- `public/theme-init.js` runs `beforeInteractive` to apply the stored/system theme before first paint.

### Chart theme sync
- Lightweight Charts instances (`PerformanceCharts`, `StakingChart`) re-theme on mode change via `chart.applyOptions()` using tokens from the new `src/styles/chartTheme.ts`.

### Migration to tokens
- Core surfaces migrated from hard-coded `zinc`/`white` values to semantic tokens: home page, dashboard layout, sync status bar, theme switcher, chart cards.

### Tests
- `src/__tests__/themeProvider.test.tsx`: 10 unit tests covering theme resolution, stored-preference application, OS-preference fallback, live `matchMedia` updates, persistence, high-contrast modes, and toggle cycling.

## Verification
- `tsc --noEmit` passes.
- `next build` compiles successfully.
- New theme unit tests pass (10/10).
- Full unit suite: no new failures (7 pre-existing failures in governance/staking suites are unrelated to this change).

## Notes
- The persisted preference uses the existing `verinode-theme` storage key so current users keep their saved high-contrast selection; `system` is added as a new valid value.